### PR TITLE
Bump build_runner to 2.5.x for faster builds

### DIFF
--- a/packages/devtools_app/pubspec.yaml
+++ b/packages/devtools_app/pubspec.yaml
@@ -61,7 +61,7 @@ dependencies:
 
 dev_dependencies:
   args: ^2.4.2
-  build_runner: ^2.3.3
+  build_runner: ^2.5.4
   devtools_test:
     path: ../devtools_test
   fake_async: ^1.3.1
@@ -77,6 +77,11 @@ dev_dependencies:
   test: ^1.21.0
   web_benchmarks: ^4.0.0
   webkit_inspection_protocol: ">=0.5.0 <2.0.0"
+
+dependency_overrides:
+  # Necessary while `stager` dep disallows `source_gen` 2.0.0. Remove when
+  # `stager` allows `source_gen` 2.0.0.
+  source_gen: ^2.0.0
 
 flutter:
   uses-material-design: true

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,5 +13,5 @@ workspace:
   - tool
 
 dev_dependencies:
-  build_runner: ^2.3.3
+  build_runner: ^2.5.4
   flutter_lints: ^5.0.0


### PR DESCRIPTION
I didn't bother benchmarking it. But this helps validate build_runner 2.5.x, and I didn't notice any slowdown, so let's bump it.