### PR TITLE
Add an integration test for the Network screen

### DIFF
--- a/packages/devtools_app/integration_test/test/live_connection/network_screen_test.dart
+++ b/packages/devtools_app/integration_test/test/live_connection/network_screen_test.dart
@@ -34,38 +34,36 @@ void main() {
     await pumpAndConnectDevTools(tester, testApp);
     await _prepareNetworkScreen(tester);
 
-    final networkScreen = _NetworkScreenHelper(tester, testApp.controlPort!);
+    final helper = _NetworkScreenHelper(tester, testApp.controlPort!);
 
     // Instruct the app to make a GET request via the dart:io HttpClient.
-    await networkScreen.triggerRequest('get/');
+    await helper.triggerRequest('get/');
     _expectInRequestTable('GET');
-    await networkScreen.clear();
+    await helper.clear();
 
     // Instruct the app to make a POST request via the dart:io HttpClient.
-    await networkScreen.triggerRequest('post/');
+    await helper.triggerRequest('post/');
     _expectInRequestTable('POST');
-    await networkScreen.clear();
+    await helper.clear();
 
     // Instruct the app to make a PUT request via the dart:io HttpClient.
-    await networkScreen.triggerRequest('put/');
+    await helper.triggerRequest('put/');
     _expectInRequestTable('PUT');
-    await networkScreen.clear();
+    await helper.clear();
 
     // Instruct the app to make a DELETE request via the dart:io HttpClient.
-    await networkScreen.triggerRequest('delete/');
+    await helper.triggerRequest('delete/');
     _expectInRequestTable('DELETE');
-    await networkScreen.clear();
+    await helper.clear();
 
     // Instruct the app to make a GET request via Dio.
-    await networkScreen.triggerRequest('dio/get/');
+    await helper.triggerRequest('dio/get/');
     _expectInRequestTable('GET');
-    await networkScreen.clear();
+    await helper.clear();
 
     // Instruct the app to make a POST request via Dio.
-    await networkScreen.triggerRequest('dio/post/');
+    await helper.triggerRequest('dio/post/');
     _expectInRequestTable('POST');
-
-    await disconnectFromTestApp(tester);
   });
 }
 
@@ -89,11 +87,12 @@ final class _NetworkScreenHelper {
   }
 }
 
-final _requestTable = find.byType(DevToolsTable<NetworkRequest>);
-
 void _expectInRequestTable(String text) {
   expect(
-    find.descendant(of: _requestTable, matching: find.text(text)),
+    find.descendant(
+      of: find.byType(DevToolsTable<NetworkRequest>),
+      matching: find.text(text),
+    ),
     findsOneWidget,
   );
 }

