### PR TITLE
Textfield focus issue workaround

### DIFF
--- a/packages/devtools_app/lib/src/app.dart
+++ b/packages/devtools_app/lib/src/app.dart
@@ -59,6 +59,7 @@ import 'shared/primitives/query_parameters.dart';
 import 'shared/primitives/utils.dart';
 import 'shared/ui/common_widgets.dart';
 import 'shared/ui/hover.dart';
+import 'shared/utils/focus_utils.dart';
 import 'shared/utils/utils.dart';
 import 'standalone_ui/standalone_screen.dart';
 
@@ -191,11 +192,16 @@ class DevToolsAppState extends State<DevToolsApp> with AutoDisposeMixin {
     addAutoDisposeListener(preferences.darkModeEnabled);
 
     releaseNotesController = ReleaseNotesController();
+
+    // Workaround for https://github.com/flutter/flutter/issues/155265.
+    setUpTextFieldFocusFixHandler();
   }
 
   @override
   void dispose() {
     FrameworkCore.dispose();
+    // Workaround for https://github.com/flutter/flutter/issues/155265.
+    removeTextFieldFocusFixHandler();
     super.dispose();
   }
 

--- a/packages/devtools_app/lib/src/shared/utils/_focus_utils_desktop.dart
+++ b/packages/devtools_app/lib/src/shared/utils/_focus_utils_desktop.dart
@@ -2,6 +2,10 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
 
-void reloadIframe() {
+void addBlurListener() {
+  // No-op for desktop platforms.
+}
+
+void removeBlurListener() {
   // No-op for desktop platforms.
 }

--- a/packages/devtools_app/lib/src/shared/utils/_focus_utils_web.dart
+++ b/packages/devtools_app/lib/src/shared/utils/_focus_utils_web.dart
@@ -1,0 +1,27 @@
+// Copyright 2025 The Flutter Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
+
+import 'dart:js_interop';
+
+import 'package:web/web.dart';
+
+const _flutterViewSelector = 'flutter-view';
+
+void addBlurListener() {
+  window.addEventListener('blur', _onBlur.toJS);
+}
+
+void removeBlurListener() {
+  window.removeEventListener('blur', _onBlur.toJS);
+}
+
+void _onBlur(Event _) {
+  final activeElement = document.activeElement as HTMLElement?;
+  if (activeElement == null) return;
+  // Only call blur on elements that are within a Flutter view.
+  final inFlutterView = activeElement.closest(_flutterViewSelector) != null;
+  if (inFlutterView) {
+    activeElement.blur();
+  }
+}

--- a/packages/devtools_app/lib/src/shared/utils/focus_utils.dart
+++ b/packages/devtools_app/lib/src/shared/utils/focus_utils.dart
@@ -1,0 +1,20 @@
+// Copyright 2025 The Flutter Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
+
+import '_focus_utils_desktop.dart'
+    if (dart.library.js_interop) '_focus_utils_web.dart';
+
+/// Workaround to prevent TextFields from holding onto focus when IFRAME-ed.
+///
+/// See https://github.com/flutter/flutter/issues/155265 for details.
+void setUpTextFieldFocusFixHandler() {
+  addBlurListener();
+}
+
+/// Workaround to prevent TextFields from holding onto focus when IFRAME-ed.
+///
+/// See https://github.com/flutter/flutter/issues/155265 for details.
+void removeTextFieldFocusFixHandler() {
+  removeBlurListener();
+}

--- a/packages/devtools_app/lib/src/standalone_ui/ide_shared/property_editor/property_editor_view.dart
+++ b/packages/devtools_app/lib/src/standalone_ui/ide_shared/property_editor/property_editor_view.dart
@@ -9,7 +9,6 @@ import 'package:flutter/material.dart';
 import '../../../shared/primitives/utils.dart';
 import '../../../shared/ui/common_widgets.dart';
 import '../../../shared/ui/filter.dart';
-import '../../../shared/utils/focus_utils.dart';
 import 'property_editor_controller.dart';
 import 'property_editor_inputs.dart';
 import 'property_editor_messages.dart';
@@ -86,7 +85,7 @@ class PropertyEditorView extends StatelessWidget {
   }
 }
 
