### PR TITLE
[Property Editor] Better messages when panel is empty

### DIFF
--- a/packages/devtools_app/lib/src/standalone_ui/ide_shared/property_editor/property_editor_messages.dart
+++ b/packages/devtools_app/lib/src/standalone_ui/ide_shared/property_editor/property_editor_messages.dart
@@ -10,6 +10,9 @@ import '../../../shared/ui/colors.dart';
 class HowToUseMessage extends StatelessWidget {
   const HowToUseMessage({super.key});
 
+  static const _lightHighlighterColor = Colors.yellow;
+  static const _darkHighlighterColor = Color.fromARGB(168, 191, 17, 196);
+
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
@@ -49,6 +52,11 @@ class HowToUseMessage extends StatelessWidget {
       context: context,
       color: colorScheme.numericConstantSyntaxColor,
     );
+    TextSpan highlight(TextSpan original) => _highlight(
+      original,
+      highlighterColor:
+          theme.isDarkTheme ? _darkHighlighterColor : _lightHighlighterColor,
+    );
 
     return Text.rich(
       TextSpan(
@@ -79,18 +87,18 @@ class HowToUseMessage extends StatelessWidget {
           colorC(') '),
           colorC('{\n'),
           colorD(' return '),
-          _highlight(colorB('Text')),
-          _highlight(colorC('(\n')),
-          _highlight(colorE('  "Hello World!"')),
-          _highlight(colorF(',\n')),
-          _highlight(colorA('  overflow')),
-          _highlight(colorF(': ')),
-          _highlight(colorB('TextOveflow')),
-          _highlight(colorF('.')),
-          _highlight(colorG('clip')),
-          _highlight(colorF(',\n')),
-          _highlight(colorC('  )')),
-          _highlight(colorF(';\n')),
+          highlight(colorB('Text')),
+          highlight(colorC('(\n')),
+          highlight(colorE('  "Hello World!"')),
+          highlight(colorF(',\n')),
+          highlight(colorA('  overflow')),
+          highlight(colorF(': ')),
+          highlight(colorB('TextOveflow')),
+          highlight(colorF('.')),
+          highlight(colorG('clip')),
+          highlight(colorF(',\n')),
+          highlight(colorC('  )')),
+          highlight(colorF(';\n')),
           colorC('}'),
         ],
       ),
@@ -106,10 +114,10 @@ class HowToUseMessage extends StatelessWidget {
     return TextSpan(text: text, style: fixedFontStyle.copyWith(color: color));
   }
 
-  TextSpan _highlight(TextSpan original) {
+  TextSpan _highlight(TextSpan original, {required Color highlighterColor}) {
     return TextSpan(
       text: original.text,
-      style: original.style!.copyWith(backgroundColor: Colors.yellow),
+      style: original.style!.copyWith(backgroundColor: highlighterColor),
     );
   }
 }

--- a/packages/devtools_app/lib/src/standalone_ui/ide_shared/property_editor/property_editor_messages.dart
+++ b/packages/devtools_app/lib/src/standalone_ui/ide_shared/property_editor/property_editor_messages.dart
@@ -1,0 +1,160 @@
+// Copyright 2025 The Flutter Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
+
+import 'package:devtools_app_shared/ui.dart';
+import 'package:flutter/material.dart';
+
+import '../../../shared/ui/colors.dart';
+
+class HowToUseMessage extends StatelessWidget {
+  const HowToUseMessage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+    TextSpan colorA(String text) => _coloredSpan(
+      text,
+      context: context,
+      color: colorScheme.declarationsSyntaxColor,
+    );
+    TextSpan colorB(String text) => _coloredSpan(
+      text,
+      context: context,
+      color: colorScheme.modifierSyntaxColor,
+    );
+    TextSpan colorC(String text) => _coloredSpan(
+      text,
+      context: context,
+      color: colorScheme.variableSyntaxColor,
+    );
+    TextSpan colorD(String text) => _coloredSpan(
+      text,
+      context: context,
+      color: colorScheme.controlFlowSyntaxColor,
+    );
+    TextSpan colorE(String text) => _coloredSpan(
+      text,
+      context: context,
+      color: colorScheme.stringSyntaxColor,
+    );
+    TextSpan colorF(String text) => _coloredSpan(
+      text,
+      context: context,
+      color: colorScheme.functionSyntaxColor,
+    );
+    TextSpan colorG(String text) => _coloredSpan(
+      text,
+      context: context,
+      color: colorScheme.numericConstantSyntaxColor,
+    );
+
+    return Text.rich(
+      TextSpan(
+        children: [
+          const TextSpan(text: '\nPlease move your cursor anywhere inside a '),
+          TextSpan(
+            text: 'Flutter widget constructor invocation',
+            style: theme.boldTextStyle,
+          ),
+          const TextSpan(text: ' to view and edit its properties.\n\n'),
+          const TextSpan(
+            text:
+                'For the example, the highlighted code below is a constructor invocation of a ',
+          ),
+          TextSpan(
+            text: 'Text',
+            style: Theme.of(
+              context,
+            ).fixedFontStyle.copyWith(color: colorScheme.primary),
+          ),
+          const TextSpan(text: ' widget:\n\n'),
+          colorA('@override\n'),
+          colorB('Widget '),
+          colorG('build'),
+          colorC('('),
+          colorB('BuildContext '),
+          colorA('context'),
+          colorC(') '),
+          colorC('{\n'),
+          colorD(' return '),
+          _highlight(colorB('Text')),
+          _highlight(colorC('(\n')),
+          _highlight(colorE('  "Hello World!"')),
+          _highlight(colorF(',\n')),
+          _highlight(colorA('  overflow')),
+          _highlight(colorF(': ')),
+          _highlight(colorB('TextOveflow')),
+          _highlight(colorF('.')),
+          _highlight(colorG('clip')),
+          _highlight(colorF(',\n')),
+          _highlight(colorC('  )')),
+          _highlight(colorF(';\n')),
+          colorC('}'),
+        ],
+      ),
+    );
+  }
+
+  TextSpan _coloredSpan(
+    String text, {
+    required BuildContext context,
+    required Color color,
+  }) {
+    final fixedFontStyle = Theme.of(context).fixedFontStyle;
+    return TextSpan(text: text, style: fixedFontStyle.copyWith(color: color));
+  }
+
+  TextSpan _highlight(TextSpan original) {
+    return TextSpan(
+      text: original.text,
+      style: original.style!.copyWith(backgroundColor: Colors.yellow),
+    );
+  }
+}
+
+class NoDartCodeMessage extends StatelessWidget {
+  const NoDartCodeMessage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Text(
+      'No Dart code found at the current cursor location.',
+      style: Theme.of(context).textTheme.bodyLarge,
+    );
+  }
+}
+
+class NoMatchingPropertiesMessage extends StatelessWidget {
+  const NoMatchingPropertiesMessage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Text('No properties matching the current filter.');
+  }
+}
+
+class NoWidgetAtLocationMessage extends StatelessWidget {
+  const NoWidgetAtLocationMessage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Text(
+      'No Flutter widget found at the current cursor location.',
+      style: Theme.of(context).textTheme.bodyLarge,
+    );
+  }
+}
+
+class WelcomeMessage extends StatelessWidget {
+  const WelcomeMessage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Text(
+      '👋 Welcome to the Flutter Property Editor!',
+      style: Theme.of(context).textTheme.bodyLarge,
+    );
+  }
+}

