### PR TITLE
Allow the `--update-on-path` flag to be passed to the `dt sync` command

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -100,9 +100,9 @@ of launch configurations for running and debugging DevTools:
 
 ### Workflow for making changes
 
-1. Change your local Flutter SDK to the latest flutter candidate branch:
+1. Ensure your local Flutter SDK, DevTools dependencies, and generated code are up-to-date:
 	```sh
-	dt update-flutter-sdk --update-on-path
+	dt sync --update-on-path
 	```
 	> Warning: this will delete any local changes in your Flutter SDK you checked out from git.
 
@@ -111,23 +111,18 @@ of launch configurations for running and debugging DevTools:
 	git checkout -b myBranch
 	```
 
-3. Ensure your branch, dependencies, and generated code are up-to-date:
-	```sh
-	dt sync
-	```
-
-4. Implement your changes, and commit to your branch:
+3. Implement your changes, and commit to your branch:
 	```sh
 	git commit -m “description”
 	```
 	If your improvement is user-facing, [document it](packages/devtools_app/release_notes/README.md) in the same PR.
 
-5. Push to your branch to GitHub:
+4. Push to your branch to GitHub:
 	```sh
 	git push origin myBranch
 	```
 
-6. Navigate to the [Pull Requests](https://github.com/flutter/devtools/pulls) tab in the main
+5. Navigate to the [Pull Requests](https://github.com/flutter/devtools/pulls) tab in the main
 [DevTools repo](https://github.com/flutter/devtools). You should see a popup to create a pull
 request from the branch in your cloned repo to the DevTools `master` branch. Create a pull request.
 
@@ -137,9 +132,18 @@ request from the branch in your cloned repo to the DevTools `master` branch. Cre
 	```
 	dt sync
 	```
-	This will pull the latest code from the upstream DevTools, upgrade dependencies, and perform code generation.
+	This command will:
+	- pull the latest code from the upstream DevTools master branch
+	- update `tool/flutter-sdk`	to the Flutter version DevTools is built and tested
+	with on the CI
+	- upgrade dependencies
+	- perform code generation
 
-- If you want to upgrade dependencies and re-generate code (like mocks), but do not want to merge `upstream/master`, instead run
+	Optionally, pass the `--update-on-path` flag to also update your local Flutter SDK
+	git checkout along with the `tool/flutter-sdk`. 
+
+- If you want to upgrade dependencies and re-generate code (like mocks), but do
+not want to merge `upstream/master` or update your Flutter SDK version, instead run
 	```
 	dt generate-code --upgrade
 	```

--- a/tool/lib/commands/shared.dart
+++ b/tool/lib/commands/shared.dart
@@ -52,6 +52,18 @@ extension BuildCommandArgsExtension on ArgParser {
     );
   }
 
+  void addUpdateOnPathFlag() {
+    addFlag(
+      SharedCommandArgs.updateOnPath.flagName,
+      negatable: false,
+      help:
+          'Update the Flutter SDK that is on PATH (your local '
+          'flutter/flutter git checkout). This flag is to be used in '
+          'combination with the ${SharedCommandArgs.updateFlutter.asArg()} '
+          'flag.',
+    );
+  }
+
   void addWasmFlag() {
     addFlag(
       SharedCommandArgs.wasm.flagName,
@@ -100,6 +112,7 @@ enum SharedCommandArgs {
   runApp('run-app'),
   serveWithDartSdk('serve-with-dart-sdk'),
   updateFlutter('update-flutter'),
+  updateOnPath('update-on-path'),
   updatePerfetto('update-perfetto');
 
   const SharedCommandArgs(this.flagName);

--- a/tool/lib/commands/sync.dart
+++ b/tool/lib/commands/sync.dart
@@ -6,8 +6,13 @@ import 'package:args/command_runner.dart';
 import 'package:io/io.dart';
 
 import '../utils.dart';
+import 'shared.dart';
 
 class SyncCommand extends Command {
+  SyncCommand() {
+    argParser.addUpdateOnPathFlag();
+  }
+
   @override
   String get name => 'sync';
 
@@ -21,7 +26,14 @@ class SyncCommand extends Command {
     await processManager.runProcess(
       CliCommand.git(['pull', 'upstream', 'master']),
     );
-    await processManager.runProcess(CliCommand.tool(['update-flutter-sdk']));
+    final updateOnPath =
+        argResults![SharedCommandArgs.updateOnPath.flagName] as bool;
+    await processManager.runProcess(
+      CliCommand.tool([
+        'update-flutter-sdk',
+        if (updateOnPath) SharedCommandArgs.updateOnPath.asArg(),
+      ]),
+    );
     await processManager.runProcess(
       CliCommand.tool(['generate-code', '--upgrade']),
     );


### PR DESCRIPTION
This will allow for running `dt sync --update-on-path` to completely update your DevTools development environment, including your local Flutter SDK.