### PR TITLE
Show `Timer` events in the Logging View

### DIFF
--- a/packages/devtools_app/lib/src/screens/logging/logging_controller.dart
+++ b/packages/devtools_app/lib/src/screens/logging/logging_controller.dart
@@ -311,6 +311,11 @@ class LoggingController extends DevToolsScreenController
     autoDisposeStreamSubscription(
       service.onExtensionEventWithHistorySafe.listen(_handleExtensionEvent),
     );
+
+    // Log timer events.
+    autoDisposeStreamSubscription(
+      service.onTimerEventWithHistorySafe.listen(_handleTimerEvent),
+    );
   }
 
   void _handleExtensionEvent(Event e) {
@@ -423,6 +428,20 @@ class LoggingController extends DevToolsScreenController
         ),
       );
     }
+  }
+
+  void _handleTimerEvent(Event e) {
+    final kind = e.kind!;
+
+    log(
+      LogData(
+        kind,
+        jsonEncode(e.json),
+        e.timestamp,
+        summary: e.details,
+        isolateRef: e.isolateRef,
+      ),
+    );
   }
 
   void _handleGCEvent(Event e) {

--- a/packages/devtools_app/lib/src/screens/logging/logging_controller.dart
+++ b/packages/devtools_app/lib/src/screens/logging/logging_controller.dart
@@ -431,11 +431,9 @@ class LoggingController extends DevToolsScreenController
   }
 
   void _handleTimerEvent(Event e) {
-    final kind = e.kind!;
-
     log(
       LogData(
-        kind,
+        e.kind!,
         jsonEncode(e.json),
         e.timestamp,
         summary: e.details,

--- a/packages/devtools_app/lib/src/screens/logging/metadata.dart
+++ b/packages/devtools_app/lib/src/screens/logging/metadata.dart
@@ -8,6 +8,7 @@ import 'package:devtools_app_shared/service.dart';
 import 'package:devtools_app_shared/ui.dart';
 import 'package:flutter/material.dart';
 import 'package:logging/logging.dart';
+import 'package:vm_service/vm_service.dart' show EventKind;
 
 import '../../shared/primitives/utils.dart';
 import 'logging_controller.dart';
@@ -201,7 +202,7 @@ class KindMetaDataChip extends MetadataChip {
     String? kindIconAsset;
     if (kind == 'stdout' || kind == 'stderr') {
       kindIcon = Icons.terminal_rounded;
-    } else if (kind == 'TimerSignificantlyOverdue') {
+    } else if (kind == EventKind.kTimerSignificantlyOverdue) {
       kindIcon = Icons.timer_rounded;
     } else if (RegExp(r'^flutter\..*$').hasMatch(kind)) {
       kindIconAsset = 'icons/flutter.png';

--- a/packages/devtools_app/lib/src/screens/logging/metadata.dart
+++ b/packages/devtools_app/lib/src/screens/logging/metadata.dart
@@ -201,6 +201,8 @@ class KindMetaDataChip extends MetadataChip {
     String? kindIconAsset;
     if (kind == 'stdout' || kind == 'stderr') {
       kindIcon = Icons.terminal_rounded;
+    } else if (kind == 'TimerSignificantlyOverdue') {
+      kindIcon = Icons.timer_rounded;
     } else if (RegExp(r'^flutter\..*$').hasMatch(kind)) {
       kindIconAsset = 'icons/flutter.png';
       kindIcon = null;

--- a/packages/devtools_app/lib/src/service/vm_service_wrapper.dart
+++ b/packages/devtools_app/lib/src/service/vm_service_wrapper.dart
@@ -246,6 +246,13 @@ class VmServiceWrapper extends VmService {
     );
   }
 
+  Stream<Event> get onTimerEventWithHistorySafe {
+    return _maybeReturnStreamWithHistory(
+      onTimerEventWithHistory,
+      fallbackStream: onTimerEvent,
+    );
+  }
+
   Stream<Event> _maybeReturnStreamWithHistory(
     Stream<Event> ddsStream, {
     required Stream<Event> fallbackStream,

--- a/packages/devtools_app/pubspec.yaml
+++ b/packages/devtools_app/pubspec.yaml
@@ -22,7 +22,7 @@ dependencies:
   collection: ^1.15.0
   dap: ^1.1.0
   dart_service_protocol_shared: ^0.0.3
-  dds_service_extensions: ^2.0.0
+  dds_service_extensions: ^2.0.2
   devtools_app_shared:
   devtools_extensions:
   devtools_shared:
@@ -53,7 +53,7 @@ dependencies:
   stack_trace: ^1.12.0
   string_scanner: ^1.4.0
   unified_analytics: ^7.0.0
-  vm_service: '>=15.0.0 <16.0.0'
+  vm_service: ^15.0.2
   vm_service_protos: ^1.0.0
   vm_snapshot_analysis: ^0.7.6
   web: ^1.0.0

--- a/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
+++ b/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
@@ -43,7 +43,8 @@ TODO: Remove this section if there are not any general updates.
 
 ## Logging updates
 
-TODO: Remove this section if there are not any general updates.
+* Started displaying events related to timers in the Logging View. -
+  [#9238](https://github.com/flutter/devtools/pull/9238).
 
 ## App size tool updates
 

--- a/packages/devtools_app/test/screens/logging/logging_controller_test.dart
+++ b/packages/devtools_app/test/screens/logging/logging_controller_test.dart
@@ -48,6 +48,22 @@ void main() {
       );
     }
 
+    void addTimerData(String message, {required IsolateRef isolateRef}) {
+      controller.log(
+        LogData(
+          'TimerSignificantlyOverdue',
+          jsonEncode({
+            'kind': 'TimerSignificantlyOverdue',
+            'details': message,
+            'isolateRef': isolateRef.toJson(),
+          }),
+          ++timestampCounter,
+          summary: message,
+          isolateRef: isolateRef,
+        ),
+      );
+    }
+
     void addGcData(String message) {
       controller.log(
         LogData(
@@ -102,6 +118,15 @@ void main() {
       );
       addLog(
         kind: 'stdout',
+        isolateRef: IsolateRef(
+          id: 'isolates/123',
+          number: '1',
+          name: 'abc-isolate',
+          isSystemIsolate: false,
+        ),
+      );
+      addTimerData(
+        'timer event',
         isolateRef: IsolateRef(
           id: 'isolates/123',
           number: '1',
@@ -173,8 +198,8 @@ void main() {
     test('matchesForSearch - default filters', () {
       prepareTestLogs();
 
-      expect(controller.filteredData.value, hasLength(10));
-      expect(controller.matchesForSearch('abc').length, equals(4));
+      expect(controller.filteredData.value, hasLength(11));
+      expect(controller.matchesForSearch('abc').length, equals(5));
       expect(controller.matchesForSearch('ghi').length, equals(2));
       expect(controller.matchesForSearch('abcd').length, equals(0));
       expect(controller.matchesForSearch('Flutter*').length, equals(2));
@@ -190,7 +215,7 @@ void main() {
       expect(controller.matchesForSearch('severe').length, equals(3));
 
       // Search by isolateRef name.
-      expect(controller.matchesForSearch('-isolate').length, equals(1));
+      expect(controller.matchesForSearch('-isolate').length, equals(2));
 
       // Search by zone name.
       expect(controller.matchesForSearch('root').length, equals(1));
@@ -202,8 +227,8 @@ void main() {
       disableAllFilters();
       prepareTestLogs();
 
-      expect(controller.filteredData.value, hasLength(17));
-      expect(controller.matchesForSearch('abc').length, equals(5));
+      expect(controller.filteredData.value, hasLength(18));
+      expect(controller.matchesForSearch('abc').length, equals(6));
       expect(controller.matchesForSearch('ghi').length, equals(3));
       expect(controller.matchesForSearch('abcd').length, equals(0));
       expect(controller.matchesForSearch('Flutter*').length, equals(7));
@@ -219,7 +244,7 @@ void main() {
       expect(controller.matchesForSearch('severe').length, equals(3));
 
       // Search by isolateRef name.
-      expect(controller.matchesForSearch('-isolate').length, equals(1));
+      expect(controller.matchesForSearch('-isolate').length, equals(2));
 
       // Search by zone name.
       expect(controller.matchesForSearch('root').length, equals(1));
@@ -230,10 +255,10 @@ void main() {
     test('matchesForSearch sets isSearchMatch property', () {
       prepareTestLogs();
 
-      expect(controller.filteredData.value, hasLength(10));
+      expect(controller.filteredData.value, hasLength(11));
       controller.search = 'abc';
       var matches = controller.searchMatches.value;
-      expect(matches.length, equals(4));
+      expect(matches.length, equals(5));
       verifyIsSearchMatch(controller.filteredData.value, matches);
 
       controller.search = 'Flutter.';
@@ -246,40 +271,40 @@ void main() {
       prepareTestLogs();
 
       // At this point data is filtered by the default setting filter values.
-      expect(controller.data, hasLength(17));
-      expect(controller.filteredData.value, hasLength(10));
+      expect(controller.data, hasLength(18));
+      expect(controller.filteredData.value, hasLength(11));
 
       controller.setActiveFilter(query: 'abc');
-      expect(controller.data, hasLength(17));
-      expect(controller.filteredData.value, hasLength(4));
+      expect(controller.data, hasLength(18));
+      expect(controller.filteredData.value, hasLength(5));
 
       controller.setActiveFilter(query: 'def');
-      expect(controller.data, hasLength(17));
+      expect(controller.data, hasLength(18));
       expect(controller.filteredData.value, hasLength(2));
 
       controller.setActiveFilter(query: 'abc def');
-      expect(controller.data, hasLength(17));
-      expect(controller.filteredData.value, hasLength(6));
+      expect(controller.data, hasLength(18));
+      expect(controller.filteredData.value, hasLength(7));
 
       controller.setActiveFilter(query: 'k:stdout');
-      expect(controller.data, hasLength(17));
+      expect(controller.data, hasLength(18));
       expect(controller.filteredData.value, hasLength(6));
 
       controller.setActiveFilter(query: '-k:stdout');
-      expect(controller.data, hasLength(17));
-      expect(controller.filteredData.value, hasLength(4));
+      expect(controller.data, hasLength(18));
+      expect(controller.filteredData.value, hasLength(5));
 
       controller.setActiveFilter(query: 'k:stdout abc');
-      expect(controller.data, hasLength(17));
+      expect(controller.data, hasLength(18));
       expect(controller.filteredData.value, hasLength(3));
 
       controller.setActiveFilter(query: 'k:stdout,flutter.navigation');
-      expect(controller.data, hasLength(17));
+      expect(controller.data, hasLength(18));
       expect(controller.filteredData.value, hasLength(7));
 
       controller.setActiveFilter();
-      expect(controller.data, hasLength(17));
-      expect(controller.filteredData.value, hasLength(10));
+      expect(controller.data, hasLength(18));
+      expect(controller.filteredData.value, hasLength(11));
 
       // Test setting filters.
       final minimumLogLevelFilter =
@@ -292,22 +317,22 @@ void main() {
 
       verboseFlutterFrameworkFilter.setting.value = false;
       controller.setActiveFilter();
-      expect(controller.data, hasLength(17));
-      expect(controller.filteredData.value, hasLength(14));
+      expect(controller.data, hasLength(18));
+      expect(controller.filteredData.value, hasLength(15));
 
       verboseFlutterServiceFilter.setting.value = false;
       controller.setActiveFilter();
-      expect(controller.data, hasLength(17));
-      expect(controller.filteredData.value, hasLength(15));
+      expect(controller.data, hasLength(18));
+      expect(controller.filteredData.value, hasLength(16));
 
       gcFilter.setting.value = false;
       controller.setActiveFilter();
-      expect(controller.data, hasLength(17));
-      expect(controller.filteredData.value, hasLength(17));
+      expect(controller.data, hasLength(18));
+      expect(controller.filteredData.value, hasLength(18));
 
       minimumLogLevelFilter.setting.value = Level.SEVERE.value;
       controller.setActiveFilter();
-      expect(controller.data, hasLength(17));
+      expect(controller.data, hasLength(18));
       expect(controller.filteredData.value, hasLength(3));
     });
 
@@ -330,8 +355,8 @@ void main() {
       });
 
       test('releaseMemory - partial release', () {
-        expect(controller.data, hasLength(17));
-        expect(controller.filteredData.value, hasLength(10));
+        expect(controller.data, hasLength(18));
+        expect(controller.filteredData.value, hasLength(11));
         controller.releaseMemory(partial: true);
         expect(controller.data, hasLength(9));
         expect(controller.filteredData.value, hasLength(2));

--- a/packages/devtools_app/test/screens/logging/logging_controller_test.dart
+++ b/packages/devtools_app/test/screens/logging/logging_controller_test.dart
@@ -51,9 +51,9 @@ void main() {
     void addTimerData(String message, {required IsolateRef isolateRef}) {
       controller.log(
         LogData(
-          'TimerSignificantlyOverdue',
+          EventKind.kTimerSignificantlyOverdue,
           jsonEncode({
-            'kind': 'TimerSignificantlyOverdue',
+            'kind': EventKind.kTimerSignificantlyOverdue,
             'details': message,
             'isolateRef': isolateRef.toJson(),
           }),

--- a/packages/devtools_test/lib/src/mocks/fake_vm_service_wrapper.dart
+++ b/packages/devtools_test/lib/src/mocks/fake_vm_service_wrapper.dart
@@ -539,4 +539,10 @@ class FakeVmServiceWrapper extends Fake implements VmServiceWrapper {
 
   @override
   Stream<Event> get onIsolateEvent => const Stream.empty();
+
+  @override
+  Stream<Event> get onTimerEvent => const Stream.empty();
+
+  @override
+  Stream<Event> get onTimerEventWithHistorySafe => const Stream.empty();
 }


### PR DESCRIPTION
I have added a new `Timer` stream to the VM Service. This PR makes events sent on that stream appear in the Logging View. Currently, the only events that can appear on the `Timer` stream are warnings issued whenever a timer fires later than expected.

e.g.

![Screenshot 2025-06-13 at 9 17 51 AM](https://github.com/user-attachments/assets/fac9e525-c5d3-4504-b5b5-ab1085bd786f)