--- a/packages/devtools_app/lib/src/standalone_ui/ide_shared/property_editor/property_editor_messages.dart
+++ b/packages/devtools_app/lib/src/standalone_ui/ide_shared/property_editor/property_editor_messages.dart
@@ -61,7 +61,7 @@ class HowToUseMessage extends StatelessWidget {
           const TextSpan(text: ' to view and edit its properties.\n\n'),
           const TextSpan(
             text:
-                'For the example, the highlighted code below is a constructor invocation of a ',
+                'For example, the highlighted code below is a constructor invocation of a ',
           ),
           TextSpan(
             text: 'Text',

--- a/packages/devtools_app/lib/src/standalone_ui/ide_shared/property_editor/property_editor_messages.dart
+++ b/packages/devtools_app/lib/src/standalone_ui/ide_shared/property_editor/property_editor_messages.dart
@@ -17,39 +17,40 @@ class HowToUseMessage extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final colorScheme = theme.colorScheme;
+    final fixedFontStyle = theme.fixedFontStyle;
     TextSpan colorA(String text) => _coloredSpan(
       text,
-      context: context,
+      style: fixedFontStyle,
       color: colorScheme.declarationsSyntaxColor,
     );
     TextSpan colorB(String text) => _coloredSpan(
       text,
-      context: context,
+      style: fixedFontStyle,
       color: colorScheme.modifierSyntaxColor,
     );
     TextSpan colorC(String text) => _coloredSpan(
       text,
-      context: context,
+      style: fixedFontStyle,
       color: colorScheme.variableSyntaxColor,
     );
     TextSpan colorD(String text) => _coloredSpan(
       text,
-      context: context,
+      style: fixedFontStyle,
       color: colorScheme.controlFlowSyntaxColor,
     );
     TextSpan colorE(String text) => _coloredSpan(
       text,
-      context: context,
+      style: fixedFontStyle,
       color: colorScheme.stringSyntaxColor,
     );
     TextSpan colorF(String text) => _coloredSpan(
       text,
-      context: context,
+      style: fixedFontStyle,
       color: colorScheme.functionSyntaxColor,
     );
     TextSpan colorG(String text) => _coloredSpan(
       text,
-      context: context,
+      style: fixedFontStyle,
       color: colorScheme.numericConstantSyntaxColor,
     );
     TextSpan highlight(TextSpan original) => _highlight(
@@ -107,19 +108,15 @@ class HowToUseMessage extends StatelessWidget {
 
   TextSpan _coloredSpan(
     String text, {
-    required BuildContext context,
+    required TextStyle style,
     required Color color,
-  }) {
-    final fixedFontStyle = Theme.of(context).fixedFontStyle;
-    return TextSpan(text: text, style: fixedFontStyle.copyWith(color: color));
-  }
+  }) => TextSpan(text: text, style: style.copyWith(color: color));
 
-  TextSpan _highlight(TextSpan original, {required Color highlighterColor}) {
-    return TextSpan(
-      text: original.text,
-      style: original.style!.copyWith(backgroundColor: highlighterColor),
-    );
-  }
+  TextSpan _highlight(TextSpan original, {required Color highlighterColor}) =>
+      TextSpan(
+        text: original.text,
+        style: original.style!.copyWith(backgroundColor: highlighterColor),
+      );
 }
 
 class NoDartCodeMessage extends StatelessWidget {

--- a/packages/devtools_app/lib/src/standalone_ui/ide_shared/property_editor/property_editor_view.dart
+++ b/packages/devtools_app/lib/src/standalone_ui/ide_shared/property_editor/property_editor_view.dart
@@ -38,9 +38,11 @@ class PropertyEditorView extends StatelessWidget {
         }
 
         final editableWidgetData = values.third as EditableWidgetData?;
-        return Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: _propertyEditorContents(editableWidgetData),
+        return SelectionArea(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: _propertyEditorContents(editableWidgetData),
+          ),
         );
       },
     );