--- a/packages/devtools_app/integration_test/test/live_connection/network_screen_test.dart
+++ b/packages/devtools_app/integration_test/test/live_connection/network_screen_test.dart
@@ -1,0 +1,109 @@
+// Copyright 2025 The Flutter Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
+
+// Do not delete these arguments. They are parsed by test runner.
+// test-argument:appPath="test/test_infra/fixtures/networking_app/bin/main.dart"
+
+import 'package:devtools_app/devtools_app.dart';
+import 'package:devtools_app/src/shared/table/table.dart' show DevToolsTable;
+import 'package:devtools_test/helpers.dart';
+import 'package:devtools_test/integration_test.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:integration_test/integration_test.dart';
+
+// To run:
+// dart run integration_test/run_tests.dart --target=integration_test/test/live_connection/network_screen_test.dart --test-app-device=cli
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  late TestApp testApp;
+
+  setUpAll(() {
+    testApp = TestApp.fromEnvironment();
+    expect(testApp.vmServiceUri, isNotNull);
+  });
+
+  tearDown(() async {
+    await resetHistory();
+  });
+
+  testWidgets('nnn', (tester) async {
+    await pumpAndConnectDevTools(tester, testApp);
+    await _prepareNetworkScreen(tester);
+
+    final networkScreen = _NetworkScreenHelper(tester, testApp.controlPort!);
+
+    // Instruct the app to make a GET request via the dart:io HttpClient.
+    await networkScreen.triggerRequest('get/');
+    _expectInRequestTable('GET');
+    await networkScreen.clear();
+
+    // Instruct the app to make a POST request via the dart:io HttpClient.
+    await networkScreen.triggerRequest('post/');
+    _expectInRequestTable('POST');
+    await networkScreen.clear();
+
+    // Instruct the app to make a PUT request via the dart:io HttpClient.
+    await networkScreen.triggerRequest('put/');
+    _expectInRequestTable('PUT');
+    await networkScreen.clear();
+
+    // Instruct the app to make a DELETE request via the dart:io HttpClient.
+    await networkScreen.triggerRequest('delete/');
+    _expectInRequestTable('DELETE');
+    await networkScreen.clear();
+
+    // Instruct the app to make a GET request via Dio.
+    await networkScreen.triggerRequest('dio/get/');
+    _expectInRequestTable('GET');
+    await networkScreen.clear();
+
+    // Instruct the app to make a POST request via Dio.
+    await networkScreen.triggerRequest('dio/post/');
+    _expectInRequestTable('POST');
+
+    await disconnectFromTestApp(tester);
+  });
+}
+
+final class _NetworkScreenHelper {
+  _NetworkScreenHelper(this._tester, this._controlPort);
+
+  final WidgetTester _tester;
+
+  final int _controlPort;
+
+  Future<void> clear() async {
+    // Press the 'Clear' button between tests.
+    await _tester.tap(find.text('Clear'));
+    await _tester.pump(safePumpDuration);
+  }
+
+  Future<void> triggerRequest(String path) async {
+    await http.get(Uri.parse('http://localhost:$_controlPort/$path'));
+    await Future.delayed(const Duration(milliseconds: 200));
+    await _tester.pump(safePumpDuration);
+  }
+}
+
+final _requestTable = find.byType(DevToolsTable<NetworkRequest>);
+
+void _expectInRequestTable(String text) {
+  expect(
+    find.descendant(of: _requestTable, matching: find.text(text)),
+    findsOneWidget,
+  );
+}
+
+/// Prepares the UI of the network screen for an integration test.
+Future<void> _prepareNetworkScreen(WidgetTester tester) async {
+  await switchToScreen(
+    tester,
+    tabIcon: ScreenMetaData.network.icon,
+    tabIconAsset: ScreenMetaData.network.iconAsset,
+    screenId: ScreenMetaData.network.id,
+  );
+}

