### PR TITLE
Add `releaseMemory` functionality to DevTools screen controllers

### DIFF
--- a/packages/devtools_app/lib/src/screens/app_size/app_size_controller.dart
+++ b/packages/devtools_app/lib/src/screens/app_size/app_size_controller.dart
@@ -11,6 +11,8 @@ import 'package:vm_snapshot_analysis/utils.dart';
 import 'package:vm_snapshot_analysis/v8_profile.dart';
 
 import '../../shared/charts/treemap.dart';
+import '../../shared/feature_flags.dart';
+import '../../shared/framework/screen.dart';
 import '../../shared/framework/screen_controllers.dart';
 import '../../shared/primitives/utils.dart';
 import '../../shared/table/table.dart';
@@ -85,6 +87,9 @@ class DiffTreeMap {
 /// `screenControllers`. The `dispose` method is called by `screenControllers`
 /// when DevTools is destroying a set of DevTools screen controllers.
 class AppSizeController extends DevToolsScreenController {
+  @override
+  final screenId = ScreenMetaData.appSize.id;
+
   static const unsupportedFileTypeError =
       'Failed to load size analysis file: file type not supported.\n\n'
       'The app size tool supports Dart AOT v8 snapshots, instruction sizes, '
@@ -765,6 +770,16 @@ class AppSizeController extends DevToolsScreenController {
     _selectedAppUnit.dispose();
     _processingNotifier.dispose();
     super.dispose();
+  }
+
+  @override
+  void releaseMemory({bool partial = false}) {
+    if (FeatureFlags.memoryObserver) {
+      // This behavior is the same regardless of the value of `partial`. We can
+      // implement a partial clearing if it becomes necessary.
+      clear(AppSizeScreen.analysisTabKey);
+      clear(AppSizeScreen.diffTabKey);
+    }
   }
 }
 

--- a/packages/devtools_app/lib/src/screens/debugger/debugger_controller.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/debugger_controller.dart
@@ -21,6 +21,7 @@ import '../../shared/diagnostics/primitives/source_location.dart';
 import '../../shared/diagnostics/tree_builder.dart';
 import '../../shared/feature_flags.dart';
 import '../../shared/framework/routing.dart';
+import '../../shared/framework/screen.dart';
 import '../../shared/framework/screen_controllers.dart';
 import '../../shared/globals.dart';
 import '../../shared/primitives/message_bus.dart';
@@ -57,6 +58,9 @@ class DebuggerController extends DevToolsScreenController
       codeViewController.subscribeToRouterEvents(routerDelegate);
     }
   }
