### PR TITLE
[Property Editor] Refactor dropdown matches IDE theme

### DIFF
--- a/packages/devtools_app/lib/src/standalone_ui/ide_shared/property_editor/property_editor_refactors.dart
+++ b/packages/devtools_app/lib/src/standalone_ui/ide_shared/property_editor/property_editor_refactors.dart
@@ -138,26 +138,34 @@ class _WrapWithOverflowButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
     return DevToolsTooltip(
       message: 'More widgets...',
       child: ContextMenuButton(
-        color: WrapWithRefactors.buttonColor(Theme.of(context)),
+        color: WrapWithRefactors.buttonColor(theme),
         icon: Icons.arrow_drop_down,
         iconSize: WrapWithRefactors.buttonIconSize,
         buttonWidth: buttonMinWidth,
         style: _wrapWithButtonStyle,
-        menuChildren: _refactorOptions(),
+        menuChildren: _refactorOptions(theme),
       ),
     );
   }
 
-  List<Widget> _refactorOptions() {
+  List<Widget> _refactorOptions(ThemeData theme) {
+    final colorScheme = theme.colorScheme;
     return refactors.map((refactor) {
       return MenuItemButton(
-        child: Text(refactor.label),
+        style: MenuItemButton.styleFrom(
+          foregroundColor: colorScheme.onSurface,
+          backgroundColor: theme.isDarkTheme
+              ? colorScheme.surface.brighten()
+              : colorScheme.surface.darken(),
+        ),
         onPressed: () async {
           await applyRefactor(refactor);
         },
+        child: Text(refactor.label),
       );
     }).toList();
   }


### PR DESCRIPTION
Fixes https://github.com/flutter/devtools/issues/9223

### Before (custom dark theme):

![image](https://github.com/user-attachments/assets/5c23c678-217d-4f4e-b22a-9e9749620d94)

### After (custom dark theme):

<img width="405" alt="Screenshot 2025-05-30 at 1 53 04 PM" src="https://github.com/user-attachments/assets/c41a9f5b-8824-4f7a-9b84-5685ef493438" />

### After (custom light theme):

<img width="377" alt="Screenshot 2025-05-30 at 1 49 45 PM" src="https://github.com/user-attachments/assets/67c97131-958e-456a-b3bd-391adaeedcfa" />

