### PR TITLE
[Property Editor] Handle deprecated widget arguments

### DIFF
--- a/packages/devtools_app/lib/src/shared/editor/api_classes.dart
+++ b/packages/devtools_app/lib/src/shared/editor/api_classes.dart
@@ -110,6 +110,7 @@ abstract class Field {
   static const hasArgument = 'hasArgument';
   static const id = 'id';
   static const isDarkMode = 'isDarkMode';
+  static const isDeprecated = 'isDeprecated';
   static const isEditable = 'isEditable';
   static const isNullable = 'isNullable';
   static const isRequired = 'isRequired';
@@ -524,6 +525,7 @@ class EditableArgument with Serializable {
     required this.isNullable,
     required this.isRequired,
     required this.isEditable,
+    required this.isDeprecated,
     required this.hasDefault,
     this.options,
     this.value,
@@ -540,6 +542,7 @@ class EditableArgument with Serializable {
         isNullable: (map[Field.isNullable] as bool?) ?? false,
         isRequired: (map[Field.isRequired] as bool?) ?? false,
         isEditable: (map[Field.isEditable] as bool?) ?? true,
+        isDeprecated: (map[Field.isDeprecated] as bool?) ?? false,
         hasDefault: map.containsKey(Field.defaultValue),
         options: (map[Field.options] as List<Object?>?)?.cast<String>(),
         value: map[Field.value],
@@ -574,6 +577,9 @@ class EditableArgument with Serializable {
   /// An argument might not be editable, e.g. if it is a positional parameter
   /// where previous positional parameters have no argument.
   final bool isEditable;
+
+  /// Whether the argument is deprecated.
+  final bool isDeprecated;
 
   /// A list of values that could be provided for this argument.
   ///
@@ -613,6 +619,7 @@ class EditableArgument with Serializable {
     Field.isNullable: isNullable,
     Field.isRequired: isRequired,
     Field.isEditable: isEditable,
+    Field.isDeprecated: isDeprecated,
     Field.options: options,
     Field.displayValue: displayValue,
     Field.errorText: errorText,

--- a/packages/devtools_app/lib/src/standalone_ui/ide_shared/property_editor/property_editor_controller.dart
+++ b/packages/devtools_app/lib/src/standalone_ui/ide_shared/property_editor/property_editor_controller.dart
@@ -156,6 +156,7 @@ class PropertyEditorController extends DisposableController
         (result?.args ?? <EditableArgument>[])
             .map(argToProperty)
             .nonNulls
+            .where(notDeprecatedWithNoValue)
             .toList();
     final name = result?.name;
     _editableWidgetData.value = (

--- a/packages/devtools_app/lib/src/standalone_ui/ide_shared/property_editor/property_editor_controller.dart
+++ b/packages/devtools_app/lib/src/standalone_ui/ide_shared/property_editor/property_editor_controller.dart
@@ -156,7 +156,8 @@ class PropertyEditorController extends DisposableController
         (result?.args ?? <EditableArgument>[])
             .map(argToProperty)
             .nonNulls
-            .where(notDeprecatedWithNoValue)
+            // Filter out any deprecated properties that aren't set.
+            .where((property) => !property.isDeprecated || property.hasArgument)
             .toList();
     final name = result?.name;
     _editableWidgetData.value = (

--- a/packages/devtools_app/lib/src/standalone_ui/ide_shared/property_editor/property_editor_types.dart
+++ b/packages/devtools_app/lib/src/standalone_ui/ide_shared/property_editor/property_editor_types.dart
@@ -143,6 +143,7 @@ class EditableProperty extends EditableArgument {
         isNullable: argument.isNullable,
         isRequired: argument.isRequired,
         isEditable: argument.isEditable,
+        isDeprecated: argument.isDeprecated,
         options: argument.options,
         displayValue: argument.displayValue,
         errorText: argument.errorText,
@@ -218,6 +219,9 @@ EditableProperty? argToProperty(EditableArgument argument) {
       return null;
   }
 }
+
+bool notDeprecatedWithNoValue(EditableArgument argument) =>
+    !(argument.isDeprecated && !argument.hasArgument);
 
 /// The following types should match those returned by the Analysis Server. See:
 /// https://github.com/dart-lang/sdk/blob/154b473cdb65c2686bb44fedec03ba2deddb80fd/pkg/analysis_server/lib/src/lsp/handlers/custom/editable_arguments/handler_editable_arguments.dart#L182

--- a/packages/devtools_app/lib/src/standalone_ui/ide_shared/property_editor/property_editor_types.dart
+++ b/packages/devtools_app/lib/src/standalone_ui/ide_shared/property_editor/property_editor_types.dart
@@ -220,9 +220,6 @@ EditableProperty? argToProperty(EditableArgument argument) {
   }
 }
 
-bool notDeprecatedWithNoValue(EditableArgument argument) =>
-    !(argument.isDeprecated && !argument.hasArgument);
-
 /// The following types should match those returned by the Analysis Server. See:
 /// https://github.com/dart-lang/sdk/blob/154b473cdb65c2686bb44fedec03ba2deddb80fd/pkg/analysis_server/lib/src/lsp/handlers/custom/editable_arguments/handler_editable_arguments.dart#L182
 const stringType = 'string';

--- a/packages/devtools_app/lib/src/standalone_ui/ide_shared/property_editor/property_editor_view.dart
+++ b/packages/devtools_app/lib/src/standalone_ui/ide_shared/property_editor/property_editor_view.dart
@@ -195,6 +195,7 @@ class _PropertyLabels extends StatelessWidget {
   Widget build(BuildContext context) {
     final colorScheme = Theme.of(context).colorScheme;
     final isSet = property.hasArgument;
+    final isDeprecated = property.isDeprecated;
     final isDefault = property.isDefault;
 
     return LayoutBuilder(
@@ -214,7 +215,22 @@ class _PropertyLabels extends StatelessWidget {
                   textColor: colorScheme.onPrimary,
                 ),
               ),
-            if (isDefault)
+            // We exclude deprecated properties that are not set, so this label
+            // is always displayed under the "set" label.
+            if (isDeprecated)
+              Padding(
+                padding: _labelPadding(isTopLabel: !isSet),
+                child: RoundedLabel(
+                  labelText: _maybeTruncateLabel('deprecated', width: width),
+                  tooltipText: 'Property argument is deprecated.',
+                  fontSize: smallFontSize,
+                  backgroundColor: colorScheme.error,
+                  textColor: colorScheme.onError,
+                ),
+              ),
+            // We only have space for two labels, so the deprecated label takes
+            // precedence over the default label.
+            if (isDefault && !isDeprecated)
               Padding(
                 padding: _labelPadding(isTopLabel: !isSet),
                 child: RoundedLabel(


### PR DESCRIPTION
Fixes https://github.com/flutter/devtools/issues/8930

* Property Editor does not show inputs for arguments that are deprecated and are not set in the source code
* Property Editor does include input if deprecated and value is set in the source code, and shows a label that the argument is deprecated

<img width="322" alt="Screenshot 2025-03-24 at 10 35 26 AM" src="https://github.com/user-attachments/assets/2a26577b-c0ef-4ce9-8030-1659910825a8" />
