### PR TITLE
Don't report error to user if script parsing fails

### DIFF
--- a/packages/devtools_app/lib/src/screens/debugger/codeview_controller.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/codeview_controller.dart
@@ -268,7 +268,6 @@ class CodeViewController extends DisposableController
         reportError(
           'Failed to parse ${scriptRef.uri}.',
           stack: StackTrace.current,
-          notifyUser: true,
         );
         return false;
       }

--- a/packages/devtools_app/test/screens/debugger/debugger_scripts_test.dart
+++ b/packages/devtools_app/test/screens/debugger/debugger_scripts_test.dart
@@ -217,25 +217,6 @@ void main() {
         ]);
       },
     );
-
-    testWidgetsWithWindowSize('an error message is shown', smallWindowSize, (
-      WidgetTester tester,
-    ) async {
-      await pumpDebuggerScreen(tester, mockDebuggerController);
-      // Dismiss any previous notifications:
-      notificationService.dismiss(
-        'Failed to parse package:gallery/src/unknown.dart.',
-      );
-      await tester.pumpAndSettle();
-
-      await showScript(mockEmptyScriptRef);
-      await tester.pumpAndSettle();
-
-      expect(
-        notificationService.activeMessages.first.text,
-        equals('Failed to parse package:gallery/src/unknown.dart.'),
-      );
-    });
   });
 }
 


### PR DESCRIPTION
We've gotten many reports of script parsing failure (see https://github.com/flutter/devtools/issues/7192), but none with details about how to reproduce or how it affects Devtools. 

Only issue with any details indicates it's user error (trying to reload a disconnected Devtools instance): https://github.com/flutter/devtools/issues/7192

I've done some investigation, and if script parsing fails the only screen affected is the debugger screen (however, the error is shown immediately on connecting to Devtools regardless of which screen your are on). 

Since 1) the debugger screen is in maintenance mode and 2) if something is actually not working as expected it would be preferred to get a real issue filed with repro steps, I think it's safe to remove reporting this error to users.
