### PR TITLE
Ignore expected exceptions from the `navigateToCode` extension method.

### DIFF
--- a/packages/devtools_app_shared/CHANGELOG.md
+++ b/packages/devtools_app_shared/CHANGELOG.md
@@ -3,6 +3,9 @@ Copyright 2025 The Flutter Authors
 Use of this source code is governed by a BSD-style license that can be
 found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
 -->
+## 0.4.1 (not released)
+* Ignore expected exceptions from the `navigateToCode` extension method.
+
 ## 0.4.0
 * Bump `dtd` dependency to `^4.0.0`.
 * Bump `devtools_shared` dependency to `^12.0.0`.

--- a/packages/devtools_app_shared/lib/src/service/service_utils.dart
+++ b/packages/devtools_app_shared/lib/src/service/service_utils.dart
@@ -63,12 +63,22 @@ extension VmServiceExtension on VmService {
     required int column,
     required String source,
   }) async {
-    await postEvent('ToolEvent', 'navigate', <String, Object>{
-      'fileUri': fileUriString,
-      'line': line,
-      'column': column,
-      'source': source,
-    });
+    try {
+      await postEvent('ToolEvent', 'navigate', <String, Object>{
+        'fileUri': fileUriString,
+        'line': line,
+        'column': column,
+        'source': source,
+      });
+    } on RPCError catch (e) {
+      // An [RPCErrorKind.kCustomStreamDoesNotExist] error is expected if the
+      // custom 'ToolEvent' stream does not have any listeners (i.e. there are
+      // no IDEs listening to this stream).
+      if (e.code == RPCErrorKind.kCustomStreamDoesNotExist.code) {
+        return;
+      }
+      rethrow;
+    }
   }
 }
 

--- a/packages/devtools_app_shared/pubspec.yaml
+++ b/packages/devtools_app_shared/pubspec.yaml
@@ -3,7 +3,7 @@
 # found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
 name: devtools_app_shared
 description: Package of Dart & Flutter structures shared between devtools_app and devtools extensions.
-version: 0.4.0
+version: 0.4.1
 repository: https://github.com/flutter/devtools/tree/master/packages/devtools_app_shared
 
 environment:


### PR DESCRIPTION
Fixes https://github.com/flutter/devtools/issues/9261