### PR TITLE
ServiceExtensionManager: return early... earlier

### DIFF
--- a/packages/devtools_app_shared/lib/src/service/service_extension_manager.dart
+++ b/packages/devtools_app_shared/lib/src/service/service_extension_manager.dart
@@ -309,6 +309,11 @@ final class ServiceExtensionManager with DisposerMixin {
     final expectedValueType =
         extensions.serviceExtensionsAllowlist[name]!.values.first.runtimeType;
 
+    if (isolateRef != _mainIsolate) return false;
+
+    final isolate = await _isolateManager.isolateState(isolateRef).isolate;
+    if (isolateRef != _mainIsolate) return false;
+
     /// Restores the service extension named [name].
     ///
     /// Returns whether isolates in the connected app are prepared for the
@@ -354,11 +359,6 @@ final class ServiceExtensionManager with DisposerMixin {
       }
       return true;
     }
-
-    if (isolateRef != _mainIsolate) return false;
-
-    final isolate = await _isolateManager.isolateState(isolateRef).isolate;
-    if (isolateRef != _mainIsolate) return false;
 
     // Do not try to restore Dart IO extensions for a paused isolate.
     if (extensions.isDartIoExtension(name) &&


### PR DESCRIPTION
I found two little opportunities to be null safe and theoretically avoid creating a local closure.

In the first, we create a local variable, `final mainIsolate`, and then create a large local closure, `callExtension`. _Then_ we check if that local variable is `null`, in order to return early. Moving that check, and one more, above the closure declaration adds three benefits: (1) the variable is promoted to be non-null, (2) the code reads a little easier, grouping these return early checks, and (3) we avoid creating the local closure when we don't need it, potentially saving memory.

The second is very similar to the first.