+
+  @override
+  final screenId = ScreenMetaData.debugger.id;
 
   @override
   void init() {

--- a/packages/devtools_app/lib/src/screens/deep_link_validation/deep_links_controller.dart
+++ b/packages/devtools_app/lib/src/screens/deep_link_validation/deep_links_controller.dart
@@ -14,6 +14,7 @@ import '../../shared/analytics/analytics.dart' as ga;
 import '../../shared/analytics/constants.dart' as gac;
 import '../../shared/analytics/metrics.dart';
 import '../../shared/feature_flags.dart';
+import '../../shared/framework/screen.dart';
 import '../../shared/framework/screen_controllers.dart';
 import '../../shared/globals.dart';
 import '../../shared/primitives/utils.dart';
@@ -158,6 +159,9 @@ class DisplayOptions {
 /// when DevTools is destroying a set of DevTools screen controllers.
 class DeepLinksController extends DevToolsScreenController
     with AutoDisposeControllerMixin {
+  @override
+  final screenId = ScreenMetaData.deepLinks.id;
+
   @override
   void dispose() {
     _selectedAndroidVariantIndex.dispose();

--- a/packages/devtools_app/lib/src/screens/inspector_shared/inspector_screen_controller.dart
+++ b/packages/devtools_app/lib/src/screens/inspector_shared/inspector_screen_controller.dart
@@ -4,6 +4,7 @@
 
 import '../../shared/analytics/metrics.dart';
 import '../../shared/console/primitives/simple_items.dart';
+import '../../shared/framework/screen.dart';
 import '../../shared/framework/screen_controllers.dart';
 import '../inspector/inspector_controller.dart' as legacy;
 import '../inspector/inspector_tree_controller.dart' as legacy;
@@ -21,6 +22,9 @@ import '../inspector_v2/inspector_tree_controller.dart' as v2;
 /// `screenControllers`. The `dispose` method is called by `screenControllers`
 /// when DevTools is destroying a set of DevTools screen controllers.
 class InspectorScreenController extends DevToolsScreenController {
+  @override
+  final screenId = ScreenMetaData.inspector.id;
+
   late v2.InspectorController v2InspectorController;
   late v2.InspectorTreeController v2InspectorTreeController;
 

--- a/packages/devtools_app/lib/src/screens/memory/framework/memory_controller.dart
+++ b/packages/devtools_app/lib/src/screens/memory/framework/memory_controller.dart
@@ -10,6 +10,7 @@ import 'dart:async';
 import 'package:devtools_app_shared/utils.dart';
 import 'package:flutter/foundation.dart';
 
+import '../../../shared/feature_flags.dart';
 import '../../../shared/framework/screen.dart';
 import '../../../shared/framework/screen_controllers.dart';
 import '../../../shared/globals.dart';
@@ -39,6 +40,9 @@ class MemoryController extends DevToolsScreenController
     with
         AutoDisposeControllerMixin,
         OfflineScreenControllerMixin<OfflineMemoryData> {
+  @override
+  final screenId = ScreenMetaData.memory.id;
+
   Future<void> get initialized => _initialized.future;
   final _initialized = Completer<void>();
 
@@ -208,6 +212,16 @@ class MemoryController extends DevToolsScreenController
       notificationService.push('Successfully garbage collected.');
     } finally {
       _gcing.value = false;
+    }
+  }
+
+  @override
+  FutureOr<void> releaseMemory({bool partial = false}) async {
+    if (FeatureFlags.memoryObserver) {
+      diff.clearSnapshots(partial: partial);
+      // Clear all allocation traces since the traces form a single tracing
+      // profile.
+      await trace?.clear();
     }
   }
 }

--- a/packages/devtools_app/lib/src/screens/memory/panes/diff/controller/diff_pane_controller.dart
+++ b/packages/devtools_app/lib/src/screens/memory/panes/diff/controller/diff_pane_controller.dart
@@ -151,12 +151,24 @@ class DiffPaneController extends DisposableController with Serializable {
     }
   }
 
-  void clearSnapshots() {
+  void clearSnapshots({bool partial = false}) {
+    const offsetForInstructionSnapshot = 1;
     final snapshots = core._snapshots;
-    for (var i = 1; i < snapshots.value.length; i++) {
+    final snapshotsToRemove = max(
+      offsetForInstructionSnapshot,
+      (snapshots.value.length - offsetForInstructionSnapshot) ~/
+          (partial ? 2 : 1),
+    );
+    final endIndexToRemoveExclusive =
+        offsetForInstructionSnapshot + snapshotsToRemove;
+    for (
+      var i = offsetForInstructionSnapshot;
+      i < endIndexToRemoveExclusive;
+      i++
+    ) {
       snapshots.value[i].dispose();
     }
-    snapshots.removeRange(1, snapshots.value.length);
+    snapshots.removeRange(1, endIndexToRemoveExclusive);
     core._selectedSnapshotIndex.value = 0;
     derived._updateValues();
   }

--- a/packages/devtools_app/lib/src/screens/network/network_controller.dart
+++ b/packages/devtools_app/lib/src/screens/network/network_controller.dart
@@ -607,6 +607,7 @@ class CurrentNetworkRequests extends ValueNotifier<List<NetworkRequest>> {
     if (partial) {
       _requestsById.keys
           .toList()
+          // Trim requests from the front so that the oldest data is removed.
           .sublist(0, _requestsById.keys.length ~/ 2)
           .forEach(_requestsById.remove);
       value = value.sublist(value.length ~/ 2);

--- a/packages/devtools_app/lib/src/screens/network/network_controller.dart
+++ b/packages/devtools_app/lib/src/screens/network/network_controller.dart
@@ -11,6 +11,8 @@ import 'package:vm_service/vm_service.dart';
 
 import '../../shared/config_specific/import_export/import_export.dart';
 import '../../shared/config_specific/logger/allowed_error.dart';
+import '../../shared/feature_flags.dart';
+import '../../shared/framework/screen.dart';
 import '../../shared/framework/screen_controllers.dart';
 import '../../shared/globals.dart';
 import '../../shared/http/http_request_data.dart';
@@ -61,6 +63,9 @@ class NetworkController extends DevToolsScreenController
         FilterControllerMixin<NetworkRequest>,
         OfflineScreenControllerMixin,
         AutoDisposeControllerMixin {
+  @override
+  final screenId = ScreenMetaData.network.id;
+
   List<DartIOHttpRequestData>? _httpRequests;
 
   Future<String?> exportAsHarFile() async {
@@ -392,9 +397,11 @@ class NetworkController extends DevToolsScreenController
 
   /// Clears the HTTP profile and socket profile from the vm, and resets the
   /// last refresh timestamp to the current time.
-  Future<void> clear() async {
-    await networkService.clearData();
-    _currentNetworkRequests.clear();
+  Future<void> clear({bool partial = false}) async {
+    if (!partial) {
+      await networkService.clearData();
+    }
+    _currentNetworkRequests.clear(partial: partial);
     _filterAndRefreshSearchMatches();
     _updateSelection();
   }
@@ -507,6 +514,13 @@ class NetworkController extends DevToolsScreenController
           .whereType<DartIOHttpRequestData>()
           .map((item) => item.getFullRequestData())
           .wait;
+
+  @override
+  FutureOr<void> releaseMemory({bool partial = false}) async {
+    if (FeatureFlags.memoryObserver) {
+      await clear(partial: partial);
+    }
+  }
 }
 
 /// Class for managing the set of all current sockets, and
@@ -589,9 +603,18 @@ class CurrentNetworkRequests extends ValueNotifier<List<NetworkRequest>> {
     }
   }
 
-  void clear() {
-    _requestsById.clear();
-    value = [];
-    notifyListeners();
+  void clear({bool partial = false}) {
+    if (partial) {
+      _requestsById.keys
+          .toList()
+          .sublist(0, _requestsById.keys.length ~/ 2)
+          .forEach(_requestsById.remove);
+      value = value.sublist(value.length ~/ 2);
+      notifyListeners();
+    } else {
+      _requestsById.clear();
+      value = [];
+      notifyListeners();
+    }
   }
 }

--- a/packages/devtools_app/lib/src/screens/performance/panes/flutter_frames/flutter_frames_controller.dart
+++ b/packages/devtools_app/lib/src/screens/performance/panes/flutter_frames/flutter_frames_controller.dart
@@ -173,6 +173,7 @@ class FlutterFramesController extends PerformanceFeatureController {
   @override
   void clearData({bool partial = false}) {
     if (partial) {
+      // Trim frames from the front so that the oldest logs are removed.
       _flutterFrames.trimToSublist(_flutterFrames.value.length ~/ 2);
     } else {
       _flutterFrames.clear();

--- a/packages/devtools_app/lib/src/screens/performance/panes/flutter_frames/flutter_frames_controller.dart
+++ b/packages/devtools_app/lib/src/screens/performance/panes/flutter_frames/flutter_frames_controller.dart
@@ -171,8 +171,12 @@ class FlutterFramesController extends PerformanceFeatureController {
   }
 
   @override
-  void clearData() {
-    _flutterFrames.clear();
+  void clearData({bool partial = false}) {
+    if (partial) {
+      _flutterFrames.trimToSublist(_flutterFrames.value.length ~/ 2);
+    } else {
+      _flutterFrames.clear();
+    }
     _unassignedFlutterFrames.clear();
     firstWellFormedFrameMicros = null;
     _selectedFrameNotifier.value = null;

--- a/packages/devtools_app/lib/src/screens/performance/panes/rebuild_stats/rebuild_stats_controller.dart
+++ b/packages/devtools_app/lib/src/screens/performance/panes/rebuild_stats/rebuild_stats_controller.dart
@@ -16,7 +16,7 @@ class RebuildStatsController extends PerformanceFeatureController {
   RebuildStatsController(super.performanceController);
 
   @override
-  FutureOr<void> clearData() {}
+  void clearData({bool partial = false}) {}
 
   @override
   void handleSelectedFrame(FlutterFrame frame) {}

--- a/packages/devtools_app/lib/src/screens/performance/panes/timeline_events/timeline_events_controller.dart
+++ b/packages/devtools_app/lib/src/screens/performance/panes/timeline_events/timeline_events_controller.dart
@@ -518,6 +518,7 @@ class TimelineEventsController extends PerformanceFeatureController
       if (traceRingBuffer.chunksLength <= 1) {
         traceRingBuffer.clear();
       } else {
+        // Trim from the front so that the oldest data is removed.
         traceRingBuffer.trimToSublist(traceRingBuffer.chunksLength ~/ 2);
       }
       unawaited(loadPerfettoTrace());

--- a/packages/devtools_app/lib/src/screens/performance/panes/timeline_events/timeline_events_controller.dart
+++ b/packages/devtools_app/lib/src/screens/performance/panes/timeline_events/timeline_events_controller.dart
@@ -513,15 +513,23 @@ class TimelineEventsController extends PerformanceFeatureController
   }
 
   @override
-  Future<void> clearData() async {
-    _unprocessedTrackEvents.clear();
-    traceRingBuffer.clear();
-    _trackDescriptors.clear();
-    _unassignedFlutterTimelineEvents.clear();
-
-    _refreshWorkTracker.clear();
-    _status.value = EventsControllerStatus.empty;
-    await perfettoController.clear();
+  Future<void> clearData({bool partial = false}) async {
+    if (partial) {
+      if (traceRingBuffer.chunksLength <= 1) {
+        traceRingBuffer.clear();
+      } else {
+        traceRingBuffer.trimToSublist(traceRingBuffer.chunksLength ~/ 2);
+      }
+      unawaited(loadPerfettoTrace());
+    } else {
+      traceRingBuffer.clear();
+      _unprocessedTrackEvents.clear();
+      _trackDescriptors.clear();
+      _unassignedFlutterTimelineEvents.clear();
+      _refreshWorkTracker.clear();
+      _status.value = EventsControllerStatus.empty;
+      await perfettoController.clear();
+    }
   }
 
   @override

--- a/packages/devtools_app/lib/src/screens/profiler/profiler_screen_controller.dart
+++ b/packages/devtools_app/lib/src/screens/profiler/profiler_screen_controller.dart
@@ -9,6 +9,8 @@ import 'package:flutter/foundation.dart';
 import 'package:vm_service/vm_service.dart';
 
 import '../../shared/config_specific/logger/allowed_error.dart';
+import '../../shared/feature_flags.dart';
+import '../../shared/framework/screen.dart';
 import '../../shared/framework/screen_controllers.dart';
 import '../../shared/globals.dart';
 import '../../shared/offline/offline_data.dart';
@@ -33,6 +35,9 @@ class ProfilerScreenController extends DevToolsScreenController
     with
         AutoDisposeControllerMixin,
         OfflineScreenControllerMixin<CpuProfileData> {
+  @override
+  final screenId = ScreenMetaData.cpuProfiler.id;
+
   final _initialized = Completer<void>();
 
   Future<void> get initialized => _initialized.future;
@@ -180,5 +185,13 @@ class ProfilerScreenController extends DevToolsScreenController
     _recordingNotifier.dispose();
     cpuProfilerController.dispose();
     super.dispose();
+  }
+
+  @override
+  FutureOr<void> releaseMemory({bool partial = false}) async {
+    if (FeatureFlags.memoryObserver) {
+      // There is no way to partially release memory for this screen.
+      await clear();
+    }
   }
 }

--- a/packages/devtools_app/lib/src/screens/vm_developer/vm_developer_tools_controller.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/vm_developer_tools_controller.dart
@@ -4,6 +4,7 @@
 
 import 'package:flutter/foundation.dart';
 
+import '../../shared/framework/screen.dart';
 import '../../shared/framework/screen_controllers.dart';
 import 'object_inspector/object_inspector_view_controller.dart';
 import 'vm_developer_tools_screen.dart';
@@ -24,6 +25,9 @@ class VMDeveloperToolsController extends DevToolsScreenController {
     ObjectInspectorViewController? objectInspectorViewController,
   }) : objectInspectorViewController =
            objectInspectorViewController ?? ObjectInspectorViewController();
+
+  @override
+  final screenId = ScreenMetaData.vmTools.id;
 
   ValueListenable<int> get selectedIndex => _selectedIndex;
   final _selectedIndex = ValueNotifier<int>(0);

--- a/packages/devtools_app/lib/src/shared/framework/screen_controllers.dart
+++ b/packages/devtools_app/lib/src/shared/framework/screen_controllers.dart
@@ -162,7 +162,7 @@ abstract class DevToolsScreenController extends DisposableController {
 
   /// This method can be overridden to release memory from the screen
   /// controller.
-  /// 
+  ///
   /// When `partial` is true, this should only release stale data from the
   /// screen controller where possible. A partial release is intended to be
   /// less disruptive to the user, wiping only the oldest data from the screen

--- a/packages/devtools_app/lib/src/shared/framework/screen_controllers.dart
+++ b/packages/devtools_app/lib/src/shared/framework/screen_controllers.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
 
+import 'dart:async';
+
 import 'package:devtools_app_shared/utils.dart';
 import 'package:meta/meta.dart';
 
@@ -83,7 +85,8 @@ class ScreenControllers {
     offlineControllers.clear();
   }
 
-  /// Calls the [callback] function on each initialized screen controller.
+  /// Calls the synchronous [callback] function on each initialized screen
+  /// controller.
   ///
   /// Optionally, calls the [callback] on the offline screen controllers when
   /// [includeOfflineControllers] is true.
@@ -100,6 +103,35 @@ class ScreenControllers {
         callback(lazyController.controller);
       }
     }
+  }
+
+  /// Calls the asynchrounous [callback] function on each initialized screen
+  /// controller.
+  ///
+  /// Optionally, calls the [callback] on the offline screen controllers when
+  /// [includeOfflineControllers] is true.
+  FutureOr<void> forEachInitializedAsync(
+    FutureOr<void> Function(DevToolsScreenController screenController)
+    callback, {
+    bool includeOfflineControllers = false,
+  }) async {
+    final controllers =
+        includeOfflineControllers
+            ? [...this.controllers.values, ...offlineControllers.values]
+            : this.controllers.values;
+
+    Future<void> helper(
+      FutureOr<void> Function(DevToolsScreenController) futureOr,
+      DevToolsScreenController controller,
+    ) async {
+      await futureOr(controller);
+    }
+
+    await [
+      for (final lazyController in controllers)
+        if (lazyController.initialized)
+          helper(callback, lazyController.controller),
+    ].wait;
   }
 }
 
@@ -125,4 +157,15 @@ class _LazyController<T extends DevToolsScreenController> {
 }
 
 /// Base class for all DevTools screen controllers.
-abstract class DevToolsScreenController extends DisposableController {}
+abstract class DevToolsScreenController extends DisposableController {
+  String get screenId;
+
+  /// This method can be overridden to release memory from the screen
+  /// controller.
+  /// 
+  /// When `partial` is true, this should only release stale data from the
+  /// screen controller where possible. A partial release is intended to be
+  /// less disruptive to the user, wiping only the oldest data from the screen
+  /// controller.
+  FutureOr<void> releaseMemory({bool partial = false}) {}
+}

--- a/packages/devtools_app/lib/src/shared/primitives/byte_utils.dart
+++ b/packages/devtools_app/lib/src/shared/primitives/byte_utils.dart
@@ -138,6 +138,9 @@ class Uint8ListRingBuffer {
   /// bytes is the length of the Uint8List.
   int get size => data.fold(0, (sum, e) => sum + e.length);
 
+  /// Returns the number of chunks of data contained in this ring buffer.
+  int get chunksLength => data.length;
+
   @visibleForTesting
   final data = ListQueue<Uint8List>();
 
@@ -169,5 +172,14 @@ class Uint8ListRingBuffer {
 
   void clear() {
     data.clear();
+  }
+
+  void trimToSublist(int start, [int? end]) {
+    for (var i = data.length; i > (end ?? data.length); i--) {
+      data.removeLast();
+    }
+    for (var i = 0; i < start; i++) {
+      data.removeFirst();
+    }
   }
 }

--- a/packages/devtools_app/test/screens/cpu_profiler/profiler_screen_controller_test.dart
+++ b/packages/devtools_app/test/screens/cpu_profiler/profiler_screen_controller_test.dart
@@ -3,20 +3,31 @@
 // found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
 
 import 'package:devtools_app/devtools_app.dart';
+import 'package:devtools_app/src/screens/profiler/cpu_profiler_controller.dart';
+import 'package:devtools_app/src/shared/feature_flags.dart';
 import 'package:devtools_app_shared/utils.dart';
 import 'package:devtools_test/devtools_test.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
+import 'package:vm_service/vm_service.dart';
+
+import '../../test_infra/test_data/cpu_profiler/cpu_profile.dart';
 
 void main() {
   group('ProfilerScreenController', () {
     late ProfilerScreenController controller;
-    final fakeServiceConnection = FakeServiceConnectionManager();
-    when(
-      fakeServiceConnection.serviceManager.connectedApp!.isFlutterAppNow,
-    ).thenReturn(false);
 
     setUp(() {
+      FeatureFlags.memoryObserver = true;
+      final fakeServiceConnection = FakeServiceConnectionManager(
+        service: FakeServiceManager.createFakeService(
+          cpuSamples: CpuSamples.parse(goldenCpuSamplesJson),
+          resolvedUriMap: goldenResolvedUriMap,
+        ),
+      );
+      final app = fakeServiceConnection.serviceManager.connectedApp!;
+      when(app.isFlutterAppNow).thenReturn(true);
+
       setGlobal(
         DevToolsEnvironmentParameters,
         ExternalDevToolsEnvironmentParameters(),
@@ -49,6 +60,22 @@ void main() {
         controller.cpuProfilerController.selectedCpuStackFrameNotifier
             .addListener(() {});
       }, throwsA(anything));
+    });
+
+    test('releaseMemory', () async {
+      FeatureFlags.memoryObserver = true;
+      await controller.cpuProfilerController.loadAllSamples();
+      expect(controller.cpuProfilerController.dataNotifier.value, isNotNull);
+      expect(
+        controller.cpuProfilerController.dataNotifier.value,
+        isNot(CpuProfilerController.baseStateCpuProfileData),
+      );
+      await controller.releaseMemory();
+      expect(
+        controller.cpuProfilerController.dataNotifier.value,
+        CpuProfilerController.baseStateCpuProfileData,
+      );
+      FeatureFlags.memoryObserver = false;
     });
   });
 }

--- a/packages/devtools_app/test/screens/logging/logging_controller_test.dart
+++ b/packages/devtools_app/test/screens/logging/logging_controller_test.dart
@@ -309,6 +309,24 @@ void main() {
       expect(controller.data, hasLength(17));
       expect(controller.filteredData.value, hasLength(3));
     });
+
+    test('releaseMemory - full release', () {
+      prepareTestLogs();
+      expect(controller.data, isNotEmpty);
+      expect(controller.filteredData.value, isNotEmpty);
+      controller.releaseMemory();
+      expect(controller.data, isEmpty);
+      expect(controller.filteredData.value, isEmpty);
+    });
+
+    test('releaseMemory - partial release', () {
+      prepareTestLogs();
+      expect(controller.data, hasLength(17));
+      expect(controller.filteredData.value, hasLength(10));
+      controller.releaseMemory(partial: true);
+      expect(controller.data, hasLength(9));
+      expect(controller.filteredData.value, hasLength(2));
+    });
   });
 
   group('LogData', () {

--- a/packages/devtools_app/test/screens/logging/logging_controller_test.dart
+++ b/packages/devtools_app/test/screens/logging/logging_controller_test.dart
@@ -8,6 +8,7 @@ library;
 import 'dart:convert';
 
 import 'package:devtools_app/devtools_app.dart';
+import 'package:devtools_app/src/shared/feature_flags.dart';
 import 'package:devtools_app/src/shared/primitives/message_bus.dart';
 import 'package:devtools_app_shared/utils.dart';
 import 'package:devtools_test/devtools_test.dart';
@@ -320,12 +321,14 @@ void main() {
     });
 
     test('releaseMemory - partial release', () {
+      FeatureFlags.memoryObserver = true;
       prepareTestLogs();
       expect(controller.data, hasLength(17));
       expect(controller.filteredData.value, hasLength(10));
       controller.releaseMemory(partial: true);
       expect(controller.data, hasLength(9));
       expect(controller.filteredData.value, hasLength(2));
+      FeatureFlags.memoryObserver = false;
     });
   });
 

--- a/packages/devtools_app/test/screens/logging/logging_controller_test.dart
+++ b/packages/devtools_app/test/screens/logging/logging_controller_test.dart
@@ -311,24 +311,31 @@ void main() {
       expect(controller.filteredData.value, hasLength(3));
     });
 
-    test('releaseMemory - full release', () {
-      prepareTestLogs();
-      expect(controller.data, isNotEmpty);
-      expect(controller.filteredData.value, isNotEmpty);
-      controller.releaseMemory();
-      expect(controller.data, isEmpty);
-      expect(controller.filteredData.value, isEmpty);
-    });
+    group('releaseMemory', () {
+      setUp(() {
+        FeatureFlags.memoryObserver = true;
+        prepareTestLogs();
+      });
 
-    test('releaseMemory - partial release', () {
-      FeatureFlags.memoryObserver = true;
-      prepareTestLogs();
-      expect(controller.data, hasLength(17));
-      expect(controller.filteredData.value, hasLength(10));
-      controller.releaseMemory(partial: true);
-      expect(controller.data, hasLength(9));
-      expect(controller.filteredData.value, hasLength(2));
-      FeatureFlags.memoryObserver = false;
+      tearDown(() {
+        FeatureFlags.memoryObserver = false;
+      });
+
+      test('releaseMemory - full release', () {
+        expect(controller.data, isNotEmpty);
+        expect(controller.filteredData.value, isNotEmpty);
+        controller.releaseMemory();
+        expect(controller.data, isEmpty);
+        expect(controller.filteredData.value, isEmpty);
+      });
+
+      test('releaseMemory - partial release', () {
+        expect(controller.data, hasLength(17));
+        expect(controller.filteredData.value, hasLength(10));
+        controller.releaseMemory(partial: true);
+        expect(controller.data, hasLength(9));
+        expect(controller.filteredData.value, hasLength(2));
+      });
     });
   });
 

--- a/packages/devtools_app/test/screens/network/network_controller_test.dart
+++ b/packages/devtools_app/test/screens/network/network_controller_test.dart
@@ -366,6 +366,63 @@ void main() {
           );
         },
       );
+
+      test('clear', () {
+        final reqs = [request1Pending, request2Pending];
+        final sockets = [socketStats1Pending, socketStats2Pending];
+        currentNetworkRequests.updateOrAddAll(
+          requests: reqs,
+          sockets: sockets,
+          timelineMicrosOffset: 0,
+        );
+
+        // Check that all requests ids are present and that there are no
+        // endtimes
+        expect(
+          currentNetworkRequests.value.map((e) => [e.id, e.endTimestamp]),
+          [
+            ['101', null],
+            ['102', null],
+            ['21', null],
+            ['22', null],
+          ],
+        );
+
+        currentNetworkRequests.clear();
+        expect(currentNetworkRequests.value, isEmpty);
+      });
+
+      test('partial clear', () {
+        final reqs = [request1Pending, request2Pending];
+        final sockets = [socketStats1Pending, socketStats2Pending];
+        currentNetworkRequests.updateOrAddAll(
+          requests: reqs,
+          sockets: sockets,
+          timelineMicrosOffset: 0,
+        );
+
+        // Check that all requests ids are present and that there are no
+        // endtimes
+        expect(
+          currentNetworkRequests.value.map((e) => [e.id, e.endTimestamp]),
+          [
+            ['101', null],
+            ['102', null],
+            ['21', null],
+            ['22', null],
+          ],
+        );
+
+        currentNetworkRequests.clear(partial: true);
+        expect(currentNetworkRequests.value.length, 2);
+        expect(
+          currentNetworkRequests.value.map((e) => [e.id, e.endTimestamp]),
+          [
+            ['21', null],
+            ['22', null],
+          ],
+        );
+      });
     });
   });
 }

