### PR TITLE
Inspector tree errors are removed on hot-reloads

### DIFF
--- a/packages/devtools_app/lib/src/framework/scaffold/scaffold.dart
+++ b/packages/devtools_app/lib/src/framework/scaffold/scaffold.dart
@@ -208,7 +208,7 @@ class DevToolsScaffoldState extends State<DevToolsScaffold>
         );
 
         // Clear error count when navigating to a screen.
-        serviceConnection.errorBadgeManager.clearErrors(screen.screenId);
+        serviceConnection.errorBadgeManager.clearErrorCount(screen.screenId);
 
         // Update routing with the change.
         WidgetsBinding.instance.addPostFrameCallback((timeStamp) {

--- a/packages/devtools_app/lib/src/screens/inspector/inspector_controller.dart
+++ b/packages/devtools_app/lib/src/screens/inspector/inspector_controller.dart
@@ -138,7 +138,7 @@ class InspectorController extends DisposableController
     // TODO(kenz): When this method is called outside  createState(), this post
     // frame callback can be removed.
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      serviceConnection.errorBadgeManager.clearErrors(InspectorScreen.id);
+      serviceConnection.errorBadgeManager.clearErrorCount(InspectorScreen.id);
     });
     filterErrors();
   }
@@ -761,7 +761,7 @@ class InspectorController extends DisposableController
       // the inspector was visible (normally they're cleared when visiting
       // the screen) and visiting an errored node seems an appropriate
       // acknowledgement of the errors.
-      serviceConnection.errorBadgeManager.clearErrors(InspectorScreen.id);
+      serviceConnection.errorBadgeManager.clearErrorCount(InspectorScreen.id);
     }
   }
 

--- a/packages/devtools_app/lib/src/screens/inspector_v2/inspector_controller.dart
+++ b/packages/devtools_app/lib/src/screens/inspector_v2/inspector_controller.dart
@@ -460,7 +460,12 @@ class InspectorController extends DisposableController
     // to wait for the first frame AFTER the isolate reload or navigation event
     // in order to request the new tree.
     if (event.kind == EventKind.kExtension) {
+      
+
       final extensionEventKind = event.extensionKind;
+      if (extensionEventKind == 'Flutter.Error') {
+        print('RECEIVED ERROR!');
+      }
       if (extensionEventKind == 'Flutter.Navigation') {
         _receivedFlutterNavigationEvent = true;
       }
@@ -474,6 +479,8 @@ class InspectorController extends DisposableController
     }
 
     if (event.kind == EventKind.kIsolateReload) {
+      print('RECEIVED ISOLATE RELOAD!');
+      serviceConnection.errorBadgeManager.clearErrors(InspectorScreen.id);
       _receivedIsolateReloadEvent = true;
     }
   }

--- a/packages/devtools_app/lib/src/screens/inspector_v2/inspector_controller.dart
+++ b/packages/devtools_app/lib/src/screens/inspector_v2/inspector_controller.dart
@@ -155,7 +155,7 @@ class InspectorController extends DisposableController
     // TODO(kenz): When this method is called outside  createState(), this post
     // frame callback can be removed.
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      serviceConnection.errorBadgeManager.clearErrors(InspectorScreen.id);
+      serviceConnection.errorBadgeManager.clearErrorCount(InspectorScreen.id);
     });
     filterErrors();
   }
@@ -460,12 +460,7 @@ class InspectorController extends DisposableController
     // to wait for the first frame AFTER the isolate reload or navigation event
     // in order to request the new tree.
     if (event.kind == EventKind.kExtension) {
-      
-
       final extensionEventKind = event.extensionKind;
-      if (extensionEventKind == 'Flutter.Error') {
-        print('RECEIVED ERROR!');
-      }
       if (extensionEventKind == 'Flutter.Navigation') {
         _receivedFlutterNavigationEvent = true;
       }
@@ -479,7 +474,6 @@ class InspectorController extends DisposableController
     }
 
     if (event.kind == EventKind.kIsolateReload) {
-      print('RECEIVED ISOLATE RELOAD!');
       serviceConnection.errorBadgeManager.clearErrors(InspectorScreen.id);
       _receivedIsolateReloadEvent = true;
     }
@@ -996,7 +990,7 @@ class InspectorController extends DisposableController
       // the inspector was visible (normally they're cleared when visiting
       // the screen) and visiting an errored node seems an appropriate
       // acknowledgement of the errors.
-      serviceConnection.errorBadgeManager.clearErrors(InspectorScreen.id);
+      serviceConnection.errorBadgeManager.clearErrorCount(InspectorScreen.id);
     }
   }
 

