### PR TITLE
Simplify the TestFileArgs constructors

### DIFF
--- a/packages/devtools_app/integration_test/test_infra/run/_in_file_args.dart
+++ b/packages/devtools_app/integration_test/test_infra/run/_in_file_args.dart
@@ -7,7 +7,7 @@ import 'dart:io';
 
 import '_test_app_driver.dart';
 
-const _defaultFlutterAppPath = 'test/test_infra/fixtures/flutter_app';
+const defaultFlutterAppPath = 'test/test_infra/fixtures/flutter_app';
 const _defaultDartCliAppPath = 'test/test_infra/fixtures/empty_app.dart';
 
 /// Test arguments, defined inside the test file as a comment.

--- a/packages/devtools_app/integration_test/test_infra/run/_in_file_args.dart
+++ b/packages/devtools_app/integration_test/test_infra/run/_in_file_args.dart
@@ -8,7 +8,7 @@ import 'dart:io';
 import '_test_app_driver.dart';
 
 const defaultFlutterAppPath = 'test/test_infra/fixtures/flutter_app';
-const _defaultDartCliAppPath = 'test/test_infra/fixtures/empty_app.dart';
+const defaultDartCliAppPath = 'test/test_infra/fixtures/empty_app.dart';
 
 /// Test arguments, defined inside the test file as a comment.
 class TestFileArgs {
@@ -31,7 +31,7 @@ class TestFileArgs {
     final appPath =
         args[_TestFileArgItems.appPath] ??
         (testAppDevice == TestAppDevice.cli
-            ? _defaultDartCliAppPath
+            ? defaultDartCliAppPath
             : defaultFlutterAppPath);
     return TestFileArgs._parse(args, appPath: appPath);
   }

--- a/packages/devtools_app/integration_test/test_infra/run/_in_file_args.dart
+++ b/packages/devtools_app/integration_test/test_infra/run/_in_file_args.dart
@@ -32,7 +32,7 @@ class TestFileArgs {
         args[_TestFileArgItems.appPath] ??
         (testAppDevice == TestAppDevice.cli
             ? _defaultDartCliAppPath
-            : _defaultFlutterAppPath);
+            : defaultFlutterAppPath);
     return TestFileArgs._parse(args, appPath: appPath);
   }
 

--- a/packages/devtools_app/test/integration_test_infra/in_file_args_test.dart
+++ b/packages/devtools_app/test/integration_test_infra/in_file_args_test.dart
@@ -25,7 +25,7 @@ final tests = [
     input: '',
     testAppDevice: TestAppDevice.flutterTester,
     expectedExperimentsOn: _defaultArgs.experimentsOn,
-    expectedAppPath: _testAppPath,
+    expectedAppPath: defaultFlutterAppPath,
   ),
   _InFileTestArgsTest(
     name: 'empty',

--- a/packages/devtools_app/test/integration_test_infra/in_file_args_test.dart
+++ b/packages/devtools_app/test/integration_test_infra/in_file_args_test.dart
@@ -32,7 +32,7 @@ final tests = [
     input: '',
     testAppDevice: TestAppDevice.cli,
     expectedExperimentsOn: _defaultArgsForCliDevice.experimentsOn,
-    expectedAppPath: _testAppPath,
+    expectedAppPath: defaultDartCliAppPath,
   ),
   _InFileTestArgsTest(
     name: 'non-empty',

--- a/packages/devtools_app/test/integration_test_infra/in_file_args_test.dart
+++ b/packages/devtools_app/test/integration_test_infra/in_file_args_test.dart
@@ -9,13 +9,13 @@ import '../../integration_test/test_infra/run/_test_app_driver.dart';
 
 const _testAppPath = 'test/test_infra/fixtures/memory_app';
 
-final _defaultArgs = TestFileArgs.parse(
-  {},
+final _defaultArgs = TestFileArgs.fromFileContent(
+  '',
   testAppDevice: TestAppDevice.flutterTester,
 );
 
-final _defaultArgsForCliDevice = TestFileArgs.parse(
-  {},
+final _defaultArgsForCliDevice = TestFileArgs.fromFileContent(
+  '',
   testAppDevice: TestAppDevice.cli,
 );
 
@@ -24,19 +24,15 @@ final tests = [
     name: 'empty',
     input: '',
     testAppDevice: TestAppDevice.flutterTester,
-    output: TestFileArgs.parse({
-      TestFileArgItems.experimentsOn: _defaultArgs.experimentsOn,
-      TestFileArgItems.appPath: _defaultArgs.appPath,
-    }, testAppDevice: TestAppDevice.flutterTester),
+    expectedExperimentsOn: _defaultArgs.experimentsOn,
+    expectedAppPath: _testAppPath,
   ),
   _InFileTestArgsTest(
     name: 'empty',
     input: '',
     testAppDevice: TestAppDevice.cli,
-    output: TestFileArgs.parse({
-      TestFileArgItems.experimentsOn: _defaultArgsForCliDevice.experimentsOn,
-      TestFileArgItems.appPath: _defaultArgsForCliDevice.appPath,
-    }, testAppDevice: TestAppDevice.cli),
+    expectedExperimentsOn: _defaultArgsForCliDevice.experimentsOn,
+    expectedAppPath: _testAppPath,
   ),
   _InFileTestArgsTest(
     name: 'non-empty',
@@ -53,10 +49,8 @@ final tests = [
 import 'dart:ui' as ui;
 ''',
     testAppDevice: TestAppDevice.flutterTester,
-    output: TestFileArgs.parse({
-      TestFileArgItems.experimentsOn: true,
-      TestFileArgItems.appPath: _testAppPath,
-    }, testAppDevice: TestAppDevice.flutterTester),
+    expectedExperimentsOn: true,
+    expectedAppPath: _testAppPath,
   ),
 ];
 
@@ -67,8 +61,8 @@ void main() {
         t.input,
         testAppDevice: t.testAppDevice,
       );
-      expect(args.experimentsOn, t.output.experimentsOn);
-      expect(args.appPath, t.output.appPath);
+      expect(args.experimentsOn, t.expectedExperimentsOn);
+      expect(args.appPath, t.expectedAppPath);
     });
   }
 }
@@ -78,11 +72,13 @@ class _InFileTestArgsTest {
     required this.name,
     required this.input,
     required this.testAppDevice,
-    required this.output,
+    required this.expectedExperimentsOn,
+    required this.expectedAppPath,
   });
 
   final String name;
   final String input;
   final TestAppDevice testAppDevice;
-  final TestFileArgs output;
+  final bool expectedExperimentsOn;
+  final String expectedAppPath;
 }


### PR DESCRIPTION
I noticed that some code here and there could be simplified, and it was sort of just like pulling a thread from a wool sweater:

* `_parseFileContent` does not need to check for empty group values, as those can be guaranteed by the regular expression. This avoids using MapEntries, and simplifies the function.
* That function and the regular expression are only used by one of the constructors, so they can be static functions on the class.
* In `TestFileArgs.parse`, the `appPath` is set over 5 lines of initializer logic. But really, this constructor is only ever called from the factory constructor (and tests), so the factory constructor can just do that logic itself.
* Then the `TestFileArgs.parse` generative constructor can be made private (after migrating the tests to use `TestFileArgs.fromFileContent`; these tests were not _testing_ `TestFileArgs.parse`, they were using it as a utility).
* The enum `TestFileArgItems` can also be made private.
* Add doc comments.