### PR TITLE
Tidy some code in the integration testing. Namely:

### DIFF
--- a/packages/devtools_app/integration_test/test_infra/run/run_test.dart
+++ b/packages/devtools_app/integration_test/test_infra/run/run_test.dart
@@ -88,7 +88,8 @@ class DevToolsAppTestRunnerArgs extends IntegrationTestRunnerArgs {
     : super(addExtraArgs: _addExtraArgs) {
     testAppDevice =
         TestAppDevice.fromArgName(
-          argResults[_testAppDeviceArg] ?? TestAppDevice.flutterTester.argName,
+          argResults.option(_testAppDeviceArg) ??
+              TestAppDevice.flutterTester.argName,
         )!;
   }
 
@@ -98,10 +99,10 @@ class DevToolsAppTestRunnerArgs extends IntegrationTestRunnerArgs {
   /// The Vm Service URI for the test app to connect devtools to.
   ///
   /// This value will only be used for tests with live connection.
-  String? get testAppUri => argResults[_testAppUriArg];
+  String? get testAppUri => argResults.option(_testAppUriArg);
 
   /// Whether golden images should be updated with the result of this test run.
-  bool get updateGoldens => argResults[_updateGoldensArg];
+  bool get updateGoldens => argResults.flag(_updateGoldensArg);
 
   static const _testAppUriArg = 'test-app-uri';
   static const _testAppDeviceArg = 'test-app-device';

--- a/packages/devtools_shared/lib/src/test/integration_test_runner.dart
+++ b/packages/devtools_shared/lib/src/test/integration_test_runner.dart
@@ -199,37 +199,33 @@ class IntegrationTestRunnerArgs {
     List<String> args, {
     bool verifyValidTarget = true,
     void Function(ArgParser)? addExtraArgs,
-  }) {
-    final argParser = buildArgParser(addExtraArgs: addExtraArgs);
-    argResults = argParser.parse(args);
-    rawArgs = args;
-
+  })  : rawArgs = args,
+        argResults = buildArgParser(addExtraArgs: addExtraArgs).parse(args) {
     if (verifyValidTarget) {
       final target = argResults[testTargetArg];
       assert(
         target != null,
-        'Please specify a test target (e.g. '
-        '--$testTargetArg=path/to/test.dart',
+        'Please specify a test target (e.g. --$testTargetArg=path/to/test.dart',
       );
     }
   }
 
   @protected
-  late final ArgResults argResults;
+  final ArgResults argResults;
 
-  late final List<String> rawArgs;
+  final List<String> rawArgs;
 
   /// The path to the test target.
-  String? get testTarget => argResults[testTargetArg];
+  String? get testTarget => argResults.option(testTargetArg);
 
   /// Whether this integration test should be run on the 'web-server' device
   /// instead of 'chrome'.
-  bool get headless => argResults[_headlessArg];
+  bool get headless => argResults.flag(_headlessArg);
 
   /// Sharding information for this test run.
   ({int shardNumber, int totalShards})? get shard {
-    final shardValue = argResults[_shardArg];
-    if (shardValue is String) {
+    final shardValue = argResults.option(_shardArg);
+    if (shardValue != null) {
       final shardParts = shardValue.split('/');
       if (shardParts.length == 2) {
         final shardNumber = int.tryParse(shardParts[0]);
@@ -243,7 +239,7 @@ class IntegrationTestRunnerArgs {
   }
 
   /// Whether the help flag `-h` was passed to the integration test command.
-  bool get help => argResults[_helpArg];
+  bool get help => argResults.flag(_helpArg);
 
   void printHelp() {
     print('Run integration tests (one or many) for the Dart DevTools package.');


### PR DESCRIPTION
* Convert the FlutterDaemonConstants from an enum into a namespaced set of constant strings. In all cases, each enum value was only used to access the 'key' string, so this simplifies to that reality. Also they weren't used as an enumeration.
* Reduce the number of JSON map lookups. This makes the code more concise.
* Use the `.option`, `.multiOption`, and `.flag` APIs from package:args, avoiding dynamic casting.
* Initialize two fields in `TestRunnerArgs` in the constructor initializers, allowing them to be non-late.