--- a/packages/devtools_app/lib/src/screens/logging/logging_controller.dart
+++ b/packages/devtools_app/lib/src/screens/logging/logging_controller.dart
@@ -289,7 +289,7 @@ class LoggingController extends DevToolsScreenController
 
   void clear() {
     _updateData([]);
-    serviceConnection.errorBadgeManager.clearErrors(LoggingScreen.id);
+    serviceConnection.errorBadgeManager.clearErrorCount(LoggingScreen.id);
   }
 
   void _handleConnectionStart(VmServiceWrapper service) {

--- a/packages/devtools_app/lib/src/screens/network/network_controller.dart
+++ b/packages/devtools_app/lib/src/screens/network/network_controller.dart
@@ -436,7 +436,7 @@ class NetworkController extends DevToolsScreenController
   @override
   void filterData(Filter<NetworkRequest> filter) {
     super.filterData(filter);
-    serviceConnection.errorBadgeManager.clearErrors(NetworkScreen.id);
+    serviceConnection.errorBadgeManager.clearErrorCount(NetworkScreen.id);
     final queryFilter = filter.queryFilter;
     if (queryFilter.isEmpty) {
       _currentNetworkRequests.value.forEach(_checkForError);

--- a/packages/devtools_app/lib/src/screens/performance/performance_controller.dart
+++ b/packages/devtools_app/lib/src/screens/performance/performance_controller.dart
@@ -255,7 +255,7 @@ class PerformanceController extends DevToolsScreenController
       await serviceConnection.serviceManager.service!.clearVMTimeline();
     }
     offlinePerformanceData = null;
-    serviceConnection.errorBadgeManager.clearErrors(PerformanceScreen.id);
+    serviceConnection.errorBadgeManager.clearErrorCount(PerformanceScreen.id);
     await _applyToFeatureControllersAsync((c) => c.clearData(partial: partial));
   }
 

--- a/packages/devtools_app/lib/src/shared/managers/error_badge_manager.dart
+++ b/packages/devtools_app/lib/src/shared/managers/error_badge_manager.dart
@@ -24,6 +24,8 @@ import '../primitives/query_parameters.dart';
 
 class ErrorBadgeManager extends DisposableController
     with AutoDisposeControllerMixin {
+  // TODO(https://github.com/flutter/devtools/issues/9105): Separate out
+  // Inspector-specific logic from this file.
   final _activeErrorCounts = <String, ValueNotifier<int>>{
     InspectorScreen.id: ValueNotifier<int>(0),
     PerformanceScreen.id: ValueNotifier<int>(0),
@@ -64,7 +66,6 @@ class ErrorBadgeManager extends DisposableController
 
       final inspectableError = _extractInspectableError(e);
       if (inspectableError != null) {
-        print('REVEIVED INSPECT ERROR!');
         incrementBadgeCount(InspectorScreen.id);
         appendError(InspectorScreen.id, inspectableError);
       }
@@ -72,8 +73,9 @@ class ErrorBadgeManager extends DisposableController
   }
 
   InspectableWidgetError? _extractInspectableError(Event error) {
-    // TODO(dantup): Switch to using the inspectorService from the serviceManager
-    //  once Jacob's change to add it lands.
+    // TODO(https://github.com/flutter/devtools/issues/9105): Switch to using
+    // the inspectorService from the serviceManager once Jacob's change to add
+    // it lands.
     final node = RemoteDiagnosticsNode(
       error.extensionData!.data,
       null,
@@ -147,8 +149,13 @@ class ErrorBadgeManager extends DisposableController
     return _activeErrorCounts[screenId];
   }
 
-  void clearErrors(String screenId) {
+  void clearErrorCount(String screenId) {
     _activeErrorCounts[screenId]?.value = 0;
+  }
+
+  void clearErrors(String screenId) {
+    clearErrorCount(screenId);
+    _activeErrors[screenId]?.value = LinkedHashMap<String, DevToolsError>();
   }
 
   void filterErrors(String screenId, bool Function(String id) isValid) {

--- a/packages/devtools_app/lib/src/shared/managers/error_badge_manager.dart
+++ b/packages/devtools_app/lib/src/shared/managers/error_badge_manager.dart
@@ -64,6 +64,7 @@ class ErrorBadgeManager extends DisposableController
 
       final inspectableError = _extractInspectableError(e);
       if (inspectableError != null) {
+        print('REVEIVED INSPECT ERROR!');
         incrementBadgeCount(InspectorScreen.id);
         appendError(InspectorScreen.id, inspectableError);
       }


### PR DESCRIPTION
Fixes https://github.com/flutter/devtools/issues/9096

We were adding an error to the tree every time we received an error event, but we were never removing them. 

When a hot-reload is triggered, any render errors are sent to the extension stream, so we can safely clear all errors on reload because any pre-existing errors will be re-sent.

The `error_badge_manager` file could use an overhaul, opened https://github.com/flutter/devtools/issues/9105 to do that as a follow up.