@@ -446,34 +448,32 @@ class _WidgetNameAndDocumentation extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return SelectionArea(
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          Container(
-            alignment: Alignment.centerLeft,
-            padding: const EdgeInsets.only(bottom: denseSpacing),
-            child: Text(
-              name,
-              style: Theme.of(context).fixedFontStyle.copyWith(
-                fontWeight: FontWeight.bold,
-                fontSize: defaultFontSize + 1,
-              ),
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Container(
+          alignment: Alignment.centerLeft,
+          padding: const EdgeInsets.only(bottom: denseSpacing),
+          child: Text(
+            name,
+            style: Theme.of(context).fixedFontStyle.copyWith(
+              fontWeight: FontWeight.bold,
+              fontSize: defaultFontSize + 1,
             ),
           ),
-          Row(
-            children: [
-              Expanded(
-                child: _ExpandableWidgetDocumentation(
-                  documentation:
-                      documentation ?? 'Creates ${addIndefiniteArticle(name)}.',
-                ),
+        ),
+        Row(
+          children: [
+            Expanded(
+              child: _ExpandableWidgetDocumentation(
+                documentation:
+                    documentation ?? 'Creates ${addIndefiniteArticle(name)}.',
               ),
-            ],
-          ),
-          const PaddedDivider.noPadding(),
-        ],
-      ),
+            ),
+          ],
+        ),
+        const PaddedDivider.noPadding(),
+      ],
     );
   }
 }

