### PR TITLE
Do not mark service extensions as 'added' so eagerly

### DIFF
--- a/packages/devtools_app/lib/src/screens/network/network_service.dart
+++ b/packages/devtools_app/lib/src/screens/network/network_service.dart
@@ -2,9 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
 
+import 'package:devtools_app_shared/service.dart';
 import 'package:vm_service/vm_service.dart';
 
-import '../../service/vm_service_wrapper.dart';
 import '../../shared/globals.dart';
 import '../../shared/primitives/utils.dart';
 import '../../shared/utils/utils.dart';

--- a/packages/devtools_app/lib/src/service/vm_service_wrapper.dart
+++ b/packages/devtools_app/lib/src/service/vm_service_wrapper.dart
@@ -519,24 +519,3 @@ class TrackedFuture<T> {
   final String name;
   final Future<T> future;
 }
-
-extension RpcErrorExtension on RPCError {
-  /// Whether this [RPCError] is some kind of "VM Service connection has gone"
-  /// error that may occur if the VM is shut down.
-  bool get isServiceDisposedError {
-    if (code == RPCErrorKind.kServiceDisappeared.code ||
-        code == RPCErrorKind.kConnectionDisposed.code) {
-      return true;
-    }
-
-    if (code == RPCErrorKind.kServerError.code) {
-      // Always ignore "client is closed" and "closed with pending request"
-      // errors because these can always occur during shutdown if we were
-      // just starting to send (or had just sent) a request.
-      return message.contains('The client is closed') ||
-          message.contains('The client closed with pending request') ||
-          message.contains('Service connection dispose');
-    }
-    return false;
-  }
-}

--- a/packages/devtools_app/lib/src/shared/diagnostics/inspector_service.dart
+++ b/packages/devtools_app/lib/src/shared/diagnostics/inspector_service.dart
@@ -22,7 +22,6 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';
 import 'package:vm_service/vm_service.dart';
 
-import '../../service/vm_service_wrapper.dart';
 import '../console/primitives/simple_items.dart';
 import '../globals.dart';
 import '../utils/utils.dart';

--- a/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
+++ b/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
@@ -39,7 +39,8 @@ TODO: Remove this section if there are not any general updates.
 
 ## Network profiler updates
 
