### PR TITLE
Prevent web apps from freezing after hot-restarts triggered from DevTools

### DIFF
--- a/packages/devtools_app/lib/src/screens/debugger/breakpoint_manager.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/breakpoint_manager.dart
@@ -95,7 +95,7 @@ class BreakpointManager with DisposerMixin {
       EventKind.kPausePostRequest,
       // We check for a resume event because package:dwds sends a resume event
       // after a hot-restart. See:
-      // https://github.com/flutter/devtools/issues/9124
+      // https://github.com/dart-lang/webdev/issues/2610
       EventKind.kResume,
     ].contains(pauseEventKind)) {
       await serviceConnection.serviceManager.isolateManager.resumeIsolate(

--- a/packages/devtools_app/lib/src/screens/debugger/breakpoint_manager.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/breakpoint_manager.dart
@@ -93,6 +93,10 @@ class BreakpointManager with DisposerMixin {
     if ([
       EventKind.kPauseStart,
       EventKind.kPausePostRequest,
+      // We check for a resume event because package:dwds sends a resume event
+      // after a hot-restart. See:
+      // https://github.com/flutter/devtools/issues/9124
+      EventKind.kResume,
     ].contains(pauseEventKind)) {
       await serviceConnection.serviceManager.isolateManager.resumeIsolate(
         isolateRef,

--- a/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
+++ b/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
@@ -15,7 +15,8 @@ To learn more about DevTools, check out the
 
 ## General updates
 
-TODO: Remove this section if there are not any general updates.
+- Prevent web apps from remaining paused after triggering a hot-restart from
+DevTools. - [#9125](https://github.com/flutter/devtools/pull/9125)
 
 ## Inspector updates
 


### PR DESCRIPTION
Fixes https://github.com/flutter/devtools/issues/9124

I still need to do some testing to make sure this doesn't introduce a regression to our breakpoint handling (although I think if the VM Service sends a `resume` event it should be safe for us to call `resume` as well). 