### PR TITLE
Fix a bug with detecting DevTools server availability

### DIFF
--- a/packages/devtools_app/lib/src/shared/preferences/preferences.dart
+++ b/packages/devtools_app/lib/src/shared/preferences/preferences.dart
@@ -20,6 +20,7 @@ import '../diagnostics/inspector_service.dart';
 import '../feature_flags.dart';
 import '../globals.dart';
 import '../primitives/query_parameters.dart';
+import '../server/server.dart';
 import '../utils/utils.dart';
 
 part '_cpu_profiler_preferences.dart';
@@ -216,12 +217,6 @@ class PreferencesController extends DisposableController
       return;
     }
 
-    // Whether DevTools was run using the `dt run` command, which runs DevTools
-    // using `flutter run` and connects it to a locally running instance of the
-    // DevTools server.
-    final usingDebugDevToolsServer =
-        (const String.fromEnvironment('debug_devtools_server')).isNotEmpty &&
-        !kReleaseMode;
     final shouldEnableWasm =
         (enabledFromStorage || enabledFromQueryParams) &&
         kIsWeb &&

--- a/packages/devtools_app/lib/src/shared/server/_server_api.dart
+++ b/packages/devtools_app/lib/src/shared/server/_server_api.dart
@@ -11,7 +11,7 @@ Future<bool> checkServerHttpApiAvailable() async {
     // in the server in the SDK (see `pkg\dds\lib\src\devtools\handler.dart`)
     // and not delegated back to DevTools shared code.
     final response = await get(
-      Uri.parse('${apiPrefix}ping'),
+      buildDevToolsServerRequestUri('${apiPrefix}ping'),
     ).timeout(const Duration(seconds: 5));
     // When running with the local dev server Flutter may serve its index page
     // for missing files to support the hashless url strategy. Check the response

--- a/packages/devtools_app/test/shared/utils/future_work_tracker_test.dart
+++ b/packages/devtools_app/test/shared/utils/future_work_tracker_test.dart
@@ -75,7 +75,7 @@ void main() {
 
     test('tracks failed work', () {
       _wrapAndRunAsync((async) async {
-        await runZonedGuarded(
+        runZonedGuarded(
           () {
             final tracker = FutureWorkTracker();
             expect(tracker.active.value, isFalse);


### PR DESCRIPTION
Fixes a bug that was introduced in https://github.com/flutter/devtools/commit/c4bd441569f1d6f2ea7648d15c18b7f833804c8f. This broke DevTools server detection in the case where DevTools is started from the `dt run` command, which allows connecting DevTools server to connect to a DevTools app running on a different origin (support added in https://github.com/flutter/devtools/pull/8621).

This regression was discovered while trying to fix https://github.com/flutter/devtools/issues/9176. 