### PR TITLE
Update inspector integration tests to handle Flutter breaking change 

### DIFF
--- a/packages/devtools_app/test/screens/inspector_v2/inspector_integration_test.dart
+++ b/packages/devtools_app/test/screens/inspector_v2/inspector_integration_test.dart
@@ -178,6 +178,9 @@ void main() {
           matchesDevToolsGolden(
             '../../test_infra/goldens/integration_inspector_v2_implementation_widgets_expanded.png',
           ),
+          // Re-enable and update goldens once Flutter version in DevTools
+          // includes https://github.com/flutter/flutter/pull/169229.
+          skip: 'https://github.com/flutter/devtools/issues/9206',
         );
 
         // Confirm the HeroControllerScope is visible, and select it:
@@ -189,6 +192,9 @@ void main() {
           matchesDevToolsGolden(
             '../../test_infra/goldens/integration_inspector_v2_hideable_widget_selected.png',
           ),
+          // Re-enable and update goldens once Flutter version in DevTools
+          // includes https://github.com/flutter/flutter/pull/169229.
+          skip: 'https://github.com/flutter/devtools/issues/9206',
         );
 
         // Collapse the hidden group that contains the HeroControllerScope:
@@ -239,6 +245,9 @@ void main() {
         matchesDevToolsGolden(
           '../../test_infra/goldens/integration_inspector_v2_hideable_widget_selected_from_search.png',
         ),
+        // Re-enable and update goldens once Flutter version in DevTools
+        // includes https://github.com/flutter/flutter/pull/169229.
+        skip: 'https://github.com/flutter/devtools/issues/9206',
       );
     });
   });

--- a/packages/devtools_app/test/screens/inspector_v2/inspector_integration_test.dart
+++ b/packages/devtools_app/test/screens/inspector_v2/inspector_integration_test.dart
@@ -166,8 +166,9 @@ void main() {
         expect(hideableNodeFinder, findsNothing);
 
         // Expand the hidden group that contains the HeroControllerScope:
-        final expandButton = findExpandCollapseButtonForNode(
-          nodeDescription: '71 more widgets...',
+        final moreWidgetsRow = findChildRowOf('MaterialApp');
+        final expandButton = findExpandCollapseButtonForRow(
+          rowFinder: moreWidgetsRow,
           isExpand: true,
         );
         await tester.tap(expandButton);
@@ -191,8 +192,9 @@ void main() {
         );
 
         // Collapse the hidden group that contains the HeroControllerScope:
-        final collapseButton = findExpandCollapseButtonForNode(
-          nodeDescription: 'ScrollConfiguration',
+        final scrollConfigurationRow = findChildRowOf('MaterialApp');
+        final collapseButton = findExpandCollapseButtonForRow(
+          rowFinder: scrollConfigurationRow,
           isExpand: false,
         );
         await tester.tap(collapseButton);
@@ -645,15 +647,22 @@ Finder findNodeMatching(String text) => find.ancestor(
   matching: find.byType(DescriptionDisplay),
 );
 
-Finder findExpandCollapseButtonForNode({
-  required String nodeDescription,
+Finder findChildRowOf(String description) {
+  final parentRowFinder = _findTreeRowMatching(description);
+  final parentWidget = _getWidgetFromFinder<InspectorRowContent>(
+    parentRowFinder,
+  );
+  final parentIndex = parentWidget.row.index;
+
+  return find.byType(InspectorRowContent).at(parentIndex + 1);
+}
+
+Finder findExpandCollapseButtonForRow({
+  required Finder rowFinder,
   required bool isExpand,
 }) {
-  final hiddenNodeFinder = findNodeMatching(nodeDescription);
-  expect(hiddenNodeFinder, findsOneWidget);
-
   final expandCollapseButtonFinder = find.descendant(
-    of: hiddenNodeFinder,
+    of: rowFinder,
     matching: find.byType(TextButton),
   );
   expect(expandCollapseButtonFinder, findsOneWidget);


### PR DESCRIPTION
Work towards https://github.com/flutter/devtools/issues/9206

The changes in https://github.com/flutter/flutter/pull/169229 affect the number of widgets in the inspector tree, affecting our inspector integration tests. 

This PR updates how we are finding the affected row in the test to look for the child row of "MaterialApp" instead of the row matching "71 more widgets..." (since this text has now changed to "72 more widgets..."). 

The changes in https://github.com/flutter/flutter/pull/169229 a will also affect a few of the goldens we are comparing against, so I've skipped them for now. After https://github.com/flutter/flutter/pull/169229 lands and DevTools' Flutter version contains includes  https://github.com/flutter/flutter/pull/169229, they will need to be un-skipped and the goldens can be updated.