### PR TITLE
Enable the memory observer with full support for releasing memory

### DIFF
--- a/packages/devtools_app/lib/src/framework/observer/memory_observer.dart
+++ b/packages/devtools_app/lib/src/framework/observer/memory_observer.dart
@@ -91,7 +91,6 @@ class MemoryObserver extends DisposableController {
             ? await debugMeasureUsageInBytes()
             : await measureMemoryUsageInBytes();
     _lastMemoryUsageInBytes = memoryUsageInBytes;
-    print('memoryUsageInBytes: $memoryUsageInBytes');
     if (memoryUsageInBytes == null) return false;
 
     final memoryInGb = convertBytes(memoryUsageInBytes, to: ByteUnit.gb);

--- a/packages/devtools_app/lib/src/framework/observer/memory_observer.dart
+++ b/packages/devtools_app/lib/src/framework/observer/memory_observer.dart
@@ -75,11 +75,9 @@ class MemoryObserver extends DisposableController {
         debugMeasureUsageInBytes != null
             ? await debugMeasureUsageInBytes()
             : await measureMemoryUsageInBytes();
-    print('memoryUsageInBytes: $memoryUsageInBytes');
     if (memoryUsageInBytes == null) return false;
 
     final memoryInGb = convertBytes(memoryUsageInBytes, to: ByteUnit.gb);
-    print('memoryInGb: $memoryInGb');
     return memoryInGb > _memoryPressureLimitGb;
   }
 

--- a/packages/devtools_app/lib/src/framework/observer/memory_observer.dart
+++ b/packages/devtools_app/lib/src/framework/observer/memory_observer.dart
@@ -91,6 +91,7 @@ class MemoryObserver extends DisposableController {
             ? await debugMeasureUsageInBytes()
             : await measureMemoryUsageInBytes();
     _lastMemoryUsageInBytes = memoryUsageInBytes;
+    print('memoryUsageInBytes: $memoryUsageInBytes');
     if (memoryUsageInBytes == null) return false;
 
     final memoryInGb = convertBytes(memoryUsageInBytes, to: ByteUnit.gb);

--- a/packages/devtools_app/lib/src/framework/observer/memory_observer.dart
+++ b/packages/devtools_app/lib/src/framework/observer/memory_observer.dart
@@ -279,7 +279,6 @@ class _SuccessOrFailureMessageState extends State<_SuccessOrFailureMessage> {
           bannerMessages.removeMessageByKey(
             _MemoryPressureBannerMessage._messageKey,
             banner_messages.universalScreenId,
-            dismiss: true,
           );
         }
         setState(() {

--- a/packages/devtools_app/lib/src/framework/observer/memory_observer.dart
+++ b/packages/devtools_app/lib/src/framework/observer/memory_observer.dart
@@ -127,7 +127,7 @@ class _MemoryPressureBannerMessage extends banner_messages.BannerWarning {
     : super(
         screenId: banner_messages.universalScreenId,
         key: _messageKey,
-        buildTextSpans: (_) {
+        buildTextSpans: (context) {
           final limitAsBytes = convertBytes(
             MemoryObserver._memoryPressureLimitGb,
             from: ByteUnit.gb,
@@ -140,9 +140,19 @@ class _MemoryPressureBannerMessage extends banner_messages.BannerWarning {
                   '${printBytes(limitAsBytes, unit: ByteUnit.gb, includeUnit: true)}. '
                   'Consider releasing memory by clearing data you are no '
                   'longer analyzing, or by clicking "Reduce memory" below, '
-                  'which will make a best-effort attempt to clear stale data. '
-                  'If you do not take action, DevTools may eventually crash '
-                  'due to an out of memory error (OOM).',
+                  'which will make a ',
+              children: [
+                TextSpan(
+                  text: 'best-effort attempt',
+                  style: Theme.of(context).boldTextStyle,
+                ),
+                const TextSpan(
+                  text:
+                      ' to clear stale data. '
+                      'If you do not take action, DevTools may eventually crash '
+                      'due to an out of memory error (OOM).',
+                ),
+              ],
             ),
           ];
         },

--- a/packages/devtools_app/lib/src/framework/observer/memory_observer.dart
+++ b/packages/devtools_app/lib/src/framework/observer/memory_observer.dart
@@ -172,9 +172,14 @@ class _MemoryPressureBannerMessage extends banner_messages.BannerWarning {
                 ),
                 const TextSpan(
                   text:
-                      ' to clear stale data. '
-                      'If you do not take action, DevTools may eventually crash '
-                      'due to an out of memory error (OOM).',
+                      ' to clear stale data. If you do not take action, '
+                      'DevTools may eventually crash due to an out of memory '
+                      'error (OOM).\n\n'
+                      'WARNING: clicking "Reduce memory" will clear data from '
+                      'other DevTools screens and may partially clear data '
+                      'from the screen you are currently using. Consider '
+                      'saving data from other DevTools screens, where '
+                      'supported, if you do not want to lose data.',
                 ),
               ],
             ),

--- a/packages/devtools_app/lib/src/screens/memory/panes/diff/controller/diff_pane_controller.dart
+++ b/packages/devtools_app/lib/src/screens/memory/panes/diff/controller/diff_pane_controller.dart
@@ -155,12 +155,14 @@ class DiffPaneController extends DisposableController with Serializable {
     const offsetForInstructionSnapshot = 1;
     final snapshots = core._snapshots;
     final snapshotsToRemove = max(
-      offsetForInstructionSnapshot,
+      0,
       (snapshots.value.length - offsetForInstructionSnapshot) ~/
           (partial ? 2 : 1),
     );
-    final endIndexToRemoveExclusive =
-        offsetForInstructionSnapshot + snapshotsToRemove;
+    final endIndexToRemoveExclusive = min(
+      snapshots.value.length,
+      offsetForInstructionSnapshot + snapshotsToRemove,
+    );
     for (
       var i = offsetForInstructionSnapshot;
       i < endIndexToRemoveExclusive;

--- a/packages/devtools_app/lib/src/shared/feature_flags.dart
+++ b/packages/devtools_app/lib/src/shared/feature_flags.dart
@@ -63,7 +63,7 @@ abstract class FeatureFlags {
   /// avoid OOM crashes.
   ///
   /// https://github.com/flutter/devtools/issues/7002
-  static bool memoryObserver = enableExperiments;
+  static bool memoryObserver = true;
 
   /// Flag to enable widget rebuild stats ui.
   ///

--- a/packages/devtools_app/lib/src/shared/framework/routing.dart
+++ b/packages/devtools_app/lib/src/shared/framework/routing.dart
@@ -121,6 +121,10 @@ class DevToolsRouterDelegate extends RouterDelegate<DevToolsRouteConfiguration>
 
   static String? get currentPage => _currentPage;
   static String? _currentPage;
+  @visibleForTesting
+  static set currentPage(String? page) {
+    _currentPage = page;
+  }
 
   final Page Function(
     BuildContext,

--- a/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
+++ b/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
@@ -15,6 +15,12 @@ To learn more about DevTools, check out the
 
 ## General updates
 
+* Added a memory pressure warning that allows you to reduce the memory usage of
+DevTools in order to avoid an OOM crash. -
+[#8989](https://github.com/flutter/devtools/pull/8989),
+[#8997](https://github.com/flutter/devtools/pull/8997),
+[#8998](https://github.com/flutter/devtools/pull/8998)
+
 * Fixed various memory leaks and lifecycle issues. - 
 [#8901](https://github.com/flutter/devtools/pull/8901),
 [#8902](https://github.com/flutter/devtools/pull/8902),
@@ -29,8 +35,10 @@ To learn more about DevTools, check out the
 [#8969](https://github.com/flutter/devtools/pull/8969),
 [#8970](https://github.com/flutter/devtools/pull/8970),
 [#8975](https://github.com/flutter/devtools/pull/8975)
+
 * Fix a bug with the review history on disconnect experience. -
 [#8985](https://github.com/flutter/devtools/pull/8985)
+
 * Fixed bug where DevTools would automatically resume instead of
 pausing on breakpoint on connection. - 
 [#8991](https://github.com/flutter/devtools/pull/8991)

--- a/packages/devtools_app/test/framework/observer/memory_observer_test.dart
+++ b/packages/devtools_app/test/framework/observer/memory_observer_test.dart
@@ -9,10 +9,14 @@ import 'package:devtools_app/src/framework/observer/memory_observer.dart';
 import 'package:devtools_app/src/shared/feature_flags.dart';
 import 'package:devtools_app/src/shared/primitives/byte_utils.dart';
 import 'package:devtools_app_shared/utils.dart';
+import 'package:devtools_test/devtools_test.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
+
+  late MockOfflineDataController offlineDataController;
+
   group('$MemoryObserver', () {
     late MemoryObserver observer;
 
@@ -32,18 +36,28 @@ void main() {
       return memoryUsageBytes;
     }
 
+    setUpAll(() {
+      FeatureFlags.memoryObserver = true;
+    });
+
     setUp(() {
       measurementComplete = Completer();
-      FeatureFlags.memoryObserver = true;
       observer = MemoryObserver(
         debugMeasureUsageInBytes: testMeasureMemoryUsage,
         pollingDuration: const Duration(milliseconds: 1),
       );
       setGlobal(BannerMessagesController, BannerMessagesController());
+      offlineDataController = MockOfflineDataController();
+      offlineDataController.showingOfflineData.value = false;
+      setGlobal(OfflineDataController, offlineDataController);
     });
 
     tearDown(() {
       observer.dispose();
+    });
+
+    tearDownAll(() {
+      FeatureFlags.memoryObserver = false;
     });
 
     test(
@@ -82,5 +96,117 @@ void main() {
           bannerMessages.messagesForScreen(universalScreenId).value;
       expect(messages, isNotEmpty);
     });
+
+    group('reduce memory', () {
+      late FakeScreenController1 screenController1;
+      late FakeScreenController2 screenController2;
+
+      setUp(() {
+        screenController1 = FakeScreenController1();
+        screenController2 = FakeScreenController2();
+        setGlobal(ScreenControllers, ScreenControllers());
+        screenControllers.register<FakeScreenController1>(
+          () => screenController1,
+        );
+        screenControllers.register<FakeScreenController2>(
+          () => screenController2,
+        );
+      });
+
+      Future<int?> testMeasureMemoryUsage() async => memoryUsageBytes;
+
+      test(
+        'fully releases other screens and partially releases the current screen',
+        () async {
+          // Lookups to force initialization.
+          screenControllers.lookup<FakeScreenController1>();
+          screenControllers.lookup<FakeScreenController2>();
+          DevToolsRouterDelegate.currentPage = screenController1.screenId;
+
+          memoryUsageBytes =
+              convertBytes(3.1, from: ByteUnit.gb, to: ByteUnit.byte).round();
+          var memoryReduced = await MemoryObserver.reduceMemory(
+            debugMeasureUsageInBytes: testMeasureMemoryUsage,
+          );
+          expect(memoryReduced, isFalse);
+          expect(screenController1.releaseMemoryCallCount, 1);
+          expect(screenController1.partialReleaseMemoryCallCount, 1);
+          expect(screenController2.releaseMemoryCallCount, 1);
+          expect(screenController2.partialReleaseMemoryCallCount, 0);
+
+          memoryUsageBytes =
+              convertBytes(1, from: ByteUnit.gb, to: ByteUnit.byte).round();
+          memoryReduced = await MemoryObserver.reduceMemory(
+            debugMeasureUsageInBytes: testMeasureMemoryUsage,
+          );
+          expect(memoryReduced, isTrue);
+          expect(screenController1.releaseMemoryCallCount, equals(1));
+          expect(screenController1.partialReleaseMemoryCallCount, equals(1));
+          expect(screenController2.releaseMemoryCallCount, equals(2));
+          expect(screenController2.partialReleaseMemoryCallCount, equals(0));
+        },
+      );
+
+      test('skips uninitialized screen controllers', () async {
+        DevToolsRouterDelegate.currentPage = screenController1.screenId;
+
+        memoryUsageBytes =
+            convertBytes(3.1, from: ByteUnit.gb, to: ByteUnit.byte).round();
+        var memoryReduced = await MemoryObserver.reduceMemory(
+          debugMeasureUsageInBytes: testMeasureMemoryUsage,
+        );
+        expect(memoryReduced, isFalse);
+        expect(screenController1.releaseMemoryCallCount, 0);
+        expect(screenController1.partialReleaseMemoryCallCount, 0);
+        expect(screenController2.releaseMemoryCallCount, 0);
+        expect(screenController2.partialReleaseMemoryCallCount, 0);
+
+        // Lookup to force initialization.
+        screenControllers.lookup<FakeScreenController1>();
+
+        memoryUsageBytes =
+            convertBytes(3.1, from: ByteUnit.gb, to: ByteUnit.byte).round();
+        memoryReduced = await MemoryObserver.reduceMemory(
+          debugMeasureUsageInBytes: testMeasureMemoryUsage,
+        );
+        expect(memoryReduced, isFalse);
+        expect(screenController1.releaseMemoryCallCount, 1);
+        expect(screenController1.partialReleaseMemoryCallCount, 1);
+        expect(screenController2.releaseMemoryCallCount, 0);
+        expect(screenController2.partialReleaseMemoryCallCount, 0);
+      });
+    });
   });
+}
+
+class FakeScreenController1 extends DevToolsScreenController {
+  @override
+  String get screenId => 'fake-screen-1';
+
+  int releaseMemoryCallCount = 0;
+  int partialReleaseMemoryCallCount = 0;
+
+  @override
+  Future<void> releaseMemory({bool partial = false}) async {
+    releaseMemoryCallCount++;
+    if (partial) {
+      partialReleaseMemoryCallCount++;
+    }
+  }
+}
+
+class FakeScreenController2 extends DevToolsScreenController {
+  @override
+  String get screenId => 'fake-screen-2';
+
+  int releaseMemoryCallCount = 0;
+  int partialReleaseMemoryCallCount = 0;
+
+  @override
+  Future<void> releaseMemory({bool partial = false}) async {
+    releaseMemoryCallCount++;
+    if (partial) {
+      partialReleaseMemoryCallCount++;
+    }
+  }
 }

--- a/packages/devtools_app/test/framework/observer/memory_observer_test.dart
+++ b/packages/devtools_app/test/framework/observer/memory_observer_test.dart
@@ -125,10 +125,10 @@ void main() {
 
           memoryUsageBytes =
               convertBytes(3.1, from: ByteUnit.gb, to: ByteUnit.byte).round();
-          var memoryReduced = await MemoryObserver.reduceMemory(
+          var result = await MemoryObserver.reduceMemory(
             debugMeasureUsageInBytes: testMeasureMemoryUsage,
           );
-          expect(memoryReduced, isFalse);
+          expect(result.success, isFalse);
           expect(screenController1.releaseMemoryCallCount, 1);
           expect(screenController1.partialReleaseMemoryCallCount, 1);
           expect(screenController2.releaseMemoryCallCount, 1);
@@ -136,10 +136,10 @@ void main() {
 
           memoryUsageBytes =
               convertBytes(1, from: ByteUnit.gb, to: ByteUnit.byte).round();
-          memoryReduced = await MemoryObserver.reduceMemory(
+          result = await MemoryObserver.reduceMemory(
             debugMeasureUsageInBytes: testMeasureMemoryUsage,
           );
-          expect(memoryReduced, isTrue);
+          expect(result.success, isTrue);
           expect(screenController1.releaseMemoryCallCount, equals(1));
           expect(screenController1.partialReleaseMemoryCallCount, equals(1));
           expect(screenController2.releaseMemoryCallCount, equals(2));
@@ -152,10 +152,10 @@ void main() {
 
         memoryUsageBytes =
             convertBytes(3.1, from: ByteUnit.gb, to: ByteUnit.byte).round();
-        var memoryReduced = await MemoryObserver.reduceMemory(
+        var result = await MemoryObserver.reduceMemory(
           debugMeasureUsageInBytes: testMeasureMemoryUsage,
         );
-        expect(memoryReduced, isFalse);
+        expect(result.success, isFalse);
         expect(screenController1.releaseMemoryCallCount, 0);
         expect(screenController1.partialReleaseMemoryCallCount, 0);
         expect(screenController2.releaseMemoryCallCount, 0);
@@ -166,10 +166,10 @@ void main() {
 
         memoryUsageBytes =
             convertBytes(3.1, from: ByteUnit.gb, to: ByteUnit.byte).round();
-        memoryReduced = await MemoryObserver.reduceMemory(
+        result = await MemoryObserver.reduceMemory(
           debugMeasureUsageInBytes: testMeasureMemoryUsage,
         );
-        expect(memoryReduced, isFalse);
+        expect(result.success, isFalse);
         expect(screenController1.releaseMemoryCallCount, 1);
         expect(screenController1.partialReleaseMemoryCallCount, 1);
         expect(screenController2.releaseMemoryCallCount, 0);

--- a/packages/devtools_app/test/screens/memory/framework/memory_controller_test.dart
+++ b/packages/devtools_app/test/screens/memory/framework/memory_controller_test.dart
@@ -120,7 +120,7 @@ void main() {
       FeatureFlags.memoryObserver = false;
     });
 
-    testWidgetsWithWindowSize('releaseMemory - full release', _windowSize, (
+    testWidgetsWithWindowSize('full release', _windowSize, (
       WidgetTester tester,
     ) async {
       await _pumpScene(tester, scene);
@@ -161,7 +161,7 @@ void main() {
       expect(scene.controller.trace!.selection.value.profiles, isEmpty);
     });
 
-    testWidgetsWithWindowSize('releaseMemory - partial release', _windowSize, (
+    testWidgetsWithWindowSize('partial release', _windowSize, (
       WidgetTester tester,
     ) async {
       await _pumpScene(tester, scene);

--- a/packages/devtools_app/test/screens/memory/framework/memory_controller_test.dart
+++ b/packages/devtools_app/test/screens/memory/framework/memory_controller_test.dart
@@ -111,68 +111,85 @@ void main() {
     },
   );
 
-  testWidgetsWithWindowSize('releaseMemory - full release', _windowSize, (
-    WidgetTester tester,
-  ) async {
-    FeatureFlags.memoryObserver = true;
-    await _pumpScene(tester, scene);
+  group('release memory', () {
+    setUp(() {
+      FeatureFlags.memoryObserver = true;
+    });
 
-    // Add some data to the Diff view.
-    await scene.takeSnapshot(tester);
-    await scene.takeSnapshot(tester);
+    tearDown(() {
+      FeatureFlags.memoryObserver = false;
+    });
 
-    // Add some data to the Trace view.
-    await scene.goToTraceTab(tester);
+    testWidgetsWithWindowSize('releaseMemory - full release', _windowSize, (
+      WidgetTester tester,
+    ) async {
+      await _pumpScene(tester, scene);
 
-    // Enable allocation tracing for one of them.
-    await tester.tap(find.byType(Checkbox).first);
-    await tester.pumpAndSettle();
+      // Add some data to the Diff view.
+      await scene.takeSnapshot(tester);
+      await scene.takeSnapshot(tester);
 
-    final tracingState = scene.controller.trace!.selection.value;
-    final selectedTrace = tracingState.filteredClassList.value.firstWhere(
-      (e) => e.traceAllocations,
-    );
-    final traceElement = find.byKey(Key(selectedTrace.clazz.id!));
-    expect(traceElement, findsOneWidget);
+      // Add some data to the Trace view.
+      await scene.goToTraceTab(tester);
 
-    // Select the list item for the traced class and refresh to fetch data.
-    await tester.tap(traceElement);
-    await tester.pumpAndSettle();
+      // Enable allocation tracing for one of them.
+      await tester.tap(find.byType(Checkbox).first);
+      await tester.pumpAndSettle();
 
-    // Set fake sample data and refresh to populate the trace view.
-    final fakeService =
-        serviceConnection.serviceManager.service as FakeVmServiceWrapper;
-    fakeService.allocationSamples = allocationTracingProfile;
-    await tester.tap(find.text('Refresh'));
-    await tester.pumpAndSettle();
+      final tracingState = scene.controller.trace!.selection.value;
+      final selectedTrace = tracingState.filteredClassList.value.firstWhere(
+        (e) => e.traceAllocations,
+      );
+      final traceElement = find.byKey(Key(selectedTrace.clazz.id!));
+      expect(traceElement, findsOneWidget);
 
-    expect(scene.controller.diff.hasSnapshots, true);
-    expect(scene.controller.trace!.selection.value.profiles, isNotEmpty);
-    await scene.controller.releaseMemory();
-    expect(scene.controller.diff.hasSnapshots, false);
-    expect(scene.controller.trace!.selection.value.profiles, isEmpty);
-    FeatureFlags.memoryObserver = false;
-  });
+      // Select the list item for the traced class and refresh to fetch data.
+      await tester.tap(traceElement);
+      await tester.pumpAndSettle();
 
-  testWidgetsWithWindowSize('releaseMemory - partial release', _windowSize, (
-    WidgetTester tester,
-  ) async {
-    FeatureFlags.memoryObserver = true;
-    await _pumpScene(tester, scene);
+      // Set fake sample data and refresh to populate the trace view.
+      final fakeService =
+          serviceConnection.serviceManager.service as FakeVmServiceWrapper;
+      fakeService.allocationSamples = allocationTracingProfile;
+      await tester.tap(find.text('Refresh'));
+      await tester.pumpAndSettle();
 
-    // Add some data to the Diff view.
-    await scene.takeSnapshot(tester);
-    await scene.takeSnapshot(tester);
-    await scene.takeSnapshot(tester);
-    await scene.takeSnapshot(tester);
+      expect(scene.controller.diff.hasSnapshots, true);
+      expect(scene.controller.trace!.selection.value.profiles, isNotEmpty);
+      await scene.controller.releaseMemory();
+      expect(scene.controller.diff.hasSnapshots, false);
+      expect(scene.controller.trace!.selection.value.profiles, isEmpty);
+    });
 
-    // Full and partial releases are identical for the tracing functionality,
-    // so we only need to check the diff behavior in this test case.
-    expect(scene.controller.diff.hasSnapshots, true);
-    expect(scene.controller.diff.core.snapshots.value.length, 5);
-    await scene.controller.releaseMemory(partial: true);
-    expect(scene.controller.diff.hasSnapshots, true);
-    expect(scene.controller.diff.core.snapshots.value.length, 3);
-    FeatureFlags.memoryObserver = false;
+    testWidgetsWithWindowSize('releaseMemory - partial release', _windowSize, (
+      WidgetTester tester,
+    ) async {
+      await _pumpScene(tester, scene);
+
+      // Add some data to the Diff view.
+      await scene.takeSnapshot(tester);
+      await scene.takeSnapshot(tester);
+      await scene.takeSnapshot(tester);
+      await scene.takeSnapshot(tester);
+
+      // Full and partial releases are identical for the tracing functionality,
+      // so we only need to check the diff behavior in this test case.
+      expect(scene.controller.diff.hasSnapshots, true);
+      expect(scene.controller.diff.core.snapshots.value.length, 5);
+      await scene.controller.releaseMemory(partial: true);
+      expect(scene.controller.diff.hasSnapshots, true);
+      expect(scene.controller.diff.core.snapshots.value.length, 3);
+    });
+
+    testWidgetsWithWindowSize('succeeds with no snapshots', _windowSize, (
+      WidgetTester tester,
+    ) async {
+      await _pumpScene(tester, scene);
+      expect(scene.controller.diff.hasSnapshots, false);
+      expect(scene.controller.diff.core.snapshots.value.length, 1);
+      await scene.controller.releaseMemory();
+      expect(scene.controller.diff.hasSnapshots, false);
+      expect(scene.controller.diff.core.snapshots.value.length, 1);
+    });
   });
 }

--- a/packages/devtools_app/test/shared/framework/screen_controllers_test.dart
+++ b/packages/devtools_app/test/shared/framework/screen_controllers_test.dart
@@ -4,17 +4,12 @@
 
 import 'package:devtools_app/devtools_app.dart';
 import 'package:devtools_app_shared/utils.dart';
-import 'package:flutter/foundation.dart';
+import 'package:devtools_test/devtools_test.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
 
 class MockDevToolsScreenController extends Mock
     implements DevToolsScreenController {}
-
-class MockOfflineDataController extends Mock implements OfflineDataController {
-  @override
-  ValueNotifier<bool> showingOfflineData = ValueNotifier<bool>(false);
-}
 
 void main() {
   group('ScreenControllers', () {

--- a/packages/devtools_test/lib/src/mocks/mocks.dart
+++ b/packages/devtools_test/lib/src/mocks/mocks.dart
@@ -299,3 +299,8 @@ final mockScriptRefs = [
   ScriptRef(uri: 'travel:adventure/cave_tours_europe.dart', id: 'fake/id/10'),
   ScriptRef(uri: 'travel:canada/banff.dart', id: 'fake/id/11'),
 ];
+
+class MockOfflineDataController extends Mock implements OfflineDataController {
+  @override
+  ValueNotifier<bool> showingOfflineData = ValueNotifier<bool>(false);
+}


### PR DESCRIPTION
Add the ability to release memory (see https://github.com/flutter/devtools/pull/8997) from the memory pressure prompt (see https://github.com/flutter/devtools/pull/8989).

_(Ignore the threshold numbers in these gifs. The actual threshold is set to 3.0 GB.)_

Successful release of memory upon clicking "Reduce memory":
![reduce-success-updated](https://github.com/user-attachments/assets/4d399178-7524-40d9-bb81-a660930a6747)

Unsuccessful release of memory upon clicking "Reduce memory":
![reduce-failed-updated](https://github.com/user-attachments/assets/3093003d-a00d-4cee-b2ff-d8f5caee52ba)

Requires https://github.com/flutter/devtools/pull/8997 to land first. Fixes https://github.com/flutter/devtools/issues/7002.