--- a/packages/devtools_app/test/standalone_ui/ide_shared/property_editor/property_editor_test.dart
+++ b/packages/devtools_app/test/standalone_ui/ide_shared/property_editor/property_editor_test.dart
@@ -121,6 +121,8 @@ void main() {
       // Change the editable args.
       controller.initForTestsOnly();
       await tester.pumpAndSettle();
+
+      // Verify the welcome message is shown.
       expect(find.textContaining(welcomeMessageText), findsOneWidget);
       expect(find.textContaining(howToUseText), findsOneWidget);
       expect(find.textContaining(exampleWidgetText), findsOneWidget);

--- a/packages/devtools_app/test/standalone_ui/ide_shared/property_editor/property_editor_test.dart
+++ b/packages/devtools_app/test/standalone_ui/ide_shared/property_editor/property_editor_test.dart
@@ -113,6 +113,18 @@ void main() {
       }
     });
 
+    testWidgets('initial welcome screen', (tester) async {
+      // Load the property editor.
+      await tester.pumpWidget(wrap(propertyEditor));
+
+      // Change the editable args.
+      controller.initForTestsOnly();
+      await tester.pumpAndSettle();
+      expect(find.textContaining(welcomeMessageText), findsOneWidget);
+      expect(find.textContaining(howToUseText), findsOneWidget);
+      expect(find.textContaining(exampleWidgetText), findsOneWidget);
+    });
+
     testWidgets('verify editable arguments for first cursor location', (
       tester,
     ) async {
@@ -228,12 +240,9 @@ void main() {
 
         // Verify "No Dart code" message is shown.
         await tester.pumpAndSettle();
-        expect(
-          find.textContaining(
-            'No Dart code found at the current cursor location.',
-          ),
-          findsOneWidget,
-        );
+        expect(find.textContaining(noDartCodeText), findsOneWidget);
+        expect(find.textContaining(howToUseText), findsOneWidget);
+        expect(find.textContaining(exampleWidgetText), findsOneWidget);
       });
     });
   });
@@ -349,6 +358,22 @@ void main() {
         defaultOption: '.bottomLeft',
         tester: tester,
       );
+    });
+
+    testWidgets('no inputs if widget has no editable properties', (
+      tester,
+    ) async {
+      // Load the property editor.
+      await tester.pumpWidget(wrap(propertyEditor));
+
+      // Change the editable args.
+      controller.initForTestsOnly(editableArgsResult: resultWithNoWidget);
+      await tester.pumpAndSettle();
+
+      // Verify the "No widget" message is displayed.
+      expect(find.textContaining(noWidgetText), findsOneWidget);
+      expect(find.textContaining(howToUseText), findsOneWidget);
+      expect(find.textContaining(exampleWidgetText), findsOneWidget);
     });
   });
 
@@ -1309,3 +1334,12 @@ final resultWithTitle = EditableArgumentsResult(
   name: 'WidgetWithTitle',
   args: [titleProperty],
 );
+final resultWithNoWidget = EditableArgumentsResult(args: []);
+
+const welcomeMessageText = 'Welcome to the Flutter Property Editor!';
+const howToUseText =
+    'Please move your cursor anywhere inside a Flutter widget constructor invocation to view and edit its properties.';
+const exampleWidgetText =
+    'For example, the highlighted code below is a constructor invocation of a Text widget:';
+const noDartCodeText = 'No Dart code found at the current cursor location.';
+const noWidgetText = 'No Flutter widget found at the current cursor location.';


### PR DESCRIPTION
Fixes https://github.com/flutter/devtools/issues/9068
Work towards https://github.com/flutter/devtools/issues/1948

Hopefully resolves confusion about how to use the Property Editor when the cursor is not in a Flutter widget constructor.

Note: I fixed the "for the example" wording after taking these screenshots, so ignore that 😬 

### When the Property Editor is first loaded:
<img width="362" alt="Screenshot 2025-03-27 at 10 46 57 AM" src="https://github.com/user-attachments/assets/e3620858-7c33-48cd-a760-857b673b9ce6" />

### When the cursor is in a Dart file but not in a widget constructor:
<img width="359" alt="Screenshot 2025-03-27 at 10 45 32 AM" src="https://github.com/user-attachments/assets/7e69468b-2d7f-46f6-a787-56782a4e26a1" />

### When the cursor is not in a Dart file:
<img width="370" alt="Screenshot 2025-03-27 at 10 45 51 AM" src="https://github.com/user-attachments/assets/38b944a1-5583-4ad9-a6f1-abafe6b80a9c" />

### Dark theme:
<img width="336" alt="Screenshot 2025-03-27 at 11 56 29 AM" src="https://github.com/user-attachments/assets/4b530b41-aca4-42ae-92aa-4a30abb91b60" />

