### PR TITLE
Simplify QueryFilter.filterArguments for callers

### DIFF
--- a/packages/devtools_app/lib/src/screens/logging/logging_controller.dart
+++ b/packages/devtools_app/lib/src/screens/logging/logging_controller.dart
@@ -739,10 +739,9 @@ class LoggingController extends DevToolsScreenController
 
     final queryFilter = filter.queryFilter;
     if (!queryFilter.isEmpty) {
-      final filteredOutByQueryFilterArgument = queryFilter
-          .filterArguments
-          .values
-          .any((argument) => !argument.matchesValue(log));
+      final filteredOutByQueryFilterArgument = queryFilter.filterArguments.any(
+        (argument) => !argument.matchesValue(log),
+      );
       if (filteredOutByQueryFilterArgument) return false;
 
       if (filter.queryFilter.substringExpressions.isNotEmpty) {

--- a/packages/devtools_app/lib/src/screens/network/network_controller.dart
+++ b/packages/devtools_app/lib/src/screens/network/network_controller.dart
@@ -449,9 +449,7 @@ class NetworkController extends DevToolsScreenController
       ..clear()
       ..addAll(
         _currentNetworkRequests.value.where((NetworkRequest r) {
-          final filteredOutByQueryFilterArgument = queryFilter
-              .filterArguments
-              .values
+          final filteredOutByQueryFilterArgument = queryFilter.filterArguments
               .any((argument) => !argument.matchesValue(r));
           if (filteredOutByQueryFilterArgument) return false;
 

--- a/packages/devtools_app/lib/src/screens/profiler/cpu_profiler_controller.dart
+++ b/packages/devtools_app/lib/src/screens/profiler/cpu_profiler_controller.dart
@@ -679,9 +679,7 @@ class CpuProfilerController extends DisposableController
 
       final queryFilter = filter.queryFilter;
       if (!queryFilter.isEmpty) {
-        final filteredOutByQueryFilterArgument = queryFilter
-            .filterArguments
-            .values
+        final filteredOutByQueryFilterArgument = queryFilter.filterArguments
             .any((argument) => !argument.matchesValue(stackFrame));
         if (filteredOutByQueryFilterArgument) return false;
 

--- a/packages/devtools_app/lib/src/shared/ui/filter.dart
+++ b/packages/devtools_app/lib/src/shared/ui/filter.dart
@@ -13,6 +13,7 @@ import 'package:flutter/material.dart';
 import '../primitives/utils.dart';
 import 'common_widgets.dart';
 
+/// A mapping from filter kinds to [QueryFilterArgument]s.
 typedef QueryFilterArgs<T> = Map<String, QueryFilterArgument<T>>;
 typedef SettingFilters<T> = List<SettingFilter<T, Object>>;
 
@@ -39,7 +40,7 @@ mixin FilterControllerMixin<T> on DisposableController
   ///
   /// This should be overriden as a getter by subclasses to support persisting
   /// the most recent filter to DevTools preferences.
-  ValueNotifier<String>? filterTagNotifier;
+  ValueNotifier<String>? get filterTagNotifier => null;
 
   ValueListenable<Filter<T>> get activeFilter => _activeFilter;
 
@@ -94,6 +95,7 @@ mixin FilterControllerMixin<T> on DisposableController
   /// query with arguments may look like 'foo category:bar type:baz'. In this
   /// example, 'category' and 'type' would need to be defined as query filter
   /// arguments.
+  @visibleForOverriding
   QueryFilterArgs<T> createQueryFilterArgs() =>
       <String, QueryFilterArgument<T>>{};
 
@@ -249,12 +251,11 @@ class _FilterDialogState<T> extends State<FilterDialog<T>>
         mainAxisSize: MainAxisSize.min,
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          for (final filter in widget.controller.settingFilters) ...[
+          for (final filter in widget.controller.settingFilters)
             if (filter is ToggleFilter<T>)
               _ToggleFilterElement(filter: filter)
             else
               _SettingFilterElement(filter: filter),
-          ],
         ],
       ),
     );
@@ -457,14 +458,14 @@ class SettingFilter<T, V> {
   Map<String, Object?> get valueAsJson => {id: setting.value};
 }
 
-class QueryFilter {
+class QueryFilter<T> {
   const QueryFilter._({
-    this.filterArguments = const <String, QueryFilterArgument>{},
+    QueryFilterArgs<T> filterArguments = const {},
     this.substringExpressions = const <Pattern>[],
     this.isEmpty = false,
-  });
+  }) : _filterArguments = filterArguments;
 
-  factory QueryFilter.empty({required QueryFilterArgs args}) {
+  factory QueryFilter.empty({required QueryFilterArgs<T> args}) {
     return QueryFilter._(
       filterArguments: args,
       substringExpressions: <Pattern>[],
@@ -474,7 +475,7 @@ class QueryFilter {
 
   factory QueryFilter.parse(
     String query, {
-    required QueryFilterArgs args,
+    required QueryFilterArgs<T> args,
     required bool useRegExp,
   }) {
     if (query.isEmpty) {
@@ -534,7 +535,12 @@ class QueryFilter {
     );
   }
 
-  final QueryFilterArgs filterArguments;
+  /// The mapping of filter kinds fo [QueryFilterArgument]s.
+  final QueryFilterArgs<T> _filterArguments;
+
+  /// The collection of all [QueryFilterArgument]s.
+  Iterable<QueryFilterArgument<T>> get filterArguments =>
+      _filterArguments.values;
 
   final List<Pattern> substringExpressions;
 
@@ -545,7 +551,7 @@ class QueryFilter {
           ? ''
           : [
             ...substringExpressions.toStringList(),
-            for (final arg in filterArguments.values) arg.display,
+            for (final arg in filterArguments) arg.display,
           ].join(' ').trim();
 }
 

--- a/packages/devtools_app/test/shared/ui/filter_test.dart
+++ b/packages/devtools_app/test/shared/ui/filter_test.dart
@@ -448,9 +448,7 @@ class _TestController extends DisposableController
 
       final queryFilter = filter.queryFilter;
       if (!queryFilter.isEmpty) {
-        final filteredOutByQueryFilterArgument = queryFilter
-            .filterArguments
-            .values
+        final filteredOutByQueryFilterArgument = queryFilter.filterArguments
             .any((argument) => !argument.matchesValue(element));
         if (filteredOutByQueryFilterArgument) return false;
 


### PR DESCRIPTION
This CL is a step towards making the "filter" code shareable, as per https://github.com/flutter/devtools/issues/7793.

(It's also just a cleanup independent of making code shareable.)

* All callers of `QueryFilter.filterArguments` just use the set of QueryFilterArguments; they do not pay any attention to the mapping from filter kinds. So just simplify the API to only expose the set of QueryFilterArguments.
* Do not expose a setter for `FilterControllerMixin.filterTagNotifier`.
* Mark `createQueryFilterArgs` as `visibleForOverriding`.
* Make QueryFilter generic, so that it's field, `_filterArguments`, and getter, `filterArguments`, are not collections of `QueryFilterArgument<dynamic>`.