### PR TITLE
[Property Editor] Add a footer for opening documentation / reporting errors 

### DIFF
--- a/packages/devtools_app/lib/src/shared/analytics/constants/_property_editor_sidebar_constants.dart
+++ b/packages/devtools_app/lib/src/shared/analytics/constants/_property_editor_sidebar_constants.dart
@@ -9,6 +9,9 @@ class PropertyEditorSidebar {
   /// Analytics id to track events that come from the DTD editor sidebar.
   static String get id => 'propertyEditorSidebar';
 
+  /// Analytics id for opening the documentation.
+  static String get documentationLink => 'propertyEditorDocumentation';
+
   /// Analytics event that is sent when the property editor is updated with new
   /// properties.
   static String widgetPropertiesUpdate({String? name}) =>

--- a/packages/devtools_app/lib/src/standalone_ui/ide_shared/property_editor/property_editor_panel.dart
+++ b/packages/devtools_app/lib/src/standalone_ui/ide_shared/property_editor/property_editor_panel.dart
@@ -82,8 +82,6 @@ class _PropertyEditorPanelState extends State<PropertyEditorPanel> {
 class _PropertyEditorConnectedPanel extends StatefulWidget {
   const _PropertyEditorConnectedPanel(this.editor, {required this.controller});
 
-  static const footerHeight = 25.0;
-
   final EditorClient editor;
   final PropertyEditorController controller;
 
@@ -155,6 +153,8 @@ class _PropertyEditorConnectedPanelState
 class _PropertyEditorFooter extends StatelessWidget {
   const _PropertyEditorFooter();
 
+  static const _footerHeight = 25.0;
+
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
@@ -165,14 +165,20 @@ class _PropertyEditorFooter extends StatelessWidget {
         color: colorScheme.surface,
         border: Border(top: BorderSide(color: Theme.of(context).focusColor)),
       ),
-      height: _PropertyEditorConnectedPanel.footerHeight,
+      height: _footerHeight,
       padding: const EdgeInsets.symmetric(vertical: densePadding),
-      alignment: Alignment.center,
       child: Row(
+        crossAxisAlignment: CrossAxisAlignment.end,
         children: [
-          const Spacer(),
           if (documentationLink != null)
-            _DocsLink(documentationLink: documentationLink),
+            Padding(
+              padding: const EdgeInsets.only(left: denseSpacing),
+              child: _DocsLink(
+                documentationLink: documentationLink,
+                color: colorScheme.onSurface,
+              ),
+            ),
+          const Spacer(),
           ReportFeedbackButton(color: colorScheme.onSurface),
         ],
       ),
@@ -190,23 +196,22 @@ class _PropertyEditorFooter extends StatelessWidget {
 }
 
 class _DocsLink extends StatelessWidget {
-  const _DocsLink({required this.documentationLink});
+  const _DocsLink({required this.documentationLink, required this.color});
 
+  final Color color;
   final String documentationLink;
 
   @override
   Widget build(BuildContext context) {
-    return RichText(
-      text: GaLinkTextSpan(
-        link: GaLink(
-          display: 'documentation',
-          url: documentationLink,
-          gaScreenName: gac.PropertyEditorSidebar.id,
-          gaSelectedItemDescription:
-              gac.PropertyEditorSidebar.documentationLink,
-        ),
-        context: context,
+    return LinkIconLabel(
+      icon: Icons.library_books_outlined,
+      link: GaLink(
+        display: 'Docs',
+        url: documentationLink,
+        gaScreenName: gac.PropertyEditorSidebar.id,
+        gaSelectedItemDescription: gac.PropertyEditorSidebar.documentationLink,
       ),
+      color: color,
     );
   }
 }

--- a/packages/devtools_app/lib/src/standalone_ui/ide_shared/property_editor/property_editor_panel.dart
+++ b/packages/devtools_app/lib/src/standalone_ui/ide_shared/property_editor/property_editor_panel.dart
@@ -161,16 +161,19 @@ class _PropertyEditorFooter extends StatelessWidget {
     final colorScheme = theme.colorScheme;
     final documentationLink = _documentationLink();
     return Container(
-      color: colorScheme.secondary,
+      decoration: BoxDecoration(
+        color: colorScheme.surface,
+        border: Border(top: BorderSide(color: Theme.of(context).focusColor)),
+      ),
       height: _PropertyEditorConnectedPanel.footerHeight,
       padding: const EdgeInsets.symmetric(vertical: densePadding),
       alignment: Alignment.center,
       child: Row(
         children: [
+          const Spacer(),
           if (documentationLink != null)
             _DocsLink(documentationLink: documentationLink),
-          const Spacer(),
-          ReportFeedbackButton(color: colorScheme.onSecondary),
+          ReportFeedbackButton(color: colorScheme.onSurface),
         ],
       ),
     );


### PR DESCRIPTION
Note: The slightly odd alignment of the "Docs" text is also an issue for the normal DevTools footer. Filed https://github.com/flutter/devtools/issues/9098 (will fix if I have time, but trying to get in a few other changes before the cut off!)

Documentation hasn't been written yet, but I will add it to the Flutter site before the stable release.

![Screenshot 2025-04-03 at 3 15 21 PM](https://github.com/user-attachments/assets/30695476-b4c7-483d-893b-fc4c3abc4eb9)
