### PR TITLE
Do not show release notes for standalone screens

### DIFF
--- a/packages/devtools_app/lib/src/framework/release_notes.dart
+++ b/packages/devtools_app/lib/src/framework/release_notes.dart
@@ -65,15 +65,14 @@ class ReleaseNotesController extends SidePanelController {
   }
 
   void _maybeShowReleaseNotes() async {
-    // Do not show release notes in embedded sidebar.
+    // Do not show release notes in standalone screens. The fact that these
+    // screens are hosted by DevTools is an implementation detail, but from the
+    // user's perspective, these tools are part of the IDE.
     if (isEmbedded()) {
       final currentUrl = getWebUrl();
       final currentPage =
           currentUrl != null ? extractCurrentPageFromUrl(currentUrl) : null;
-      if (currentPage == StandaloneScreenType.vsCodeFlutterPanel.name ||
-          currentPage == StandaloneScreenType.editorSidebar.name) {
-        return;
-      }
+      if (StandaloneScreenType.includes(currentPage)) return;
     }
 
     SemanticVersion previousVersion = SemanticVersion();

--- a/packages/devtools_app/lib/src/standalone_ui/standalone_screen.dart
+++ b/packages/devtools_app/lib/src/standalone_ui/standalone_screen.dart
@@ -56,6 +56,9 @@ enum StandaloneScreenType {
       ),
     };
   }
+
+  static bool includes(String? screenName) =>
+      values.any((value) => value.name == screenName);
 }
 
 /// Widget that returns a [CenteredCircularProgressIndicator] while it waits for


### PR DESCRIPTION
Fixes https://github.com/flutter/devtools/issues/9119