-class _PropertiesList extends StatefulWidget {
+class _PropertiesList extends StatelessWidget {
   const _PropertiesList({required this.controller});
 
   final PropertyEditorController controller;
@@ -95,38 +94,16 @@ class _PropertiesList extends StatefulWidget {
   static const denseItemPadding = defaultItemPadding / 2;
 
   @override
-  State<_PropertiesList> createState() => _PropertiesListState();
-}
-
-class _PropertiesListState extends State<_PropertiesList> {
-  @override
-  void initState() {
-    super.initState();
-    // Workaround for https://github.com/flutter/flutter/issues/155265.
-    setUpTextFieldFocusFixHandler();
-  }
-
-  @override
-  void dispose() {
-    // Workaround for https://github.com/flutter/flutter/issues/155265.
-    removeTextFieldFocusFixHandler();
-    super.dispose();
-  }
-
-  @override
   Widget build(BuildContext context) {
     return ValueListenableBuilder(
-      valueListenable: widget.controller.filteredData,
+      valueListenable: controller.filteredData,
       builder: (context, properties, _) {
         return Column(
           children: <Widget>[
-            _FilterControls(controller: widget.controller),
+            _FilterControls(controller: controller),
             if (properties.isEmpty) const NoMatchingPropertiesMessage(),
             for (final property in properties)
-              _EditablePropertyItem(
-                property: property,
-                controller: widget.controller,
-              ),
+              _EditablePropertyItem(property: property, controller: controller),
           ].joinWith(const PaddedDivider.noPadding()),
         );
       },

--- a/packages/devtools_app/lib/src/standalone_ui/ide_shared/property_editor/property_editor_view.dart
+++ b/packages/devtools_app/lib/src/standalone_ui/ide_shared/property_editor/property_editor_view.dart
@@ -9,6 +9,7 @@ import 'package:flutter/material.dart';
 import '../../../shared/primitives/utils.dart';
 import '../../../shared/ui/common_widgets.dart';
 import '../../../shared/ui/filter.dart';
+import '../../../shared/utils/focus_utils.dart';
 import 'property_editor_controller.dart';
 import 'property_editor_inputs.dart';
 import 'property_editor_messages.dart';
@@ -101,15 +102,15 @@ class _PropertiesListState extends State<_PropertiesList> {
   @override
   void initState() {
     super.initState();
-    // Workaround for https://github.com/flutter/devtools/issues/8929.
+    // Workaround for https://github.com/flutter/flutter/issues/155265.
     setUpTextFieldFocusFixHandler();
   }
 
   @override
   void dispose() {
-    super.dispose();
-    // Workaround for https://github.com/flutter/devtools/issues/8929.
+    // Workaround for https://github.com/flutter/flutter/issues/155265.
     removeTextFieldFocusFixHandler();
+    super.dispose();
   }
 
   @override

--- a/packages/devtools_app/lib/src/standalone_ui/ide_shared/property_editor/utils/_utils_web.dart
+++ b/packages/devtools_app/lib/src/standalone_ui/ide_shared/property_editor/utils/_utils_web.dart
@@ -2,23 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
 
-import 'dart:js_interop';
-
 import 'package:web/web.dart';
 
 void reloadIframe() {
   window.location.reload();
-}
-
-void addBlurListener() {
-  window.addEventListener('blur', _onBlur.toJS);
-}
-
-void removeBlurListener() {
-  window.removeEventListener('blur', _onBlur.toJS);
-}
-
-void _onBlur(Event _) {
-  final inputElement = document.activeElement as HTMLElement?;
-  inputElement?.blur();
 }

--- a/packages/devtools_app/lib/src/standalone_ui/ide_shared/property_editor/utils/utils.dart
+++ b/packages/devtools_app/lib/src/standalone_ui/ide_shared/property_editor/utils/utils.dart
@@ -141,17 +141,3 @@ class DartDocConverter {
 void forceReload() {
   reloadIframe();
 }
-
-/// Workaround to prevent TextFields from holding onto focus when IFRAME-ed.
-///
-/// See https://github.com/flutter/devtools/issues/8929 for details.
-void setUpTextFieldFocusFixHandler() {
-  addBlurListener();
-}
-
-/// Workaround to prevent TextFields from holding onto focus when IFRAME-ed.
-///
-/// See https://github.com/flutter/devtools/issues/8929 for details.
-void removeTextFieldFocusFixHandler() {
-  removeBlurListener();
-}

--- a/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
+++ b/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
@@ -43,6 +43,9 @@ DevTools in order to avoid an OOM crash. -
 pausing on breakpoint on connection. - 
 [#8991](https://github.com/flutter/devtools/pull/8991)
 
+* Prevented text inputs from stealing focus from the IDE. - 
+[#9091](https://github.com/flutter/devtools/pull/9091)
+
 ## Inspector updates
 
 TODO: Remove this section if there are not any general updates.


### PR DESCRIPTION
Adds the workaround for https://github.com/flutter/flutter/issues/155265 to ALL of DevTools, not just the Property Editor. 

Incorporates @ditman's suggestions as well to check if we are in a `<flutter-view>` first before calling `blur` (thank you!)

FYI @DanTup @jwren 

Also FYI @johnpryan (Dartpad has the same issue, so adding this workaround there might be a good idea until it's fixed upstream in Flutter)