### PR TITLE
Use --no-minify-wasm when creating devtools for releases.

### DIFF
--- a/tool/build_release.sh
+++ b/tool/build_release.sh
@@ -81,7 +81,8 @@ flutter build web \
   --wasm \
   --pwa-strategy=offline-first \
   --release \
-  --no-tree-shake-icons
+  --no-tree-shake-icons \
+  --no-minify-wasm
 
 # Ensure permissions are set correctly on canvaskit binaries.
 chmod 0755 build/web/canvaskit/canvaskit.*

--- a/tool/lib/commands/build.dart
+++ b/tool/lib/commands/build.dart
@@ -45,7 +45,8 @@ class BuildCommand extends Command {
       ..addPubGetFlag()
       ..addBulidModeOption()
       ..addWasmFlag()
-      ..addNoStripWasmFlag();
+      ..addNoStripWasmFlag()
+      ..addNoMinifyWasmFlag();
   }
 
   @override
@@ -67,6 +68,8 @@ class BuildCommand extends Command {
     final buildMode = results[SharedCommandArgs.buildMode.flagName] as String;
     final useWasm = results[SharedCommandArgs.wasm.flagName] as bool;
     final noStripWasm = results[SharedCommandArgs.noStripWasm.flagName] as bool;
+    final noMinifyWasm =
+        results[SharedCommandArgs.noMinifyWasm.flagName] as bool;
 
     final webBuildDir = Directory(
       path.join(repo.devtoolsAppDirectoryPath, 'build', 'web'),
@@ -105,6 +108,7 @@ class BuildCommand extends Command {
           if (useWasm) ...[
             SharedCommandArgs.wasm.asArg(),
             if (noStripWasm) SharedCommandArgs.noStripWasm.asArg(),
+            if (noMinifyWasm) SharedCommandArgs.noMinifyWasm.asArg(),
           ] else ...[
             // Do not minify stack traces in debug mode.
             if (buildMode == 'debug') '--dart2js-optimization=O1',

--- a/tool/lib/commands/serve.dart
+++ b/tool/lib/commands/serve.dart
@@ -92,6 +92,7 @@ class ServeCommand extends Command {
       ..addBulidModeOption()
       ..addWasmFlag()
       ..addNoStripWasmFlag()
+      ..addNoMinifyWasmFlag()
       // Flags defined in the server in DDS.
       ..addFlag(
         _machineFlag,
@@ -147,6 +148,7 @@ class ServeCommand extends Command {
         results[SharedCommandArgs.updatePerfetto.flagName] as bool;
     final useWasm = results[SharedCommandArgs.wasm.flagName] as bool;
     final noStripWasm = results[SharedCommandArgs.noStripWasm.flagName] as bool;
+    final noMinifyWasm = results[SharedCommandArgs.noMinifyWasm.flagName] as bool;
     final runPubGet = results[SharedCommandArgs.pubGet.flagName] as bool;
     final devToolsAppBuildMode =
         results[SharedCommandArgs.buildMode.flagName] as String;
@@ -172,6 +174,7 @@ class ServeCommand extends Command {
           ..remove(SharedCommandArgs.updatePerfetto.asArg())
           ..remove(SharedCommandArgs.wasm.asArg())
           ..remove(SharedCommandArgs.noStripWasm.asArg())
+          ..remove(SharedCommandArgs.noMinifyWasm.asArg())
           ..remove(valueAsArg(_buildAppFlag))
           ..remove(valueAsArg(_buildAppFlag, negated: true))
           ..remove(SharedCommandArgs.runApp.asArg())
@@ -221,6 +224,7 @@ class ServeCommand extends Command {
           if (updatePerfetto) SharedCommandArgs.updatePerfetto.asArg(),
           if (useWasm) SharedCommandArgs.wasm.asArg(),
           if (noStripWasm) SharedCommandArgs.noStripWasm.asArg(),
+          if (noMinifyWasm) SharedCommandArgs.noMinifyWasm.asArg(),
           '${SharedCommandArgs.buildMode.asArg()}=$devToolsAppBuildMode',
           SharedCommandArgs.pubGet.asArg(negated: !runPubGet),
         ]),

--- a/tool/lib/commands/shared.dart
+++ b/tool/lib/commands/shared.dart
@@ -84,6 +84,17 @@ extension BuildCommandArgsExtension on ArgParser {
     );
   }
 
+  void addNoMinifyWasmFlag() {
+    addFlag(
+      SharedCommandArgs.noMinifyWasm.flagName,
+      defaultsTo: false,
+      help:
+          'When this flag is present, class names and errors will not be '
+          'truncated. This flag is ignored if the --wasm flag is '
+          'not present.',
+    );
+  }
+
   void addDebugServerFlag() {
     addFlag(
       SharedCommandArgs.debugServer.flagName,
@@ -109,6 +120,7 @@ enum SharedCommandArgs {
   pubGet('pub-get'),
   wasm('wasm'),
   noStripWasm('no-strip-wasm'),
+  noMinifyWasm('no-minify-wasm'),
   runApp('run-app'),
   serveWithDartSdk('serve-with-dart-sdk'),
   updateFlutter('update-flutter'),


### PR DESCRIPTION
In order to better debug WASM-specific errors, disable minification of wasm builds of devtools.

Also adds support for the flag to the local development CLI so that it can be used when debugging wasm locally.

The `--no-minify-wasm` flag was added here:
https://github.com/flutter/flutter/commit/85486ffffc164cc8f7eeeca31603a83b620a088d