--- a/packages/devtools_app/test/screens/performance/flutter_frames/flutter_frames_controller_test.dart
+++ b/packages/devtools_app/test/screens/performance/flutter_frames/flutter_frames_controller_test.dart
@@ -109,5 +109,35 @@ void main() {
       expect(framesController.selectedFrame.value, equals(testFrame0));
       expect(framesController.displayRefreshRate.value, equals(120.0));
     });
+
+    test('can clearData', () {
+      framesController.addFrame(testFrame0);
+      framesController.addFrame(testFrame1);
+      framesController.addFrame(testFrame2);
+      framesController.addFrame(jankyFrame);
+      framesController.handleSelectedFrame(testFrame0);
+      expect(framesController.flutterFrames.value.length, 4);
+      expect(framesController.selectedFrame.value, equals(testFrame0));
+      framesController.clearData();
+      expect(framesController.flutterFrames.value, isEmpty);
+      expect(framesController.selectedFrame.value, isNull);
+    });
+
+    test('can clearData - partial', () {
+      framesController.addFrame(testFrame0);
+      framesController.addFrame(testFrame1);
+      framesController.addFrame(testFrame2);
+      framesController.addFrame(jankyFrame);
+      framesController.handleSelectedFrame(testFrame0);
+      expect(framesController.flutterFrames.value.length, 4);
+      expect(framesController.selectedFrame.value, equals(testFrame0));
+      framesController.clearData(partial: true);
+      expect(framesController.flutterFrames.value.length, 2);
+      expect(framesController.flutterFrames.value, isNot(contains(testFrame0)));
+      expect(framesController.flutterFrames.value, isNot(contains(testFrame1)));
+      expect(framesController.flutterFrames.value, contains(testFrame2));
+      expect(framesController.flutterFrames.value, contains(jankyFrame));
+      expect(framesController.selectedFrame.value, isNull);
+    });
   });
 }

