### PR TITLE
Don't connect the SSE API when running embedded

### DIFF
--- a/packages/devtools_app/lib/src/shared/config_specific/framework_initialize/_framework_initialize_web.dart
+++ b/packages/devtools_app/lib/src/shared/config_specific/framework_initialize/_framework_initialize_web.dart
@@ -28,12 +28,15 @@ Future<String> initializePlatform() async {
       );
 
   // TODO(kenz): this server connection initialized listeners that are never
-  // disposed, so this is likely leaking resources.
+  //  disposed, so this is likely leaking resources.
   // Here, we try and initialize the connection between the DevTools web app and
   // its local server. DevTools can be launched without the server however, so
   // establishing this connection is a best-effort.
-  // TODO(kenz): investigate it we can remove the DevToolsServerConnection
-  // code in general. We do not appear to be using the SSE connection.
+  // TODO(kenz): investigate if we can remove the DevToolsServerConnection
+  //  code in general - it is currently only used for non-embedded pages to
+  //  support some functionality like having VS Code reuse existing browser tabs
+  //  and showing notifications if you try to launch when you already have one
+  //  open.
   final connection = await DevToolsServerConnection.connect();
   if (connection != null) {
     setGlobal(Storage, server.ServerConnectionStorage());

--- a/packages/devtools_app/lib/src/shared/server/server_api_client.dart
+++ b/packages/devtools_app/lib/src/shared/server/server_api_client.dart
@@ -5,6 +5,7 @@
 import 'dart:async';
 import 'dart:convert';
 
+import 'package:devtools_app_shared/ui.dart' show isEmbedded;
 import 'package:devtools_shared/devtools_shared.dart';
 import 'package:flutter/foundation.dart';
 import 'package:http/http.dart' as http;
@@ -47,6 +48,14 @@ class DevToolsServerConnection {
           : baseUri.resolve('api/');
 
   static Future<DevToolsServerConnection?> connect() async {
+    // Don't connect SSE when running embedded because the API does not provide
+    // anything that is used when embedded but it ties up one of the limited
+    // number of connections to the server.
+    // https://github.com/flutter/devtools/issues/8298
+    if (isEmbedded()) {
+      return null;
+    }
+
     final serverUri = Uri.parse(devToolsServerUriAsString);
     final apiUri = apiUriFor(serverUri);
     final pingUri = apiUri.resolve('ping');


### PR DESCRIPTION
This prevents the SSE connection from being connected when running embedded. DevTools was already capable of running without this connection (since it discards exceptions connecting, and the server may be unavailable in some contexts).

It doesn't fix any issues, but it increases the number of embedded DevTools pages that can be shown in VS Code before they stop working (before this fix, I couldn't open every page, but with this change I can open them all and should have a few connections to spare).

See https://github.com/flutter/devtools/issues/8298
See https://github.com/flutter/devtools/issues/8763

I've verified the connection is still being made when running in the browser, but not when embedded.

@kenzieschmoll I don't know if we have a good way to test something like this (I think there were some with the server that moved to the SDK).