### PR TITLE
Support --dtd-exposed-uri in dt tool

### DIFF
--- a/tool/lib/commands/serve.dart
+++ b/tool/lib/commands/serve.dart
@@ -19,6 +19,7 @@ const _buildAppFlag = 'build-app';
 // AllowAnythingParser instead of manually passing these args through.
 const _machineFlag = 'machine';
 const _dtdUriFlag = 'dtd-uri';
+const _dtdExposedUriFlag = 'dtd-exposed-uri';
 const _allowEmbeddingFlag = 'allow-embedding';
 
 /// This command builds DevTools in release mode by running the
@@ -102,6 +103,11 @@ class ServeCommand extends Command {
       ..addOption(
         _dtdUriFlag,
         help: 'Sets the dtd uri when starting the devtools server',
+      )
+      ..addOption(
+        _dtdExposedUriFlag,
+        help:
+            'Sets the dtd uri that is exposed to the client when starting the devtools server',
       )
       ..addFlag(
         _allowEmbeddingFlag,


### PR DESCRIPTION
`--dtd-exposed-uri` is a flag supported by the DevTools server but not in `dt serve`. This makes it difficult to run DevTools from source in a web based IDE because Dart-Code will pass this flag and the call to `dt serve` will fail.