### PR TITLE
[Property Editor] Create a better `key` for text inputs

### DIFF
--- a/packages/devtools_app/lib/src/standalone_ui/ide_shared/property_editor/property_editor_controller.dart
+++ b/packages/devtools_app/lib/src/standalone_ui/ide_shared/property_editor/property_editor_controller.dart
@@ -179,12 +179,14 @@ class PropertyEditorController extends DisposableController
           property.name,
           property.type,
           property.value, // Include the property value.
+          property.displayValue,
           widgetName,
           fileUri,
         )
         : Object.hash(
           property.name,
           property.type,
+          property.displayValue,
           fileUri,
           widgetName,
           range.start.line, // Include the start position of the property.


### PR DESCRIPTION
Follow-up to https://github.com/flutter/devtools/pull/9087

I realized there was a bug with the `key` implementation added in the PR linked above. 

If (from their IDE) a user changed a `string`, `int` or `double` literal value to an expression, the Property Editor text input wouldn't rebuild as expected. This is because the expression is saved as the `displayValue`, which we weren't using to create the hash. 