--- a/packages/devtools_app/test/screens/performance/timeline_events/timeline_events_controller_test.dart
+++ b/packages/devtools_app/test/screens/performance/timeline_events/timeline_events_controller_test.dart
@@ -81,5 +81,33 @@ void main() {
         equals(testRasterTrackId),
       );
     });
+
+    group('can clearData', () {
+      setUp(() async {
+        // Set some data in the controller. It does not matter if it is connected
+        // data or offline.
+        offlineDataController.startShowingOfflineData(
+          offlineApp: serviceConnection.serviceManager.connectedApp!,
+        );
+        final offlineData = OfflinePerformanceData.fromJson(rawPerformanceData);
+        when(
+          performanceController.offlinePerformanceData,
+        ).thenReturn(offlineData);
+        await eventsController.setOfflineData(offlineData);
+      });
+
+      test('full', () async {
+        expect(eventsController.fullPerfettoTrace, isNotEmpty);
+        await eventsController.clearData();
+        expect(eventsController.fullPerfettoTrace, isEmpty);
+      });
+
+      test('partial', () async {
+        expect(eventsController.fullPerfettoTrace, isNotEmpty);
+        await eventsController.clearData();
+        // This is empty because the original data only has one chunk.
+        expect(eventsController.fullPerfettoTrace, isEmpty);
+      });
+    });
   });
 }

