### PR TITLE
[Property Editor] Include error code in exceptions sent to GA

### DIFF
--- a/packages/devtools_app/lib/src/standalone_ui/ide_shared/property_editor/property_editor_inputs.dart
+++ b/packages/devtools_app/lib/src/standalone_ui/ide_shared/property_editor/property_editor_inputs.dart
@@ -405,8 +405,12 @@ mixin _PropertyInputMixin<T extends StatefulWidget, U> on State<T> {
     required EditableProperty property,
   }) {
     final errorType = errorResponse.errorType;
+    final messageFromType = errorType?.message;
+    final messageFromResponse = errorResponse.errorMessage;
     final errorMessage =
-        errorType?.message ?? errorResponse.errorMessage ?? 'Unknown error.';
+        (messageFromType != null && messageFromResponse != null)
+        ? '$messageFromType / $messageFromResponse'
+        : messageFromType ?? messageFromResponse ?? 'Unknown error.';
     final propertyInfo = '(Property: ${property.name})';
     final errorCode = errorType?.code != null ? '${errorType!.code}: ' : '';
     return '$errorCode$errorMessage $propertyInfo';

--- a/packages/devtools_app/lib/src/standalone_ui/ide_shared/property_editor/property_editor_inputs.dart
+++ b/packages/devtools_app/lib/src/standalone_ui/ide_shared/property_editor/property_editor_inputs.dart
@@ -386,8 +386,7 @@ mixin _PropertyInputMixin<T extends StatefulWidget, U> on State<T> {
     final succeeded = errorResponse == null || errorResponse.success;
     if (!succeeded) {
       setState(() {
-        _serverError =
-            '${errorResponse.errorType?.message ?? 'Encountered unknown error.'} (Property: ${property.name})';
+        _serverError = _errorMessage(errorResponse, property: property);
       });
       ga.reportError('property-editor $_serverError');
     }
@@ -399,5 +398,17 @@ mixin _PropertyInputMixin<T extends StatefulWidget, U> on State<T> {
         succeeded: succeeded,
       ),
     );
+  }
+
+  String _errorMessage(
+    EditArgumentResponse errorResponse, {
+    required EditableProperty property,
+  }) {
+    final errorType = errorResponse.errorType;
+    final errorMessage =
+        errorType?.message ?? errorResponse.errorMessage ?? 'Unknown error.';
+    final propertyInfo = '(Property: ${property.name})';
+    final errorCode = errorType?.code != null ? '${errorType!.code}: ' : '';
+    return '$errorCode$errorMessage $propertyInfo';
   }
 }


### PR DESCRIPTION
Our current property edit exceptions in GA are not very helpful for figuring out why an edit did not succeed:

```
property-editor Encountered unknown error. (Property: textDirection)
```

This adds the error code so that we can figure out why these edits didn't succeed. I am planning on doing a DevTools CP with these changes.