### PR TITLE
Fix deep links page displaying incorrect Windows path formats + a crash if no iOS config

### DIFF
--- a/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
+++ b/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
@@ -77,7 +77,10 @@ TODO: Remove this section if there are not any general updates.
 
 ## Deep links tool updates
 
-TODO: Remove this section if there are not any general updates.
+* Fixed an issue with Windows file paths showing incorrectly in the Deep Links
+page [#9027](https://github.com/flutter/devtools/pull/9027).
+* Fixed an issue with the Deep Links page crashing when no iOS configuration is
+present [#9027](https://github.com/flutter/devtools/pull/9027).
 
 ## VS Code Sidebar updates
 

--- a/packages/devtools_shared/lib/src/deeplink/xcode_build_options.dart
+++ b/packages/devtools_shared/lib/src/deeplink/xcode_build_options.dart
@@ -18,8 +18,9 @@ extension type const XcodeBuildOptions._(Map<String, Object?> _json) {
 
   /// The available configurations for iOS build of this Flutter project.
   List<String> get configurations =>
-      (_json[_kConfigurationsKey] as List).cast<String>();
+      (_json[_kConfigurationsKey] as List?)?.cast<String>() ?? [];
 
   /// The available targets for iOS build of this Flutter project.
-  List<String> get targets => (_json[_kTargetsKey] as List).cast<String>();
+  List<String> get targets =>
+      (_json[_kTargetsKey] as List?)?.cast<String>() ?? [];
 }


### PR DESCRIPTION
This fixes some of the issues noted in https://github.com/flutter/devtools/issues/7747, but not all of them (see my comment at https://github.com/flutter/devtools/issues/7747#issuecomment-2721733757).