--- a/packages/devtools_app/test/shared/primitives/byte_utils_test.dart
+++ b/packages/devtools_app/test/shared/primitives/byte_utils_test.dart
@@ -33,18 +33,18 @@ void main() {
       expect(buffer.data, isEmpty);
 
       buffer.addData(list1);
-      expect(buffer.data.length, 1);
+      expect(buffer.chunksLength, 1);
       expect(buffer.size, 4);
       expect(buffer.data, contains(list1));
 
       buffer.addData(list2);
-      expect(buffer.data.length, 2);
+      expect(buffer.chunksLength, 2);
       expect(buffer.size, 8);
       expect(buffer.data, contains(list1));
       expect(buffer.data, contains(list2));
 
       buffer.addData(list3);
-      expect(buffer.data.length, 2);
+      expect(buffer.chunksLength, 2);
       expect(buffer.size, 8);
       expect(buffer.data, isNot(contains(list1)));
       expect(buffer.data, contains(list2));
@@ -78,7 +78,7 @@ void main() {
       buffer
         ..addData(list1)
         ..addData(list2);
-      expect(buffer.data.length, 2);
+      expect(buffer.chunksLength, 2);
       expect(buffer.size, 8);
       expect(buffer.data, contains(list1));
       expect(buffer.data, contains(list2));
@@ -86,6 +86,37 @@ void main() {
       buffer.clear();
       expect(buffer.data, isEmpty);
       expect(buffer.size, 0);
+    });
+
+    test('can trim to sublist', () {
+      final list1 = Uint8List.fromList([1, 2, 3, 4]);
+      final list2 = Uint8List.fromList([5, 6, 7, 8]);
+      final list3 = Uint8List.fromList([9, 10, 11, 12]);
+      final list4 = Uint8List.fromList([13, 14, 15, 16]);
+
+      final buffer = Uint8ListRingBuffer(maxSizeBytes: 100);
+      expect(buffer.data, isEmpty);
+
+      buffer
+        ..addData(list1)
+        ..addData(list2)
+        ..addData(list3)
+        ..addData(list4);
+      expect(buffer.chunksLength, 4);
+      expect(buffer.size, 16);
+      expect(buffer.data, contains(list1));
+      expect(buffer.data, contains(list2));
+      expect(buffer.data, contains(list3));
+      expect(buffer.data, contains(list4));
+
+      buffer.trimToSublist(1, 3);
+      expect(buffer.data, isNot(contains(list1)));
+      expect(buffer.data, contains(list2));
+      expect(buffer.data, contains(list3));
+      expect(buffer.data, isNot(contains(list4)));
+
+      expect(buffer.chunksLength, 2);
+      expect(buffer.size, 8);
     });
   });
 


### PR DESCRIPTION
Adds a lifecycle method `releaseMemory` to each `DevToolsScreenController`. When implemented, this method should release memory from the screen controller, either a full release or a partial. Not all screen controller's have data to release, for example the Inspector, which always pulls live data from the connected app.

These methods will be called from the `MemoryObserver` when a memory pressure threshold is hit in DevTools and the user decides to release memory. This will be connected in a follow up PR to keep the PR size manageable.

Follow up to https://github.com/flutter/devtools/pull/8989 and work towards https://github.com/flutter/devtools/issues/7002. 