### PR TITLE
Initialize analytics metrics before framework initialization

### DIFF
--- a/packages/devtools_app/lib/initialization.dart
+++ b/packages/devtools_app/lib/initialization.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
 
+import 'dart:async';
+
 import 'package:devtools_app_shared/utils.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_web_plugins/url_strategy.dart';
@@ -9,6 +11,7 @@ import 'package:flutter_web_plugins/url_strategy.dart';
 import 'src/app.dart';
 import 'src/framework/framework_core.dart';
 import 'src/screens/debugger/syntax_highlighter.dart';
+import 'src/shared/analytics/analytics.dart' as ga;
 import 'src/shared/analytics/analytics_controller.dart';
 import 'src/shared/config_specific/logger/logger_helpers.dart';
 import 'src/shared/feature_flags.dart';
@@ -73,6 +76,11 @@ Future<void> initializeDevTools({
     enableExperiments: shouldEnableExperiments,
   );
 
+  // Initialize analytics metrics before initializing the framework so that any
+  // analytics events include the expected metadata.
+  // TODO(kenz): consider making the dimensions that need initialization `late`
+  // so that they can be initialized on first access rather than manually. 
+  unawaited(ga.setupDimensions());
   await FrameworkCore.init();
 }
 

--- a/packages/devtools_app/lib/initialization.dart
+++ b/packages/devtools_app/lib/initialization.dart
@@ -79,7 +79,7 @@ Future<void> initializeDevTools({
   // Initialize analytics metrics before initializing the framework so that any
   // analytics events include the expected metadata.
   // TODO(kenz): consider making the dimensions that need initialization `late`
-  // so that they can be initialized on first access rather than manually. 
+  // so that they can be initialized on first access rather than manually.
   unawaited(ga.setupDimensions());
   await FrameworkCore.init();
 }

--- a/packages/devtools_app/lib/initialization.dart
+++ b/packages/devtools_app/lib/initialization.dart
@@ -11,7 +11,6 @@ import 'package:flutter_web_plugins/url_strategy.dart';
 import 'src/app.dart';
 import 'src/framework/framework_core.dart';
 import 'src/screens/debugger/syntax_highlighter.dart';
-import 'src/shared/analytics/analytics.dart' as ga;
 import 'src/shared/analytics/analytics_controller.dart';
 import 'src/shared/config_specific/logger/logger_helpers.dart';
 import 'src/shared/feature_flags.dart';
@@ -76,11 +75,6 @@ Future<void> initializeDevTools({
     enableExperiments: shouldEnableExperiments,
   );
 
-  // Initialize analytics metrics before initializing the framework so that any
-  // analytics events include the expected metadata.
-  // TODO(kenz): consider making the dimensions that need initialization `late`
-  // so that they can be initialized on first access rather than manually.
-  unawaited(ga.setupDimensions());
   await FrameworkCore.init();
 }
 

--- a/packages/devtools_app/lib/src/app.dart
+++ b/packages/devtools_app/lib/src/app.dart
@@ -45,7 +45,6 @@ import 'screens/provider/provider_screen.dart';
 import 'screens/vm_developer/vm_developer_tools_controller.dart';
 import 'screens/vm_developer/vm_developer_tools_screen.dart';
 import 'service/service_extension_widgets.dart';
-import 'shared/analytics/analytics.dart' as ga;
 import 'shared/analytics/analytics_controller.dart';
 import 'shared/feature_flags.dart';
 import 'shared/framework/framework_controller.dart';
@@ -167,8 +166,6 @@ class DevToolsAppState extends State<DevToolsApp> with AutoDisposeMixin {
     // if (kIsWeb) {
     //   unawaited(BrowserContextMenu.disableContextMenu());
     // }
-
-    unawaited(ga.setupDimensions());
 
     void clearRoutesAndSetState() {
       setState(() {

--- a/packages/devtools_app/lib/src/framework/framework_core.dart
+++ b/packages/devtools_app/lib/src/framework/framework_core.dart
@@ -20,6 +20,7 @@ import '../extensions/extension_service.dart';
 import '../screens/debugger/breakpoint_manager.dart';
 import '../service/service_manager.dart';
 import '../service/vm_service_wrapper.dart';
+import '../shared/analytics/analytics.dart' as ga;
 import '../shared/config_specific/framework_initialize/framework_initialize.dart';
 import '../shared/console/eval/eval_service.dart';
 import '../shared/feature_flags.dart';
@@ -55,6 +56,17 @@ abstract class FrameworkCore {
     _initGlobals();
 
     await initializePlatform();
+
+    // Initialize analytics metrics before initializing the rest of the
+    // framework. It is important that this method call is here, after the
+    // `storage` global variable has been set by the `initializePlatform` call,
+    // since the analytics dimensions reference the `storage` global. We
+    // initialize this now so that any analytics events sent from here on our
+    // include the expected metadata.
+    // TODO(kenz): consider making the dimensions that need initialization
+    // `late` so that they can be initialized on first access rather than
+    // manually.
+    await ga.setupDimensions();
 
     // Print DevTools info at startup.
     _log.info(


### PR DESCRIPTION
We weren't initializing some metrics like `ideLaunched`, `ideLaunchedFeature`, `devtoolsChrome`, and `devtoolsPlatformType` before they were first accessed. This PR changes the behavior so that the analytics metrics are initialized before initializing the DevTools framework (which may result in sending analytics events).

CC @biggs0125 this was preventing us from having IDE, platform, and chrome information on the JS fallback events.