--- a/packages/devtools_app/integration_test/test/live_connection/network_screen_test.dart
+++ b/packages/devtools_app/integration_test/test/live_connection/network_screen_test.dart
@@ -28,6 +28,7 @@ void main() {
 
   tearDown(() async {
     await resetHistory();
+    await http.get(Uri.parse('http://localhost:${testApp.controlPort}/exit/'));
   });
 
   testWidgets('nnn', (tester) async {

--- a/packages/devtools_app/integration_test/test_infra/run/_test_app_driver.dart
+++ b/packages/devtools_app/integration_test/test_infra/run/_test_app_driver.dart
@@ -199,8 +199,8 @@ class TestDartCliApp extends IntegrationTestApp {
   static const vmServicePrefix = 'The Dart VM service is listening on ';
   static const controlPortKey = 'controlPort';
 
-  late final int? _controlPort;
   int? get controlPort => _controlPort;
+  late final int? _controlPort;
 
   @override
   Future<void> startProcess() async {

--- a/packages/devtools_app/integration_test/test_infra/run/run_test.dart
+++ b/packages/devtools_app/integration_test/test_infra/run/run_test.dart
@@ -58,7 +58,10 @@ Future<void> runFlutterIntegrationTest(
   // Run the flutter integration test.
   final testRunner = IntegrationTestRunner();
   try {
-    final testArgs = <String, Object>{if (!offline) 'service_uri': testAppUri};
+    final testArgs = <String, Object>{
+      if (!offline) 'service_uri': testAppUri,
+      if (testApp is TestDartCliApp) 'control_port': testApp.controlPort,
+    };
     final testTarget = testRunnerArgs.testTarget!;
     debugLog('starting test run for $testTarget');
     await testRunner.run(

--- a/packages/devtools_app/integration_test/test_infra/run/run_test.dart
+++ b/packages/devtools_app/integration_test/test_infra/run/run_test.dart
@@ -58,7 +58,7 @@ Future<void> runFlutterIntegrationTest(
   // Run the flutter integration test.
   final testRunner = IntegrationTestRunner();
   try {
-    final testArgs = <String, Object>{
+    final testArgs = <String, Object?>{
       if (!offline) 'service_uri': testAppUri,
       if (testApp is TestDartCliApp) 'control_port': testApp.controlPort,
     };

--- a/packages/devtools_app/test/test_infra/fixtures/networking_app/bin/main.dart
+++ b/packages/devtools_app/test/test_infra/fixtures/networking_app/bin/main.dart
@@ -1,0 +1,170 @@
+// Copyright 2025 The Flutter Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
+
+// ignore_for_file: avoid_print
+
+import 'dart:async';
+import 'dart:convert' show json;
+import 'dart:io' as io;
+
+import 'package:dio/dio.dart';
+import 'package:http/http.dart' as http;
+
+void main() async {
+  final testServer = await _bindTestServer();
+  await _bindControlServer(testServer);
+}
+
+/// Binds a "test" HTTP server to an available port.
+///
+/// This server can receive requests, and responds to them.
+Future<io.HttpServer> _bindTestServer() async {
+  final server = await io.HttpServer.bind(io.InternetAddress.loopbackIPv4, 0);
+  server.listen((request) {
+    request.response.write('fallthrough');
+    if (request.uri.path.contains('complete/')) {
+      request.response.close();
+    }
+  });
+  return server;
+}
+
+/// Binds a "control" HTTP server to an available port.
+///
+/// This server has an HTTP client, and can receive commands for that client to
+/// send requests to the "test" HTTP server.
+Future<io.HttpServer> _bindControlServer(io.HttpServer testServer) async {
+  final client = _HttpClient(testServer.port);
+
+  final server = await io.HttpServer.bind(io.InternetAddress.loopbackIPv4, 0);
+  print(json.encode({'controlPort': server.port}));
+  server.listen((request) {
+    request.response.headers.add('Access-Control-Allow-Origin', '*');
+    request.response.headers.add(
+      'Access-Control-Allow-Methods',
+      'POST,GET,DELETE,PUT,OPTIONS',
+    );
+    final path = request.uri.path;
+    final hasBody = path.contains('/body/');
+    request.response.statusCode = 200;
+    request.response.write('>$path<');
+
+    if (path.startsWith('/get/')) {
+      client.get();
+    } else if (path.startsWith('/post/')) {
+      client.post(hasBody: hasBody);
+    } else if (path.startsWith('/put/')) {
+      client.put(hasBody: hasBody);
+    } else if (path.startsWith('/delete/')) {
+      client.delete(hasBody: hasBody);
+    } else if (path.startsWith('/dio/get/')) {
+      client.dioGet();
+    } else if (path.startsWith('/dio/post/')) {
+      client.dioPost(hasBody: hasBody);
+    } else if (path.startsWith('/packageHttp/post/')) {
+      client.packageHttpPost(hasBody: hasBody);
+    } else if (path.startsWith('/packageHttp/postStreamed/')) {
+      client.packageHttpPostStreamed(hasBody: hasBody);
+    }
+    request.response.close();
+  });
+  return server;
+}
+
+// TODO WebSocket
+// TODO package:http - BrowserClient - https://pub.dev/documentation/http/latest/browser_client/BrowserClient-class.html
+// TODO cupertino_http - https://pub.dev/packages/cupertino_http
+// TODO cronet_http - https://pub.dev/packages/cronet_http
+// TDOO fetch_client? https://pub.dev/packages/fetch_client
+
+class _HttpClient {
+  _HttpClient(int testServerPort)
+    : _uri = Uri.http('127.0.0.1:$testServerPort', '/');
+
+  final Uri _uri;
+
+  final io.HttpClient client = io.HttpClient();
+
+  final _dio = Dio();
+
+  void get() async {
+    print('Sending GET...');
+    final request = await client.getUrl(_uri);
+    print('Sent GET: $request');
+    // No body.
+    final response = await request.done;
+    print('Received GET response: $response');
+  }
+
+  void post({bool hasBody = false}) async {
+    print('Sending POST...');
+    final request = await client.postUrl(_uri);
+    print('Sent POST: $request');
+    if (hasBody) {
+      request.write('Request Body');
+    }
+    final response = await request.done;
+    print('Received POST response: $response');
+  }
+
+  void put({bool hasBody = false}) async {
+    print('Sending PUT...');
+    final request = await client.putUrl(_uri);
+    print('Sent PUT: $request');
+    if (hasBody) {
+      request.write('Request Body');
+    }
+    final response = await request.done;
+    print('Received POST response: $response');
+  }
+
+  void delete({bool hasBody = false}) async {
+    print('Sending DELETE...');
+    final request = await client.deleteUrl(_uri);
+    print('Sent DELETE: $request');
+    if (hasBody) {
+      request.write('Request Body');
+    }
+    final response = await request.done;
+    print('Received DELETE response: $response');
+  }
+
+  void packageHttpPost({bool hasBody = false}) async {
+    print('Sending package:http POST...');
+    final response = await http.post(
+      _uri,
+      body: hasBody ? {'name': 'doodle', 'color': 'blue'} : null,
+    );
+    print('Received package:http POST response: $response');
+  }
+
+  void packageHttpPostStreamed({bool hasBody = false}) async {
+    print('Sending streamed package:http POST...');
+    final request =
+        http.StreamedRequest('POST', _uri)
+          ..contentLength = 20
+          ..sink.add([11, 12, 13, 14, 15, 16, 17, 18, 19, 20])
+          ..sink.add([21, 22, 23, 24, 25, 26, 27, 28, 29, 30]);
+    unawaited(request.sink.close());
+    final response = await request.send();
+
+    print('Received package:http POST response: $response');
+  }
+
+  void dioGet() async {
+    print('Sending Dio GET...');
+    // No body.
+    final response = await _dio.getUri(_uri);
+    print('Received Dio GET response: $response');
+  }
+
+  void dioPost({bool hasBody = false}) async {
+    print('Sending Dio POST...');
+    final response = await _dio.postUri(
+      _uri,
+      data: hasBody ? {'a': 'b', 'c': 'd'} : null,
+    );
+    print('Received Dio POST response: $response');
+  }
+}

--- a/packages/devtools_app/test/test_infra/fixtures/networking_app/bin/main.dart
+++ b/packages/devtools_app/test/test_infra/fixtures/networking_app/bin/main.dart
@@ -65,7 +65,7 @@ Future<io.HttpServer> _bindControlServer(io.HttpServer testServer) async {
     } else if (path.startsWith('/packageHttp/post/')) {
       client.packageHttpPost(hasBody: hasBody);
     } else if (path.startsWith('/packageHttp/postStreamed/')) {
-      client.packageHttpPostStreamed(hasBody: hasBody);
+      client.packageHttpPostStreamed();
     }
     request.response.close();
   });
@@ -84,7 +84,7 @@ class _HttpClient {
 
   final Uri _uri;
 
-  final io.HttpClient client = io.HttpClient();
+  final client = io.HttpClient();
 
   final _dio = Dio();
 
@@ -139,7 +139,7 @@ class _HttpClient {
     print('Received package:http POST response: $response');
   }
 
-  void packageHttpPostStreamed({bool hasBody = false}) async {
+  void packageHttpPostStreamed() async {
     print('Sending streamed package:http POST...');
     final request =
         http.StreamedRequest('POST', _uri)

--- a/packages/devtools_app/test/test_infra/fixtures/networking_app/bin/main.dart
+++ b/packages/devtools_app/test/test_infra/fixtures/networking_app/bin/main.dart
@@ -40,15 +40,14 @@ Future<io.HttpServer> _bindControlServer(io.HttpServer testServer) async {
   final server = await io.HttpServer.bind(io.InternetAddress.loopbackIPv4, 0);
   print(json.encode({'controlPort': server.port}));
   server.listen((request) {
-    request.response.headers.add('Access-Control-Allow-Origin', '*');
-    request.response.headers.add(
-      'Access-Control-Allow-Methods',
-      'POST,GET,DELETE,PUT,OPTIONS',
-    );
+    request.response.headers
+      ..add('Access-Control-Allow-Origin', '*')
+      ..add('Access-Control-Allow-Methods', 'POST,GET,DELETE,PUT,OPTIONS');
     final path = request.uri.path;
     final hasBody = path.contains('/body/');
-    request.response.statusCode = 200;
-    request.response.write('>$path<');
+    request.response
+      ..statusCode = 200
+      ..write('received request at: "$path"');
 
     if (path.startsWith('/get/')) {
       client.get();

--- a/packages/devtools_app/test/test_infra/fixtures/networking_app/bin/main.dart
+++ b/packages/devtools_app/test/test_infra/fixtures/networking_app/bin/main.dart
@@ -65,6 +65,9 @@ Future<io.HttpServer> _bindControlServer(io.HttpServer testServer) async {
       client.packageHttpPost(hasBody: hasBody);
     } else if (path.startsWith('/packageHttp/postStreamed/')) {
       client.packageHttpPostStreamed();
+    } else if (path.startsWith('/exit/')) {
+      client.close();
+      io.exit(0);
     }
     request.response.close();
   });
@@ -83,13 +86,18 @@ class _HttpClient {
 
   final Uri _uri;
 
-  final client = io.HttpClient();
+  final _client = io.HttpClient();
 
   final _dio = Dio();
 
+  void close() {
+    _client.close(force: true);
+    _dio.close(force: true);
+  }
+
   void get() async {
     print('Sending GET...');
-    final request = await client.getUrl(_uri);
+    final request = await _client.getUrl(_uri);
     print('Sent GET: $request');
     // No body.
     final response = await request.done;
@@ -98,7 +106,7 @@ class _HttpClient {
 
   void post({bool hasBody = false}) async {
     print('Sending POST...');
-    final request = await client.postUrl(_uri);
+    final request = await _client.postUrl(_uri);
     print('Sent POST: $request');
     if (hasBody) {
       request.write('Request Body');
@@ -109,7 +117,7 @@ class _HttpClient {
 
   void put({bool hasBody = false}) async {
     print('Sending PUT...');
-    final request = await client.putUrl(_uri);
+    final request = await _client.putUrl(_uri);
     print('Sent PUT: $request');
     if (hasBody) {
       request.write('Request Body');
@@ -120,7 +128,7 @@ class _HttpClient {
 
   void delete({bool hasBody = false}) async {
     print('Sending DELETE...');
-    final request = await client.deleteUrl(_uri);
+    final request = await _client.deleteUrl(_uri);
     print('Sent DELETE: $request');
     if (hasBody) {
       request.write('Request Body');

--- a/packages/devtools_app/test/test_infra/fixtures/networking_app/pubspec.yaml
+++ b/packages/devtools_app/test/test_infra/fixtures/networking_app/pubspec.yaml
@@ -1,0 +1,16 @@
+name: networking_app
+description: "A Dart project with networking"
+publish_to: none
+version: 0.0.1
+
+environment:
+  sdk: ^3.8.0-70.0.dev
+
+dependencies:
+  # I'd love to use cupertino_http 2.0.2, but it requires Xcode to change the
+  # Deployment Target to OS X 10.15, which I'm unable to do.
+  #cupertino_http: ^1.5.1
+  #cupertino_icons: ^1.0.8
+  dio: ^5.8.0
+  http: ^1.3.0
+

--- a/packages/devtools_test/lib/src/integration_test/integration_test_utils.dart
+++ b/packages/devtools_test/lib/src/integration_test/integration_test_utils.dart
@@ -118,25 +118,30 @@ Future<void> disconnectFromTestApp(WidgetTester tester) async {
 }
 
 class TestApp {
-  TestApp._({required this.vmServiceUri});
+  TestApp._({required this.vmServiceUri, required this.controlPort});
 
-  factory TestApp.fromJson(Map<String, Object> json) {
+  factory TestApp._fromJson(Map<String, Object> json) {
     final serviceUri = json[serviceUriKey] as String?;
     if (serviceUri == null) {
       throw Exception('Cannot create a TestApp with a null service uri.');
     }
-    return TestApp._(vmServiceUri: serviceUri);
+    final controlPort = json[controlPortKey] as int?;
+    return TestApp._(vmServiceUri: serviceUri, controlPort: controlPort);
   }
 
   factory TestApp.fromEnvironment() {
     const testArgs = String.fromEnvironment('test_args');
     final argsMap = (jsonDecode(testArgs) as Map).cast<String, Object>();
-    return TestApp.fromJson(argsMap);
+    return TestApp._fromJson(argsMap);
   }
 
   static const serviceUriKey = 'service_uri';
 
+  static const controlPortKey = 'control_port';
+
   final String vmServiceUri;
+
+  final int? controlPort;
 }
 
 Future<void> verifyScreenshot(


### PR DESCRIPTION
There's a lot to this change!

I wanted precise control over when the "test app" makes requests, and what kind, etc. I've added a capability for a Dart test app to print out what port it's "control server" is listening to, very similar to how it prints out the URL for DevTools to connect to.

The "control server" is a basic HTTP server, that can be controlled with very simple requests. In this case, when the server sees a request to '/get/', it calls a dart:io HttpClient to send an HTTP GET request. A request to '/post/' directs the HttpClient to send an HTTP POST request, etc.

For the network screen tests to see complete requests, there is a second HTTP server that responds to the test requests.

So some changes are made to TestDartCliApp to support the "control port". This int is then passed to the integration test in the 'test args' (see the changes to `integration_test/test_infra/run/run_test.dart`).

OK, then the test itself: This test is simple for now. The following types of requests are validated:

* dart:io HttpClient GET
* dart:io HttpClient POST
* dart:io HttpClient PUT
* dart:io HttpClient DELETE
* Dio GET
* Dio POST

There are some TODOs for other requests we want to validate.

Work towards https://github.com/flutter/devtools/issues/7554.