### PR TITLE
Fix remaining license headers

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,6 +1,6 @@
-# Copyright 2020 The Chromium Authors. All rights reserved.
+# Copyright 2020 The Flutter Authors
 # Use of this source code is governed by a BSD-style license that can be
-# found in the LICENSE file.
+# found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
 
 name: devtools
 

--- a/.github/workflows/flutter-prep.yaml
+++ b/.github/workflows/flutter-prep.yaml
@@ -1,6 +1,6 @@
-# Copyright 2023 The Chromium Authors. All rights reserved.
+# Copyright 2023 The Flutter Authors
 # Use of this source code is governed by a BSD-style license that can be
-# found in the LICENSE file.
+# found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
 
 name: Flutter SDK prep
 

--- a/packages/devtools_app/benchmark/scripts/utils.dart
+++ b/packages/devtools_app/benchmark/scripts/utils.dart
@@ -1,6 +1,6 @@
-// Copyright 2023 The Chromium Authors. All rights reserved.
+// Copyright 2023 The Flutter Authors
 // Use of this source code is governed by a BSD-style license that can be
-// found in the LICENSE file.
+// found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
 
 import 'dart:io';
 

--- a/packages/devtools_app/lib/src/screens/network/constants.dart
+++ b/packages/devtools_app/lib/src/screens/network/constants.dart
@@ -1,6 +1,6 @@
-// Copyright 2024 The Chromium Authors. All rights reserved.
+// Copyright 2024 The Flutter Authors
 // Use of this source code is governed by a BSD-style license that can be