-TODO: Remove this section if there are not any general updates.
+* Fixed network logging after a hot restart. -
+  [#9271](https://github.com/flutter/devtools/pull/9271).
 
 ## Logging updates
 

--- a/packages/devtools_app_shared/lib/service.dart
+++ b/packages/devtools_app_shared/lib/service.dart
@@ -10,6 +10,7 @@ export 'src/service/flutter_version.dart';
 export 'src/service/isolate_manager.dart' hide TestIsolateManager;
 export 'src/service/isolate_state.dart';
 export 'src/service/resolved_uri_manager.dart';
+export 'src/service/rpc_error_extension.dart';
 export 'src/service/service_extension_manager.dart'
     hide TestServiceExtensionManager;
 export 'src/service/service_manager.dart';

--- a/packages/devtools_app_shared/lib/src/service/rpc_error_extension.dart
+++ b/packages/devtools_app_shared/lib/src/service/rpc_error_extension.dart
@@ -1,0 +1,26 @@
+// Copyright 2025 The Flutter Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
+
+import 'package:vm_service/vm_service.dart';
+
+extension RpcErrorExtension on RPCError {
+  /// Whether this [RPCError] is some kind of "VM Service connection has gone"
+  /// error that may occur if the VM is shut down.
+  bool get isServiceDisposedError {
+    if (code == RPCErrorKind.kServiceDisappeared.code ||
+        code == RPCErrorKind.kConnectionDisposed.code) {
+      return true;
+    }
+
+    if (code == RPCErrorKind.kServerError.code) {
+      // Always ignore "client is closed" and "closed with pending request"
+      // errors because these can always occur during shutdown if we were
+      // just starting to send (or had just sent) a request.
+      return message.contains('The client is closed') ||
+          message.contains('The client closed with pending request') ||
+          message.contains('Service connection dispose');
+    }
+    return false;
+  }
+}

--- a/packages/devtools_app_shared/lib/src/service/service_extension_manager.dart
+++ b/packages/devtools_app_shared/lib/src/service/service_extension_manager.dart
@@ -297,7 +297,7 @@ final class ServiceExtensionManager with DisposerMixin {
 
   /// Restores the service extension named [name] from the device.
   ///
-  /// Returns whether isolates in the test app are prepared for the restore.
+  /// Returns whether isolates in the connected app are prepared for the restore.
   Future<bool> _restoreExtensionFromDeviceIfReady(String name) async {
     final isolateRef = _isolateManager.mainIsolate.value;
     if (isolateRef == null) return false;

--- a/packages/devtools_app_shared/lib/src/service/service_extension_manager.dart
+++ b/packages/devtools_app_shared/lib/src/service/service_extension_manager.dart
@@ -14,6 +14,7 @@ import '../utils/auto_dispose.dart';
 import 'connected_app.dart';
 import 'constants.dart';
 import 'isolate_manager.dart';
+import 'rpc_error_extension.dart';
 import 'service_extensions.dart' as extensions;
 import 'service_utils.dart';
 
@@ -338,6 +339,10 @@ final class ServiceExtensionManager with DisposerMixin {
             await _maybeRestoreExtension(name, value);
           default:
             return true;
+        }
+      } on RPCError catch (e) {
+        if (e.isServiceDisposedError) {
+          return false;
         }
       } catch (e) {
         // Do not report an error if the VMService has gone away or the

--- a/packages/devtools_app_shared/lib/src/service/service_extension_manager.dart
+++ b/packages/devtools_app_shared/lib/src/service/service_extension_manager.dart
@@ -297,20 +297,20 @@ final class ServiceExtensionManager with DisposerMixin {
 
   /// Restores the service extension named [name] from the device.
   ///
-  /// Returns whether the service extension was actually restored.
+  /// Returns whether isolates in the test app are prepared for the restore.
   Future<bool> _restoreExtensionFromDevice(String name) async {
     final isolateRef = _isolateManager.mainIsolate.value;
     if (isolateRef == null) return false;
 
     if (!extensions.serviceExtensionsAllowlist.containsKey(name)) {
-      return false;
+      return true;
     }
     final expectedValueType =
         extensions.serviceExtensionsAllowlist[name]!.values.first.runtimeType;
 
     /// Restores the service extension named [name].
     ///
-    /// Returns whether the service extension was actually restored.
+    /// Returns whether isolates in the test app are prepared for the restore.
     Future<bool> restore() async {
       // The restore request is obsolete if the isolate has changed.
       if (isolateRef != _mainIsolate) return false;
@@ -390,7 +390,7 @@ final class ServiceExtensionManager with DisposerMixin {
 
   /// Calls the service extension named [name] with [value].
   ///
-  /// Returns whether the service extension was successfully called.
+  /// Returns whether isolates in the test app are prepared for the call.
   Future<bool> _callServiceExtension(String name, Object? value) async {
     if (_service == null) return false;
 

--- a/packages/devtools_app_shared/lib/src/service/service_extension_manager.dart
+++ b/packages/devtools_app_shared/lib/src/service/service_extension_manager.dart
@@ -326,16 +326,16 @@ final class ServiceExtensionManager with DisposerMixin {
         switch (expectedValueType) {
           case const (bool):
             final enabled = response.json!['enabled'] == 'true' ? true : false;
-            return await _maybeRestoreExtension(name, enabled);
+            await _maybeRestoreExtension(name, enabled);
           case const (String):
             final String? value = response.json!['value'];
-            return await _maybeRestoreExtension(name, value);
+            await _maybeRestoreExtension(name, value);
           case const (int):
           case const (double):
             final value = num.parse(
               response.json![name.substring(name.lastIndexOf('.') + 1)],
             );
-            return await _maybeRestoreExtension(name, value);
+            await _maybeRestoreExtension(name, value);
           default:
             return true;
         }
@@ -366,9 +366,7 @@ final class ServiceExtensionManager with DisposerMixin {
   }
 
   /// Maybe restores the service extension named [name] with [value].
-  ///
-  /// Returns whether the service extension's state is set.
-  Future<bool> _maybeRestoreExtension(String name, Object? value) async {
+  Future<void> _maybeRestoreExtension(String name, Object? value) async {
     final extensionDescription = extensions.serviceExtensionsAllowlist[name];
     if (extensionDescription is extensions.ToggleableServiceExtension) {
       if (value == extensionDescription.enabledValue) {
@@ -378,9 +376,7 @@ final class ServiceExtensionManager with DisposerMixin {
           value: value,
           callExtension: false,
         );
-        return true;
       }
-      return false;
     } else {
       await setServiceExtensionState(
         name,
@@ -388,7 +384,6 @@ final class ServiceExtensionManager with DisposerMixin {
         value: value,
         callExtension: false,
       );
-      return true;
     }
   }
 
@@ -439,8 +434,6 @@ final class ServiceExtensionManager with DisposerMixin {
             // of the extension name (ext.flutter.extensionName => extensionName).
             args: {name.substring(name.lastIndexOf('.') + 1): value},
           );
-        } else {
-          return false;
         }
       } on RPCError catch (e) {
         if (e.code == RPCErrorKind.kServerError.code) {


### PR DESCRIPTION
Fixes https://github.com/flutter/devtools/issues/9203

The code here had a race condition. After an app performs a hot restart, we enter `_addServiceExtension` twice for each service extension that is to be re-added. I'm not sure why twice. But I believe the code at the top of `_addServiceExtension`:

```dart
if (!_serviceExtensions.add(name)) {
  // If the service extension was already added we do not need to add it
  // again. This can happen depending on the timing between when extension
  // added events were received and when we requested the list of all
  // service extensions already defined for the isolate.
  return;
}
```

is here specifically so that the second call just quietly short circuits. However, https://github.com/flutter/devtools/issues/9203 is the result of the situation where we add to `_serviceExtensions` too eagerly: in the first call, we add a service extension, say `"ext.dart.io.httpEnableTimelineLogging"`, to `_serviceExtensions`, and _then_ we find out that `_isolateManager.mainIsolate.value` is null, and we short-circuit return! When the second call comes in, and `_isolateManager.mainIsolate.value` is _not_ null, we've already added to `_serviceExtensions` so we short circuit again.

The fix is to make some of these functions return whether or not they successfully added/restored a service extension, as they all have several conditions that result in a short circuit. If they return `true`, then we can:

```dart
_serviceExtensions.add(name);
_hasServiceExtension(name).value = true;
```