### PR TITLE
[Property Editor] Debounce calls to the Analysis Server for `editableArguments`

### DIFF
--- a/packages/devtools_app/lib/src/framework/observer/memory_observer.dart
+++ b/packages/devtools_app/lib/src/framework/observer/memory_observer.dart
@@ -38,12 +38,12 @@ class MemoryObserver extends DisposableController {
 
   static const _memoryPressureLimitGb = 3.0;
 
-  DebounceTimer? _timer;
+  PeriodicDebouncer? _timer;
 
   @override
   void init() {
     super.init();
-    _timer = DebounceTimer.periodic(_pollingDuration, _pollForMemoryUsage);
+    _timer = PeriodicDebouncer.run(_pollingDuration, _pollForMemoryUsage);
   }
 
   @override

--- a/packages/devtools_app/lib/src/screens/memory/panes/chart/controller/chart_connection.dart
+++ b/packages/devtools_app/lib/src/screens/memory/panes/chart/controller/chart_connection.dart
@@ -36,7 +36,7 @@ class ChartVmConnection extends DisposableController
 
   bool initialized = false;
 
-  DebounceTimer? _polling;
+  PeriodicDebouncer? _polling;
 
   late final bool isDeviceAndroid;
 
@@ -79,7 +79,7 @@ class ChartVmConnection extends DisposableController
       ),
     );
 
