### PR TITLE
Register and unregister VM service connections on DTD from the DevTools server

### DIFF
--- a/packages/devtools_app/lib/src/shared/managers/dtd_manager_extensions.dart
+++ b/packages/devtools_app/lib/src/shared/managers/dtd_manager_extensions.dart
@@ -5,7 +5,7 @@
 import 'package:devtools_app_shared/service.dart';
 import 'package:dtd/dtd.dart';
 // ignore: implementation_imports, intentional use of extension methods in DTD
-import 'package:dtd/src/unified_analytics_service.dart';
+import 'package:dtd/src/services/unified_analytics_service.dart';
 import 'package:logging/logging.dart';
 import 'package:unified_analytics/unified_analytics.dart' as ua;
 

--- a/packages/devtools_app/pubspec.yaml
+++ b/packages/devtools_app/pubspec.yaml
@@ -26,7 +26,7 @@ dependencies:
   devtools_app_shared:
   devtools_extensions:
   devtools_shared:
-  dtd: ^2.5.0
+  dtd: ^3.0.0
   file: ^7.0.0
   file_selector: ^1.0.0
   fixnum: ^1.1.0

--- a/packages/devtools_app_shared/CHANGELOG.md
+++ b/packages/devtools_app_shared/CHANGELOG.md
@@ -3,7 +3,9 @@ Copyright 2025 The Flutter Authors
 Use of this source code is governed by a BSD-style license that can be
 found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
 -->
-## 0.4.0 (not released)
+## 0.4.0
+* Bump `dtd` dependency to `^3.0.0`.
+* Bump `devtools_shared` dependency to `^11.3.0`.
 * Add `DisposableController.init` method and `DisposableController.disposed`
 getter.
 * Move the `Disposable` class from the 

--- a/packages/devtools_app_shared/pubspec.yaml
+++ b/packages/devtools_app_shared/pubspec.yaml
@@ -15,8 +15,8 @@ resolution: workspace
 dependencies:
   collection: ^1.15.0
   dds_service_extensions: ^2.0.0
-  devtools_shared: ^11.1.0
-  dtd: ^2.1.0
+  devtools_shared: ^11.3.0
+  dtd: ^3.0.0
   flutter:
     sdk: flutter
   logging: ^1.1.1

--- a/packages/devtools_extensions/CHANGELOG.md
+++ b/packages/devtools_extensions/CHANGELOG.md
@@ -3,7 +3,7 @@ Copyright 2025 The Flutter Authors
 Use of this source code is governed by a BSD-style license that can be
 found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
 -->
-## 0.3.2 (not released)
+## 0.4.0
 * Bump `devtools_app_shared` dependency to `0.4.0`.
 * Add `ShowBannerMessageExtensionEvent.dismissOnConnectionChanges` field. This
 value is set from an optional parameter in the constructor (defaults to `true`).

--- a/packages/devtools_extensions/example/packages_with_extensions/foo/packages/foo_devtools_extension/pubspec.yaml
+++ b/packages/devtools_extensions/example/packages_with_extensions/foo/packages/foo_devtools_extension/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
     path: ../../../../../../devtools_app_shared
   devtools_extensions:
     path: ../../../../../../devtools_extensions 
-  dtd: ^2.2.0
+  dtd: ^3.0.0
   path: ^1.8.0
   flutter:
     sdk: flutter

--- a/packages/devtools_extensions/pubspec.yaml
+++ b/packages/devtools_extensions/pubspec.yaml
@@ -3,7 +3,7 @@
 # found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
 name: devtools_extensions
 description: A package for building and supporting extensions for Dart DevTools.
-version: 0.3.2
+version: 0.4.0
 
 repository: https://github.com/flutter/devtools/tree/master/packages/devtools_extensions
 

--- a/packages/devtools_shared/CHANGELOG.md
+++ b/packages/devtools_shared/CHANGELOG.md
@@ -3,6 +3,12 @@ Copyright 2025 The Flutter Authors
 Use of this source code is governed by a BSD-style license that can be
 found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
 -->
+# 11.3.0
+* Update `dtd` dependency to `^3.0.0`.
+* Register and unregister VM service connections on DTD. This change only
+applies to the case where the DevTools server starts DTD (i.e. when a DTD
+connection was not passed to the server on startup).
+
 # 11.2.1
 * Rename `Handler` extension methods to `VmServiceHandler`. This member was
 marked `@visibleForTesting` and should not be used outside of this package, so

--- a/packages/devtools_shared/lib/src/server/handlers/_vm_service.dart
+++ b/packages/devtools_shared/lib/src/server/handlers/_vm_service.dart
@@ -63,6 +63,20 @@ extension VmServiceHandler on Never {
     try {
       dartToolingDaemon = await DartToolingDaemon.connect(dtd!.localUri);
 
+      // ignore: unnecessary_null_comparison, intentionally added to guard against future logic changes.
+      if (dtdSecret != null) {
+        final uriAsString = vmServiceUri.toString();
+        connected
+            ? await dartToolingDaemon.registerVmService(
+                uri: uriAsString,
+                secret: dtdSecret,
+              )
+            : await dartToolingDaemon.unregisterVmService(
+                uri: uriAsString,
+                secret: dtdSecret,
+              );
+      }
+
       final detectRootResponse = await detectRootPackageForVmService(
         vmServiceUriAsString: vmServiceUriAsString,
         vmServiceUri: vmServiceUri,

--- a/packages/devtools_shared/pubspec.yaml
+++ b/packages/devtools_shared/pubspec.yaml
@@ -4,7 +4,7 @@
 name: devtools_shared
 description: Package of shared Dart structures between devtools_app, dds, and other tools.
 
-version: 11.2.1
+version: 11.3.0
 
 repository: https://github.com/flutter/devtools/tree/master/packages/devtools_shared
 
@@ -16,7 +16,7 @@ resolution: workspace
 dependencies:
   args: ^2.4.2
   collection: ^1.15.0
-  dtd: ^2.2.0
+  dtd: ^3.0.0
   extension_discovery: ^2.1.0
   meta: ^1.9.1
   path: ^1.8.0


### PR DESCRIPTION
This PR bumps the DTD dependency to `^3.0.0` everywhere to pull in the new changes including the DTD `ConnectedApp` service (see https://github.com/dart-lang/sdk/issues/60540).