### PR TITLE
Do not await service extension call in the performance screen

### DIFF
--- a/packages/devtools_app/lib/src/screens/performance/panes/flutter_frames/flutter_frames_chart.dart
+++ b/packages/devtools_app/lib/src/screens/performance/panes/flutter_frames/flutter_frames_chart.dart
@@ -7,6 +7,7 @@ import 'dart:math' as math;
 
 import 'package:devtools_app_shared/ui.dart';
 import 'package:devtools_app_shared/utils.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 import '../../../../shared/analytics/analytics.dart' as ga;
@@ -39,7 +40,7 @@ class FlutterFramesChart extends StatelessWidget {
 
   final bool showingOfflineData;
 
-  final bool impellerEnabled;
+  final ValueListenable<bool> impellerEnabled;
 
   @override
   Widget build(BuildContext context) {
@@ -86,7 +87,7 @@ class _FlutterFramesChart extends StatefulWidget {
 
   final bool showingOfflineData;
 
-  final bool impellerEnabled;
+  final ValueListenable<bool> impellerEnabled;
 
   static double get frameNumberSectionHeight => scaleByFontFactor(20.0);
 
@@ -203,7 +204,7 @@ class FramesChart extends StatefulWidget {
 
   final BoxConstraints constraints;
 
-  final bool impellerEnabled;
+  final ValueListenable<bool> impellerEnabled;
 
   @override
   State<FramesChart> createState() => _FramesChartState();
@@ -346,13 +347,18 @@ class _FramesChartState extends State<FramesChart> with AutoDisposeMixin {
         chartAxisPainter,
         Padding(padding: EdgeInsets.only(left: _yAxisUnitsSpace), child: chart),
         fpsLinePainter,
-        Positioned(
-          right: denseSpacing,
-          top: densePadding,
-          child: Text(
-            'Engine: ${widget.impellerEnabled ? 'Impeller' : 'Skia'}',
-            style: themeData.subtleChartTextStyle,
-          ),
+        ValueListenableBuilder(
+          valueListenable: widget.impellerEnabled,
+          builder: (context, impellerEnabled, child) {
+            return Positioned(
+              right: denseSpacing,
+              top: densePadding,
+              child: Text(
+                'Engine: ${impellerEnabled ? 'Impeller' : 'Skia'}',
+                style: themeData.subtleChartTextStyle,
+              ),
+            );
+          },
         ),
       ],
     );
@@ -382,7 +388,7 @@ class FramesChartControls extends StatelessWidget {
 
   final bool showingOfflineData;
 
-  final bool impellerEnabled;
+  final ValueListenable<bool> impellerEnabled;
 
   @override
   Widget build(BuildContext context) {
@@ -408,21 +414,26 @@ class FramesChartControls extends StatelessWidget {
               );
             },
           ),
-        Legend(
-          dense: true,
-          entries: [
-            LegendEntry(terse ? 'UI' : 'Frame Time (UI)', mainUiColor),
-            LegendEntry(
-              terse ? 'Raster' : 'Frame Time (Raster)',
-              mainRasterColor,
-            ),
-            LegendEntry(terse ? 'Jank' : 'Jank (slow frame)', uiJankColor),
-            if (!impellerEnabled)
-              LegendEntry(
-                'Shader Compilation',
-                shaderCompilationColor.background,
-              ),
-          ],
+        ValueListenableBuilder(
+          valueListenable: impellerEnabled,
+          builder: (context, impellerEnabled, child) {
+            return Legend(
+              dense: true,
+              entries: [
+                LegendEntry(terse ? 'UI' : 'Frame Time (UI)', mainUiColor),
+                LegendEntry(
+                  terse ? 'Raster' : 'Frame Time (Raster)',
+                  mainRasterColor,
+                ),
+                LegendEntry(terse ? 'Jank' : 'Jank (slow frame)', uiJankColor),
+                if (!impellerEnabled)
+                  LegendEntry(
+                    'Shader Compilation',
+                    shaderCompilationColor.background,
+                  ),
+              ],
+            );
+          },
         ),
         AverageFPS(
           frames: frames,

--- a/packages/devtools_app/lib/src/screens/performance/performance_controller.dart
+++ b/packages/devtools_app/lib/src/screens/performance/performance_controller.dart
@@ -273,6 +273,7 @@ class PerformanceController extends DevToolsScreenController
     _applyToFeatureControllers((c) => c.dispose());
     enhanceTracingController.dispose();
     rebuildCountModel.dispose();
+    _impellerEnabled.dispose();
     super.dispose();
   }
 

--- a/packages/devtools_app/lib/src/screens/performance/performance_controller.dart
+++ b/packages/devtools_app/lib/src/screens/performance/performance_controller.dart
@@ -124,9 +124,17 @@ class PerformanceController extends DevToolsScreenController
 
       if (serviceConnection.serviceManager.connectedApp?.isFlutterAppNow ??
           false) {
-        final impellerEnabledResponse = await serviceConnection.serviceManager
-            .callServiceExtensionOnMainIsolate(registrations.isImpellerEnabled);
-        _impellerEnabled = impellerEnabledResponse.json?['enabled'] == true;
+        // Do not await this future because this will hang if the app is paused
+        // upon connection.
+        unawaited(
+          serviceConnection.serviceManager
+              .callServiceExtensionOnMainIsolate(
+                registrations.isImpellerEnabled,
+              )
+              .then((response) {
+                _impellerEnabled = response.json?['enabled'] == true;
+              }),
+        );
       } else {
         _impellerEnabled = false;
       }

--- a/packages/devtools_app/lib/src/screens/performance/performance_controller.dart
+++ b/packages/devtools_app/lib/src/screens/performance/performance_controller.dart
@@ -9,6 +9,7 @@ import 'dart:async';
 
 import 'package:devtools_app_shared/service.dart';
 import 'package:devtools_app_shared/utils.dart';
+import 'package:flutter/foundation.dart';
 import 'package:vm_service/vm_service.dart';
 
 import '../../service/service_registrations.dart' as registrations;
@@ -83,8 +84,8 @@ class PerformanceController extends DevToolsScreenController
   /// any selection modifications that occur while the data is displayed.
   OfflinePerformanceData? offlinePerformanceData;
 
-  bool get impellerEnabled => _impellerEnabled;
-  bool _impellerEnabled = false;
+  ValueListenable<bool> get impellerEnabled => _impellerEnabled;
+  final _impellerEnabled = ValueNotifier<bool>(false);
 
   Future<void> get initialized => _initialized.future;
   final _initialized = Completer<void>();
@@ -132,11 +133,11 @@ class PerformanceController extends DevToolsScreenController
                 registrations.isImpellerEnabled,
               )
               .then((response) {
-                _impellerEnabled = response.json?['enabled'] == true;
+                _impellerEnabled.value = response.json?['enabled'] == true;
               }),
         );
       } else {
-        _impellerEnabled = false;
+        _impellerEnabled.value = false;
       }
 
       enhanceTracingController.init();

--- a/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
+++ b/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
@@ -25,7 +25,8 @@ TODO: Remove this section if there are not any general updates.
 
 ## Performance updates
 
-TODO: Remove this section if there are not any general updates.
+- Fixes a bug where the Performance page would hang when connected to a paused
+Flutter app. - [#9162](https://github.com/flutter/devtools/pull/9162)
 
 ## CPU profiler updates
 

--- a/packages/devtools_app/test/screens/performance/flutter_frames/flutter_frames_chart_test.dart
+++ b/packages/devtools_app/test/screens/performance/flutter_frames/flutter_frames_chart_test.dart
@@ -29,7 +29,7 @@ void main() {
         FlutterFramesChart(
           framesController,
           showingOfflineData: showingOfflineData,
-          impellerEnabled: impellerEnabled,
+          impellerEnabled: FixedValueListenable(impellerEnabled),
         ),
       ),
     );


### PR DESCRIPTION
Fixes infinite spinner when Performance page is opened while connected to a paused Flutter app. Addresses hang issue described here: https://github.com/flutter/devtools/issues/6708#issuecomment-2660177207