-    _polling = DebounceTimer.periodic(chartUpdateDelay, ({
+    _polling = PeriodicDebouncer.run(chartUpdateDelay, ({
       DebounceCancelledCallback? cancelledCallback,
     }) async {
       if (!_isConnected) {

--- a/packages/devtools_app/lib/src/screens/network/network_controller.dart
+++ b/packages/devtools_app/lib/src/screens/network/network_controller.dart
@@ -160,7 +160,7 @@ class NetworkController extends DevToolsScreenController
   /// This timestamp is on the monotonic clock used by the timeline.
   int lastSocketDataRefreshMicros = 0;
 
-  DebounceTimer? _pollingTimer;
+  PeriodicDebouncer? _pollingTimer;
 
   @visibleForTesting
   bool get isPolling => _pollingTimer != null;
@@ -272,7 +272,7 @@ class NetworkController extends DevToolsScreenController
 
   void _updatePollingState(bool recording) {
     if (recording) {
-      _pollingTimer ??= DebounceTimer.periodic(
+      _pollingTimer ??= PeriodicDebouncer.run(
         // TODO(kenz): look into improving performance by caching more data.
         // Polling less frequently helps performance.
         _pollingDuration,

--- a/packages/devtools_app/lib/src/shared/utils/utils.dart
+++ b/packages/devtools_app/lib/src/shared/utils/utils.dart
@@ -194,8 +194,9 @@ class Debouncer {
 
   /// Invokes the [callback] once after the specified [duration] has elapsed.
   ///
-  /// If multiple invokations are called while the timer is running, the
-  /// callback will be further delayed.
+  /// If multiple invokations are called while the timer is running, only the
+  /// last one will be called once no more invokations happen within the given
+  /// [duration].
   void run(void Function() callback) {
     _activeTimer?.cancel();
     _activeTimer = Timer(duration, callback);

--- a/packages/devtools_app/lib/src/shared/utils/utils.dart
+++ b/packages/devtools_app/lib/src/shared/utils/utils.dart
@@ -185,17 +185,39 @@ extension IsKeyType on KeyEvent {
   bool get isKeyDownOrRepeat => this is KeyDownEvent || this is KeyRepeatEvent;
 }
 
+/// A helper class for [Timer] functionality, where the callbacks are debounced.
+class Debouncer {
+  Debouncer({required this.duration});
+
+  final Duration duration;
+  Timer? _activeTimer;
+
+  /// Invokes the [callback] once after the specified [duration] has elapsed.
+  ///
+  /// If multiple invokations are called while the timer is running, the
+  /// callback will be further delayed.
+  void run(void Function() callback) {
+    _activeTimer?.cancel();
+    _activeTimer = Timer(duration, callback);
+  }
+
+  void dispose() {
+    _activeTimer?.cancel();
+    _activeTimer = null;
+  }
+}
+
 typedef DebounceCancelledCallback = bool Function();
 
-/// A helper class for [Timer] functionality, where the callbacks are debounced.
-class DebounceTimer {
-  /// A periodic timer that ensures [callback] is only called at most once
-  /// per [duration].
+/// A periodic debouncer that calls the given [callback] at most once per
+/// [duration].
+class PeriodicDebouncer {
+  /// Start running the periodic debouncer.
   ///
   /// [callback] is triggered once immediately, and then every [duration] the
   /// timer checks to see if the previous [callback] call has finished running.
   /// If it has finished, then then next call to [callback] will begin.
-  DebounceTimer.periodic(
+  PeriodicDebouncer.run(
     Duration duration,
     Future<void> Function({DebounceCancelledCallback? cancelledCallback})
     callback,

--- a/packages/devtools_app/lib/src/shared/utils/utils.dart
+++ b/packages/devtools_app/lib/src/shared/utils/utils.dart
@@ -186,7 +186,7 @@ extension IsKeyType on KeyEvent {
 }
 
 /// A helper class for [Timer] functionality, where the callbacks are debounced.
-class Debouncer {
+class Debouncer extends Disposable {
   Debouncer({required this.duration});
 
   final Duration duration;
@@ -198,13 +198,16 @@ class Debouncer {
   /// last one will be called once no more invokations happen within the given
   /// [duration].
   void run(void Function() callback) {
+    if (disposed) return;
     _activeTimer?.cancel();
     _activeTimer = Timer(duration, callback);
   }
 
+  @override
   void dispose() {
     _activeTimer?.cancel();
     _activeTimer = null;
+    super.dispose();
   }
 }
 

--- a/packages/devtools_app/lib/src/standalone_ui/ide_shared/property_editor/property_editor_controller.dart
+++ b/packages/devtools_app/lib/src/standalone_ui/ide_shared/property_editor/property_editor_controller.dart
@@ -75,6 +75,12 @@ class PropertyEditorController extends DisposableController
     );
   }
 
+  @override
+  void dispose() {
+    _editableArgsDebouncer.dispose();
+    super.dispose();
+  }
+
   Future<EditArgumentResponse?> editArgument<T>({
     required String name,
     required T value,

--- a/packages/devtools_app/lib/src/standalone_ui/ide_shared/property_editor/property_editor_controller.dart
+++ b/packages/devtools_app/lib/src/standalone_ui/ide_shared/property_editor/property_editor_controller.dart
@@ -39,12 +39,12 @@ class PropertyEditorController extends DisposableController
 
   late final Debouncer _editableArgsDebouncer;
 
+  static const _editableArgsDebounceDuration = Duration(milliseconds: 600);
+
   @override
   void init() {
     super.init();
-    _editableArgsDebouncer = Debouncer(
-      duration: const Duration(milliseconds: 600),
-    );
+    _editableArgsDebouncer = Debouncer(duration: _editableArgsDebounceDuration);
 
     autoDisposeStreamSubscription(
       editorClient.activeLocationChangedStream.listen((event) async {
@@ -57,7 +57,7 @@ class PropertyEditorController extends DisposableController
         // Don't do anything if the event corresponds to the current position
         // and document version.
         //
-        // Note: This is ony checked if the document version is not null. For
+        // Note: This is only checked if the document version is not null. For
         // IntelliJ, the document verison is always null, so identical events
         // indicating a valid change are possible.
         if (textDocument.version != null &&

--- a/packages/devtools_app/lib/src/standalone_ui/ide_shared/property_editor/property_editor_controller.dart
+++ b/packages/devtools_app/lib/src/standalone_ui/ide_shared/property_editor/property_editor_controller.dart
@@ -9,6 +9,7 @@ import '../../../shared/analytics/analytics.dart' as ga;
 import '../../../shared/analytics/constants.dart' as gac;
 import '../../../shared/editor/api_classes.dart';
 import '../../../shared/editor/editor_client.dart';
+import '../../../shared/utils/utils.dart';
 
 typedef EditableWidgetData =
     ({List<EditableArgument> args, String? name, String? documentation});
@@ -22,7 +23,7 @@ typedef EditArgumentFunction =
 class PropertyEditorController extends DisposableController
     with AutoDisposeControllerMixin {
   PropertyEditorController(this.editorClient) {
-    _init();
+    init();
   }
 
   final EditorClient editorClient;
@@ -36,7 +37,15 @@ class PropertyEditorController extends DisposableController
       _editableWidgetData;
   final _editableWidgetData = ValueNotifier<EditableWidgetData?>(null);
 
-  void _init() {
+  late final Debouncer _editableArgsDebouncer;
+
+  @override
+  void init() {
+    super.init();
+    _editableArgsDebouncer = Debouncer(
+      duration: const Duration(milliseconds: 600),
+    );
+
     autoDisposeStreamSubscription(
       editorClient.activeLocationChangedStream.listen((event) async {
         final textDocument = event.textDocument;
@@ -45,29 +54,22 @@ class PropertyEditorController extends DisposableController
         if (textDocument == null) {
           return;
         }
-        // Don't do anything if the event corresponds to the current position.
-        if (textDocument == _currentDocument &&
+        // Don't do anything if the event corresponds to the current position
+        // and document version.
+        //
+        // Note: This is ony checked if the document version is not null. For
+        // IntelliJ, the document verison is always null, so identical events
+        // indicating a valid change are possible.
+        if (textDocument.version != null &&
+            textDocument == _currentDocument &&
             cursorPosition == _currentCursorPosition) {
           return;
         }
-        _currentDocument = textDocument;
-        _currentCursorPosition = cursorPosition;
-        // Get the editable arguments for the current position.
-        final result = await editorClient.getEditableArguments(
-          textDocument: textDocument,
-          position: cursorPosition,
-        );
-        final args = result?.args ?? <EditableArgument>[];
-        final name = result?.name;
-        _editableWidgetData.value = (
-          args: args,
-          name: name,
-          documentation: result?.documentation,
-        );
-        // Register impression.
-        ga.impression(
-          gaId,
-          gac.PropertyEditorSidebar.widgetPropertiesUpdate(name: name),
+        _editableArgsDebouncer.run(
+          () => _updateWithEditableArgs(
+            textDocument: textDocument,
+            cursorPosition: cursorPosition,
+          ),
         );
       }),
     );
@@ -85,6 +87,31 @@ class PropertyEditorController extends DisposableController
       position: position,
       name: name,
       value: value,
+    );
+  }
+
+  Future<void> _updateWithEditableArgs({
+    required TextDocument textDocument,
+    required CursorPosition cursorPosition,
+  }) async {
+    _currentDocument = textDocument;
+    _currentCursorPosition = cursorPosition;
+    // Get the editable arguments for the current position.
+    final result = await editorClient.getEditableArguments(
+      textDocument: textDocument,
+      position: cursorPosition,
+    );
+    final args = result?.args ?? <EditableArgument>[];
+    final name = result?.name;
+    _editableWidgetData.value = (
+      args: args,
+      name: name,
+      documentation: result?.documentation,
+    );
+    // Register impression.
+    ga.impression(
+      gaId,
+      gac.PropertyEditorSidebar.widgetPropertiesUpdate(name: name),
     );
   }
 

--- a/packages/devtools_app/test/shared/utils/utils_test.dart
+++ b/packages/devtools_app/test/shared/utils/utils_test.dart
@@ -187,6 +187,9 @@ void main() {
       debouncer.dispose();
       await Future.delayed(const Duration(milliseconds: 150));
       expect(callbackCount, 0);
+      debouncer.run(() => callbackCount++);
+      await Future.delayed(const Duration(milliseconds: 150));
+      expect(callbackCount, 0);
     });
   });
 


### PR DESCRIPTION
Fixes https://github.com/flutter/devtools/issues/9004

Because IntelliJ does not support document versions, the `ActiveLocationChanged` event will always include a `null` text document version identifier. 

Because of this, this PR:
* Only ignores identical `ActiveLocationChanged` events if the text document version is not `null`
* Adds debouncing to limit the number of requests sent to the Analysis Server

Currently VS Code debounces the `ActiveLocationChanged` events with a duration of 200 ms. In DevTools, I've added further debouncing for the requests to the Analysis Server with a duration of 600 ms.

With this change, when I type a line of code with a length of 42 characters in VS Code, we're sending 8 requests to the Analysis Server. Before, with just the VS Code debouncing, we were sending 12. _(Note: We can further increase the debounce duration if necessary, FYI @bwilkerson)_

Finally, I renamed the existing `DebounceTimer` class to `PeriodicDebouncer` to make clear the difference between that debouncer and the one I've added.