-// found in the LICENSE file.
+// found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
 
 enum NetworkEventKeys {
   log,

--- a/packages/devtools_app/lib/src/screens/network/har_builder.dart
+++ b/packages/devtools_app/lib/src/screens/network/har_builder.dart
@@ -1,6 +1,6 @@
-// Copyright 2024 The Chromium Authors. All rights reserved.
+// Copyright 2024 The Flutter Authors
 // Use of this source code is governed by a BSD-style license that can be
-// found in the LICENSE file.
+// found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
 
 import '../../shared/http/http_request_data.dart';
 import '../../shared/utils/utils.dart';

--- a/packages/devtools_app/lib/src/screens/network/har_data_entry.dart
+++ b/packages/devtools_app/lib/src/screens/network/har_data_entry.dart
@@ -1,6 +1,6 @@
-// Copyright 2024 The Chromium Authors. All rights reserved.
+// Copyright 2024 The Flutter Authors
 // Use of this source code is governed by a BSD-style license that can be
-// found in the LICENSE file.
+// found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
 
 import 'dart:convert';
 

--- a/packages/devtools_app/lib/src/screens/network/har_network_data.dart
+++ b/packages/devtools_app/lib/src/screens/network/har_network_data.dart
@@ -1,6 +1,6 @@
-// Copyright 2024 The Chromium Authors. All rights reserved.
+// Copyright 2024 The Flutter Authors
 // Use of this source code is governed by a BSD-style license that can be
-// found in the LICENSE file.
+// found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
 
 import 'package:devtools_shared/devtools_shared.dart';
 import '../../shared/http/http_request_data.dart';

--- a/packages/devtools_app/lib/src/screens/network/network_controller.dart
+++ b/packages/devtools_app/lib/src/screens/network/network_controller.dart
@@ -1,6 +1,6 @@
-// Copyright 2019 The Chromium Authors. All rights reserved.
+// Copyright 2019 The Flutter Authors
 // Use of this source code is governed by a BSD-style license that can be
-// found in the LICENSE file.
+// found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
 
 import 'dart:async';
 import 'dart:convert';

--- a/packages/devtools_app/lib/src/screens/network/network_model.dart
+++ b/packages/devtools_app/lib/src/screens/network/network_model.dart
@@ -1,6 +1,6 @@
-// Copyright 2019 The Chromium Authors. All rights reserved.
+// Copyright 2019 The Flutter Authors
 // Use of this source code is governed by a BSD-style license that can be
-// found in the LICENSE file.
+// found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
 
 import 'package:devtools_shared/devtools_shared.dart';
 import 'package:flutter/material.dart';

--- a/packages/devtools_app/lib/src/screens/network/network_request_inspector.dart
+++ b/packages/devtools_app/lib/src/screens/network/network_request_inspector.dart
@@ -1,6 +1,6 @@
-// Copyright 2019 The Chromium Authors. All rights reserved.
+// Copyright 2019 The Flutter Authors
 // Use of this source code is governed by a BSD-style license that can be
-// found in the LICENSE file.
+// found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
 
 import 'package:devtools_app_shared/ui.dart';
 import 'package:flutter/material.dart';

--- a/packages/devtools_app/lib/src/screens/network/network_request_inspector_views.dart
+++ b/packages/devtools_app/lib/src/screens/network/network_request_inspector_views.dart
@@ -1,6 +1,6 @@
-// Copyright 2019 The Chromium Authors. All rights reserved.
+// Copyright 2019 The Flutter Authors
 // Use of this source code is governed by a BSD-style license that can be
-// found in the LICENSE file.
+// found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
 
 import 'dart:convert';
 

--- a/packages/devtools_app/lib/src/screens/network/network_screen.dart
+++ b/packages/devtools_app/lib/src/screens/network/network_screen.dart
@@ -1,6 +1,6 @@
-// Copyright 2019 The Chromium Authors. All rights reserved.
+// Copyright 2019 The Flutter Authors
 // Use of this source code is governed by a BSD-style license that can be
-// found in the LICENSE file.
+// found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
 
 import 'dart:async';
 

--- a/packages/devtools_app/lib/src/screens/network/network_service.dart
+++ b/packages/devtools_app/lib/src/screens/network/network_service.dart
@@ -1,6 +1,6 @@
-// Copyright 2019 The Chromium Authors. All rights reserved.
+// Copyright 2019 The Flutter Authors
 // Use of this source code is governed by a BSD-style license that can be
-// found in the LICENSE file.
+// found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
 
 import 'package:vm_service/vm_service.dart';
 

--- a/packages/devtools_app/lib/src/screens/network/offline_network_data.dart
+++ b/packages/devtools_app/lib/src/screens/network/offline_network_data.dart
@@ -1,6 +1,6 @@
-// Copyright 2024 The Chromium Authors. All rights reserved.
+// Copyright 2024 The Flutter Authors
 // Use of this source code is governed by a BSD-style license that can be
-// found in the LICENSE file.
+// found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
 
 import 'package:devtools_shared/devtools_shared.dart';
 

--- a/packages/devtools_app/lib/src/screens/network/utils/http_utils.dart
+++ b/packages/devtools_app/lib/src/screens/network/utils/http_utils.dart
@@ -1,6 +1,6 @@
-// Copyright 2024 The Chromium Authors. All rights reserved.
+// Copyright 2024 The Flutter Authors
 // Use of this source code is governed by a BSD-style license that can be
-// found in the LICENSE file.
+// found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
 
 import 'dart:convert';
 

--- a/packages/devtools_app/lib/src/shared/http/constants.dart
+++ b/packages/devtools_app/lib/src/shared/http/constants.dart
@@ -1,6 +1,6 @@
-// Copyright 2024 The Chromium Authors. All rights reserved.
+// Copyright 2024 The Flutter Authors
 // Use of this source code is governed by a BSD-style license that can be
-// found in the LICENSE file.
+// found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
 
 enum HttpRequestDataKeys {
   connectionInfo,

--- a/packages/devtools_app/test/integration_test_infra/in_file_args_test.dart
+++ b/packages/devtools_app/test/integration_test_infra/in_file_args_test.dart
@@ -31,9 +31,9 @@ void main() {
       const testAppPath = 'test/test_infra/fixtures/memory_app';
 
       final args = TestFileArgs.fromFileContent('''
-// Copyright 2023 The Chromium Authors. All rights reserved.
+// Copyright 2023 The Flutter Authors
 // Use of this source code is governed by a BSD-style license that can be
-// found in the LICENSE file.
+// found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
 
 // Do not delete these arguments. They are parsed by test runner.
 //test-argument:appPath="$testAppPath"

--- a/packages/devtools_app/test/screens/network/har_network_test.dart
+++ b/packages/devtools_app/test/screens/network/har_network_test.dart
@@ -1,6 +1,6 @@
-// Copyright 2024 The Chromium Authors. All rights reserved.
+// Copyright 2024 The Flutter Authors
 // Use of this source code is governed by a BSD-style license that can be
-// found in the LICENSE file.
+// found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
 
 import 'dart:convert';
 import 'dart:io';

--- a/packages/devtools_app/test/screens/network/network_controller_test.dart
+++ b/packages/devtools_app/test/screens/network/network_controller_test.dart
@@ -1,6 +1,6 @@
-// Copyright 2020 The Chromium Authors. All rights reserved.
+// Copyright 2020 The Flutter Authors
 // Use of this source code is governed by a BSD-style license that can be
-// found in the LICENSE file.
+// found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
 
 @TestOn('vm')
 library;

--- a/packages/devtools_app/test/screens/network/network_model_test.dart
+++ b/packages/devtools_app/test/screens/network/network_model_test.dart
@@ -1,6 +1,6 @@
-// Copyright 2020 The Chromium Authors. All rights reserved.
+// Copyright 2020 The Flutter Authors
 // Use of this source code is governed by a BSD-style license that can be
-// found in the LICENSE file.
+// found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
 
 import 'dart:convert';
 

--- a/packages/devtools_app/test/screens/network/network_profiler_test.dart
+++ b/packages/devtools_app/test/screens/network/network_profiler_test.dart
@@ -1,6 +1,6 @@
-// Copyright 2020 The Chromium Authors. All rights reserved.
+// Copyright 2020 The Flutter Authors
 // Use of this source code is governed by a BSD-style license that can be
-// found in the LICENSE file.
+// found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
 
 @TestOn('vm')
 library;

--- a/packages/devtools_app/test/screens/network/network_request_inspector_test.dart
+++ b/packages/devtools_app/test/screens/network/network_request_inspector_test.dart
@@ -1,6 +1,6 @@
-// Copyright 2022 The Chromium Authors. All rights reserved.
+// Copyright 2022 The Flutter Authors
 // Use of this source code is governed by a BSD-style license that can be
-// found in the LICENSE file.
+// found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
 
 import 'dart:convert';
 

--- a/packages/devtools_app/test/screens/network/network_screen_test.dart
+++ b/packages/devtools_app/test/screens/network/network_screen_test.dart
@@ -1,6 +1,6 @@
-// Copyright 2020 The Chromium Authors. All rights reserved.
+// Copyright 2020 The Flutter Authors
 // Use of this source code is governed by a BSD-style license that can be
-// found in the LICENSE file.
+// found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
 
 import 'package:devtools_app/devtools_app.dart';
 import 'package:devtools_app_shared/ui.dart';

--- a/packages/devtools_app/test/screens/network/network_table_test.dart
+++ b/packages/devtools_app/test/screens/network/network_table_test.dart
@@ -1,6 +1,6 @@
-// Copyright 2020 The Chromium Authors. All rights reserved.
+// Copyright 2020 The Flutter Authors
 // Use of this source code is governed by a BSD-style license that can be
-// found in the LICENSE file.
+// found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
 
 @TestOn('vm')
 library;

--- a/packages/devtools_app/test/screens/network/offline_data_test.dart
+++ b/packages/devtools_app/test/screens/network/offline_data_test.dart
@@ -1,6 +1,6 @@
-// Copyright 2024 The Chromium Authors. All rights reserved.
+// Copyright 2024 The Flutter Authors
 // Use of this source code is governed by a BSD-style license that can be
-// found in the LICENSE file.
+// found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
 
 import 'dart:convert';
 import 'dart:io';

--- a/packages/devtools_app/test/screens/network/utils/network_test_utils.dart
+++ b/packages/devtools_app/test/screens/network/utils/network_test_utils.dart
@@ -1,6 +1,6 @@
-// Copyright 2020 The Chromium Authors. All rights reserved.
+// Copyright 2020 The Flutter Authors
 // Use of this source code is governed by a BSD-style license that can be
-// found in the LICENSE file.
+// found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
 
 import 'package:vm_service/vm_service.dart';
 

--- a/third_party/packages/perfetto_ui_compiled/lib/dist/devtools/devtools_dark.css
+++ b/third_party/packages/perfetto_ui_compiled/lib/dist/devtools/devtools_dark.css
@@ -1,7 +1,7 @@
 /**
-Copyright 2022 The Chromium Authors. All rights reserved.
+Copyright 2022 The Flutter Authors
 Use of this source code is governed by a BSD-style license that can be
-found in the LICENSE file.
+found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
 **/
 
 @import "devtools_shared.css";

--- a/third_party/packages/perfetto_ui_compiled/lib/dist/devtools/devtools_light.css
+++ b/third_party/packages/perfetto_ui_compiled/lib/dist/devtools/devtools_light.css
@@ -1,7 +1,7 @@
 /**
-Copyright 2022 The Chromium Authors. All rights reserved.
+Copyright 2022 The Flutter Authors
 Use of this source code is governed by a BSD-style license that can be
-found in the LICENSE file.
+found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
 **/
 
 @import "devtools_shared.css";

--- a/third_party/packages/perfetto_ui_compiled/lib/dist/devtools/devtools_shared.css
+++ b/third_party/packages/perfetto_ui_compiled/lib/dist/devtools/devtools_shared.css
@@ -1,7 +1,7 @@
 /**
-Copyright 2022 The Chromium Authors. All rights reserved.
+Copyright 2022 The Flutter Authors
 Use of this source code is governed by a BSD-style license that can be
-found in the LICENSE file.
+found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
 **/
 
 :root {

--- a/third_party/packages/widget_icons/example/lib/main.dart
+++ b/third_party/packages/widget_icons/example/lib/main.dart
@@ -1,6 +1,6 @@
-// Copyright 2021 The Chromium Authors. All rights reserved.
+// Copyright 2021 The Flutter Authors
 // Use of this source code is governed by a BSD-style license that can be
-// found in the LICENSE file.
+// found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
 
 import 'package:flutter/material.dart';
 import 'package:widget_icons/widget_icons.dart';

--- a/third_party/packages/widget_icons/lib/widget_icons.dart
+++ b/third_party/packages/widget_icons/lib/widget_icons.dart
@@ -1,6 +1,6 @@
-// Copyright 2021 The Chromium Authors. All rights reserved.
+// Copyright 2021 The Flutter Authors
 // Use of this source code is governed by a BSD-style license that can be
-// found in the LICENSE file.
+// found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
 
 // ignore_for_file: constant_identifier_names
 

--- a/third_party/packages/widget_icons/lib/widget_theme.dart
+++ b/third_party/packages/widget_icons/lib/widget_theme.dart
@@ -1,6 +1,6 @@
-// Copyright 2021 The Chromium Authors. All rights reserved.
+// Copyright 2021 The Flutter Authors
 // Use of this source code is governed by a BSD-style license that can be
-// found in the LICENSE file.
+// found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
 
 import 'package:flutter/material.dart';
 import 'package:widget_icons/widget_icons.dart';

--- a/third_party/packages/widget_icons/test/widget_theme_test.dart
+++ b/third_party/packages/widget_icons/test/widget_theme_test.dart
@@ -1,6 +1,6 @@
-// Copyright 2021 The Chromium Authors. All rights reserved.
+// Copyright 2021 The Flutter Authors
 // Use of this source code is governed by a BSD-style license that can be
-// found in the LICENSE file.
+// found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:widget_icons/widget_icons.dart';

--- a/tool/json_to_map.dart
+++ b/tool/json_to_map.dart
@@ -49,9 +49,9 @@ void main(List<String> args) {
       File('$jsonFileDirectoryPath/$fileNameWithoutExtension.dart')
         ..createSync()
         ..writeAsStringSync('''
-// Copyright 2023 The Chromium Authors. All rights reserved.
+// Copyright 2023 The Flutter Authors
 // Use of this source code is governed by a BSD-style license that can be
-// found in the LICENSE file.
+// found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
 
 // ignore_for_file: prefer_single_quotes
 // ignore_for_file: prefer-trailing-comma


### PR DESCRIPTION
Supersedes https://github.com/flutter/devtools/pull/8719.