### PR TITLE
[PropertyEditor] Do not send requests to `getEditableArguments` for non-Dart files

### DIFF
--- a/packages/devtools_app/lib/src/standalone_ui/ide_shared/property_editor/property_editor_controller.dart
+++ b/packages/devtools_app/lib/src/standalone_ui/ide_shared/property_editor/property_editor_controller.dart
@@ -12,7 +12,12 @@ import '../../../shared/editor/editor_client.dart';
 import '../../../shared/utils/utils.dart';
 
 typedef EditableWidgetData =
-    ({List<EditableArgument> args, String? name, String? documentation});
+    ({
+      List<EditableArgument> args,
+      String? name,
+      String? documentation,
+      String? fileUri,
+    });
 
 typedef EditArgumentFunction =
     Future<EditArgumentResponse?> Function<T>({
@@ -65,6 +70,15 @@ class PropertyEditorController extends DisposableController
             cursorPosition == _currentCursorPosition) {
           return;
         }
+        if (!textDocument.uriAsString.endsWith('.dart')) {
+          _editableWidgetData.value = (
+            args: [],
+            name: null,
+            documentation: null,
+            fileUri: textDocument.uriAsString,
+          );
+          return;
+        }
         _editableArgsDebouncer.run(
           () => _updateWithEditableArgs(
             textDocument: textDocument,
@@ -113,6 +127,7 @@ class PropertyEditorController extends DisposableController
       args: args,
       name: name,
       documentation: result?.documentation,
+      fileUri: _currentDocument?.uriAsString,
     );
     // Register impression.
     ga.impression(
@@ -132,6 +147,7 @@ class PropertyEditorController extends DisposableController
         args: editableArgsResult.args,
         name: editableArgsResult.name,
         documentation: editableArgsResult.documentation,
+        fileUri: document?.uriAsString,
       );
     }
     if (document != null) {

--- a/packages/devtools_app/lib/src/standalone_ui/ide_shared/property_editor/property_editor_view.dart
+++ b/packages/devtools_app/lib/src/standalone_ui/ide_shared/property_editor/property_editor_view.dart
@@ -42,7 +42,13 @@ class PropertyEditorView extends StatelessWidget {
           );
         }
 
-        final (:args, :name, :documentation) = editableWidgetData;
+        final (:args, :name, :documentation, :fileUri) = editableWidgetData;
+        if (fileUri == null || !fileUri.endsWith('.dart')) {
+          return const CenteredMessage(
+            message: 'No Dart code found at the current cursor location.',
+          );
+        }
+
         return Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [

--- a/packages/devtools_app/lib/src/standalone_ui/ide_shared/property_editor/property_editor_view.dart
+++ b/packages/devtools_app/lib/src/standalone_ui/ide_shared/property_editor/property_editor_view.dart
@@ -52,7 +52,7 @@ class PropertyEditorView extends StatelessWidget {
 
         final (:properties, :name, :documentation, :fileUri) =
             editableWidgetData;
-        if (fileUri == null || !fileUri.endsWith('.dart')) {
+        if (fileUri != null && !fileUri.endsWith('.dart')) {
           return const CenteredMessage(
             message: 'No Dart code found at the current cursor location.',
           );

--- a/packages/devtools_app/test/standalone_ui/ide_shared/property_editor/property_editor_test.dart
+++ b/packages/devtools_app/test/standalone_ui/ide_shared/property_editor/property_editor_test.dart
@@ -99,6 +99,7 @@ void main() {
           ),
         ).thenAnswer((realInvocation) {
           getEditableArgsCalled?.complete();
+          getEditableArgsCalled = Completer<void>();
           return Future.value(result);
         });
       }


### PR DESCRIPTION
Fixes https://github.com/flutter/devtools/issues/9048