### PR TITLE
[Property Editor] Use new DTD api to check if the connection is closed

### DIFF
--- a/packages/devtools_app/lib/src/shared/editor/editor_client.dart
+++ b/packages/devtools_app/lib/src/shared/editor/editor_client.dart
@@ -30,6 +30,8 @@ class EditorClient extends DisposableController
 
   String get gaId => EditorSidebar.id;
 
+  bool get isDtdClosed => _dtd.isClosed;
+
   Future<void> _initialize() async {
     autoDisposeStreamSubscription(
       _dtd.onEvent('Service').listen((data) {
@@ -315,10 +317,6 @@ class EditorClient extends DisposableController
         errorMessage: 'Unknown error: $e',
       );
     }
-  }
-
-  bool isClientClosed() {
-    return _dtd.isClosed;
   }
 
   Future<DTDResponse> _call(

--- a/packages/devtools_app/lib/src/shared/editor/editor_client.dart
+++ b/packages/devtools_app/lib/src/shared/editor/editor_client.dart
@@ -317,25 +317,8 @@ class EditorClient extends DisposableController
     }
   }
 
-  Future<bool> isClientClosed() async {
-    try {
-      // Make an empty request to DTD.
-      await _dtd.call('', '');
-    } on StateError catch (e) {
-      // TODO(https://github.com/flutter/devtools/issues/9028): Replace with a
-      // check for whether DTD is closed. Requires a change to package:dtd.
-      //
-      // This is only a temporary fix. If the error in package:json_rpc_2 is
-      // changed, this will no longer catch it. See:
-      // https://github.com/dart-lang/tools/blob/b55643dadafd3ac6b2bd20823802f75929ebf98e/pkgs/json_rpc_2/lib/src/client.dart#L151
-      if (e.message.contains('The client is closed.')) {
-        return true;
-      }
-    } catch (e) {
-      // Ignore other exceptions. If the client is open, we expect this to fail
-      // with the error: 'Unknown method "."'.
-    }
-    return false;
+  bool isClientClosed() {
+    return _dtd.isClosed;
   }
 
   Future<DTDResponse> _call(

--- a/packages/devtools_app/lib/src/standalone_ui/ide_shared/property_editor/property_editor_controller.dart
+++ b/packages/devtools_app/lib/src/standalone_ui/ide_shared/property_editor/property_editor_controller.dart
@@ -176,7 +176,7 @@ class PropertyEditorController extends DisposableController
 
   Timer _periodicallyCheckConnection(Duration interval) {
     return Timer.periodic(interval, (timer) {
-      final isClosed = editorClient.isClientClosed();
+      final isClosed = editorClient.isDtdClosed;
       if (isClosed) {
         _shouldReconnect.value = true;
         timer.cancel();

--- a/packages/devtools_app/lib/src/standalone_ui/ide_shared/property_editor/property_editor_controller.dart
+++ b/packages/devtools_app/lib/src/standalone_ui/ide_shared/property_editor/property_editor_controller.dart
@@ -175,8 +175,8 @@ class PropertyEditorController extends DisposableController
   }
 
   Timer _periodicallyCheckConnection(Duration interval) {
-    return Timer.periodic(interval, (timer) async {
-      final isClosed = await editorClient.isClientClosed();
+    return Timer.periodic(interval, (timer) {
+      final isClosed = editorClient.isClientClosed();
       if (isClosed) {
         _shouldReconnect.value = true;
         timer.cancel();

--- a/packages/devtools_app/pubspec.yaml
+++ b/packages/devtools_app/pubspec.yaml
@@ -25,7 +25,7 @@ dependencies:
   devtools_app_shared:
   devtools_extensions:
   devtools_shared:
-  dtd: ^2.4.0
+  dtd: ^2.5.0
   file: ^7.0.0
   file_selector: ^1.0.0
   fixnum: ^1.1.0


### PR DESCRIPTION
Work towards https://github.com/flutter/devtools/issues/9028, https://github.com/flutter/devtools/issues/1948

Now that the `isClosed` API method has been added to `package:dtd`, we don't need to send a request to determine whether the connection is closed. 

Follow-up to https://github.com/flutter/devtools/pull/9043