### PR TITLE
Tidy up some nits in ServiceConnectionManager

### DIFF
--- a/packages/devtools_app/lib/src/service/service_manager.dart
+++ b/packages/devtools_app/lib/src/service/service_manager.dart
@@ -61,9 +61,8 @@ class ServiceConnectionManager {
       );
   }
 
-  late final ServiceManager<VmServiceWrapper> _serviceManager;
-
   ServiceManager<VmServiceWrapper> get serviceManager => _serviceManager;
+  late final ServiceManager<VmServiceWrapper> _serviceManager;
 
   final vmFlagManager = VmFlagManager();
 


### PR DESCRIPTION
* Make `ServiceConnectionManager.serviceManager`, which is `late final`, private, with a public getter. This is a no-op, but is safer code. See https://dart.dev/effective-dart/design#avoid-public-late-final-fields-without-initializers.
* Make `_errorBadgeManager` public, and remove the public getter, since it is already final.
* Make `flutterViewId` private.
* Remove unused `renderFrameWithRasterStats`.
* Add doc comments.