### PR TITLE
[tool] Add an option to specify the path of a Flutter SDK

### DIFF
--- a/tool/lib/devtools_command_runner.dart
+++ b/tool/lib/devtools_command_runner.dart
@@ -27,6 +27,8 @@ import 'commands/update_version.dart';
 
 const _flutterFromPathFlag = 'flutter-from-path';
 
+const _flutterSdkPathFlag = 'flutter-sdk-path';
+
 class DevToolsCommandRunner extends CommandRunner {
   DevToolsCommandRunner()
     : super('dt', 'A repo management tool for DevTools.') {
@@ -49,21 +51,31 @@ class DevToolsCommandRunner extends CommandRunner {
     addCommand(UpdateFlutterSdkCommand());
     addCommand(UpdatePerfettoCommand());
 
-    argParser.addFlag(
-      _flutterFromPathFlag,
-      abbr: 'p',
-      negatable: false,
-      help:
-          'Use the Flutter SDK on PATH for any `flutter`, `dart` and '
-          '`dt` commands spawned by this process, instead of the '
-          'Flutter SDK from tool/flutter-sdk which is used by default.',
-    );
+    argParser
+      ..addFlag(
+        _flutterFromPathFlag,
+        abbr: 'p',
+        negatable: false,
+        help:
+            'Use the Flutter SDK on PATH for any `flutter`, `dart` and '
+            '`dt` commands spawned by this process, instead of the '
+            'Flutter SDK from tool/flutter-sdk which is used by default.',
+      )
+      ..addOption(
+        _flutterSdkPathFlag,
+        help:
+            'Use the Flutter SDK from the specified path for any `flutter`, '
+            '`dart`, and `dt` commands spawned by this process, instead of the '
+            'Flutter SDK from tool/flutter-sdk which is used by default.',
+      );
   }
 
   @override
   Future<void> runCommand(ArgResults topLevelResults) {
-    if (topLevelResults[_flutterFromPathFlag]) {
+    if (topLevelResults.flag(_flutterFromPathFlag)) {
       FlutterSdk.useFromPathEnvironmentVariable();
+    } else if (topLevelResults.wasParsed(_flutterSdkPathFlag)) {
+      FlutterSdk.useFromPath(topLevelResults.option(_flutterSdkPathFlag)!);
     } else {
       FlutterSdk.useFromCurrentVm();
     }

--- a/tool/lib/model.dart
+++ b/tool/lib/model.dart
@@ -196,6 +196,13 @@ class FlutterSdk {
     _current = findFromPathEnvironmentVariable();
   }
 
+  /// Sets the active Flutter SDK to the one at [sdkPath].
+  ///
+  /// Throws if an SDK is not found at [sdkPath].
+  static void useFromPath(String sdkPath) {
+    _current = findFromPath(sdkPath);
+  }
+
   /// Finds the Flutter SDK that contains the Dart VM being used to run this
   /// script.
   ///
@@ -233,6 +240,14 @@ class FlutterSdk {
       'Unable to locate the Flutter SDK from the current running Dart VM:\n'
       '${Platform.resolvedExecutable}',
     );
+  }
+
+  static FlutterSdk findFromPath(String sdkPath) {
+    if (path.basename(path.dirname(sdkPath)) == 'bin') {
+      return FlutterSdk._(path.dirname(path.dirname(sdkPath)));
+    }
+
+    throw Exception('Unable to locate the Flutter SDK at "$sdkPath"');
   }
 
   /// Finds a Flutter SDK in the `PATH` environment variable


### PR DESCRIPTION
This is necessary for compiling the devtools app via `dt`, as it is simpler to provide the Flutter SDK path directly than to try editing the PATH (platform-independent) before running `dt`.