### PR TITLE
Rework the integration test timeout logic

### DIFF
--- a/packages/devtools_app/integration_test/test/live_connection/app_test.dart
+++ b/packages/devtools_app/integration_test/test/live_connection/app_test.dart
@@ -8,8 +8,6 @@ import 'package:devtools_test/integration_test.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 
-import '../../test_infra/run/_utils.dart';
-
 // To run:
 // dart run integration_test/run_tests.dart --target=integration_test/test/live_connection/app_test.dart
 

--- a/packages/devtools_app/integration_test/test/live_connection/app_test.dart
+++ b/packages/devtools_app/integration_test/test/live_connection/app_test.dart
@@ -25,14 +25,18 @@ void main() {
     await resetHistory();
   });
 
-  testWidgets('connect to app and switch tabs', (tester) async {
-    await pumpAndConnectDevTools(tester, testApp);
+  testWidgets(
+    'connect to app and switch tabs',
+    timeout: const Timeout(Duration(minutes: 2)),
+    (tester) async {
+      await pumpAndConnectDevTools(tester, testApp);
 
-    // For the sake of this test, do not show extension screens by default.
-    preferences.devToolsExtensions.showOnlyEnabledExtensions.value = true;
-    await tester.pumpAndSettle(shortPumpDuration);
+      // For the sake of this test, do not show extension screens by default.
+      preferences.devToolsExtensions.showOnlyEnabledExtensions.value = true;
+      await tester.pumpAndSettle(shortPumpDuration);
 
-    logStatus('verify that we can load each DevTools screen');
-    await navigateThroughDevToolsScreens(tester, connectedToApp: true);
-  });
+      logStatus('verify that we can load each DevTools screen');
+      await navigateThroughDevToolsScreens(tester, connectedToApp: true);
+    },
+  );
 }

--- a/packages/devtools_app/integration_test/test/live_connection/app_test.dart
+++ b/packages/devtools_app/integration_test/test/live_connection/app_test.dart
@@ -8,6 +8,8 @@ import 'package:devtools_test/integration_test.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 
+import '../../test_infra/run/_utils.dart';
+
 // To run:
 // dart run integration_test/run_tests.dart --target=integration_test/test/live_connection/app_test.dart
 
@@ -25,18 +27,16 @@ void main() {
     await resetHistory();
   });
 
-  testWidgets(
-    'connect to app and switch tabs',
-    timeout: const Timeout(Duration(minutes: 2)),
-    (tester) async {
-      await pumpAndConnectDevTools(tester, testApp);
+  testWidgets('connect to app and switch tabs', timeout: shortTimeout, (
+    tester,
+  ) async {
+    await pumpAndConnectDevTools(tester, testApp);
 
-      // For the sake of this test, do not show extension screens by default.
-      preferences.devToolsExtensions.showOnlyEnabledExtensions.value = true;
-      await tester.pumpAndSettle(shortPumpDuration);
+    // For the sake of this test, do not show extension screens by default.
+    preferences.devToolsExtensions.showOnlyEnabledExtensions.value = true;
+    await tester.pumpAndSettle(shortPumpDuration);
 
-      logStatus('verify that we can load each DevTools screen');
-      await navigateThroughDevToolsScreens(tester, connectedToApp: true);
-    },
-  );
+    logStatus('verify that we can load each DevTools screen');
+    await navigateThroughDevToolsScreens(tester, connectedToApp: true);
+  });
 }

--- a/packages/devtools_app/integration_test/test/live_connection/debugger_panel_test.dart
+++ b/packages/devtools_app/integration_test/test/live_connection/debugger_panel_test.dart
@@ -29,7 +29,9 @@ void main() {
     expect(testApp.vmServiceUri, isNotNull);
   });
 
-  testWidgets('Debugger panel', (tester) async {
+  testWidgets('Debugger panel', timeout: const Timeout(Duration(minutes: 4)), (
+    tester,
+  ) async {
     await pumpAndConnectDevTools(tester, testApp);
     await switchToScreen(
       tester,

--- a/packages/devtools_app/integration_test/test/live_connection/debugger_panel_test.dart
+++ b/packages/devtools_app/integration_test/test/live_connection/debugger_panel_test.dart
@@ -13,6 +13,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 
+import '../../test_infra/run/_utils.dart';
+
 // To run the test while connected to a flutter-tester device:
 // dart run integration_test/run_tests.dart --target=integration_test/test/live_connection/debugger_panel_test.dart
 
@@ -29,9 +31,7 @@ void main() {
     expect(testApp.vmServiceUri, isNotNull);
   });
 
-  testWidgets('Debugger panel', timeout: const Timeout(Duration(minutes: 4)), (
-    tester,
-  ) async {
+  testWidgets('Debugger panel', timeout: longTimeout, (tester) async {
     await pumpAndConnectDevTools(tester, testApp);
     await switchToScreen(
       tester,

--- a/packages/devtools_app/integration_test/test/live_connection/debugger_panel_test.dart
+++ b/packages/devtools_app/integration_test/test/live_connection/debugger_panel_test.dart
@@ -13,8 +13,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 
-import '../../test_infra/run/_utils.dart';
-
 // To run the test while connected to a flutter-tester device:
 // dart run integration_test/run_tests.dart --target=integration_test/test/live_connection/debugger_panel_test.dart
 

--- a/packages/devtools_app/integration_test/test/live_connection/devtools_extensions_test.dart
+++ b/packages/devtools_app/integration_test/test/live_connection/devtools_extensions_test.dart
@@ -41,125 +41,129 @@ void main() {
     resetDevToolsExtensionEnabledStates();
   });
 
-  testWidgets('end to end extensions flow', (tester) async {
-    await pumpDevTools(tester);
+  testWidgets(
+    'end to end extensions flow',
+    timeout: const Timeout(Duration(minutes: 3)),
+    (tester) async {
+      await pumpDevTools(tester);
 
-    // TODO(https://github.com/flutter/devtools/issues/9196): re-enable this
-    // test verification once DTD can be started from the integration test
-    // harness.
-    // logStatus(
-    //   'verify static extensions are available before connecting to an app',
-    // );
-    // expect(extensionService.availableExtensions.length, 2);
-    // expect(extensionService.visibleExtensions.length, 2);
-    // await _verifyExtensionsSettingsMenu(tester, [
-    //   ExtensionEnabledState.none, // dart_foo
-    //   ExtensionEnabledState.none, // standalone_extension
-    // ]);
+      // TODO(https://github.com/flutter/devtools/issues/9196): re-enable this
+      // test verification once DTD can be started from the integration test
+      // harness.
+      // logStatus(
+      //   'verify static extensions are available before connecting to an app',
+      // );
+      // expect(extensionService.availableExtensions.length, 2);
+      // expect(extensionService.visibleExtensions.length, 2);
+      // await _verifyExtensionsSettingsMenu(tester, [
+      //   ExtensionEnabledState.none, // dart_foo
+      //   ExtensionEnabledState.none, // standalone_extension
+      // ]);
 
-    await connectToTestApp(tester, testApp);
+      await connectToTestApp(tester, testApp);
 
-    expect(extensionService.availableExtensions.length, 3);
-    expect(extensionService.visibleExtensions.length, 3);
-    await _verifyExtensionsSettingsMenu(tester, [
-      ExtensionEnabledState.none, // dart_foo
-      ExtensionEnabledState.none, // foo
-      ExtensionEnabledState.none, // standalone_extension
-    ], closeMenuWhenDone: false);
+      expect(extensionService.availableExtensions.length, 3);
+      expect(extensionService.visibleExtensions.length, 3);
+      await _verifyExtensionsSettingsMenu(tester, [
+        ExtensionEnabledState.none, // dart_foo
+        ExtensionEnabledState.none, // foo
+        ExtensionEnabledState.none, // standalone_extension
+      ], closeMenuWhenDone: false);
 
-    await _verifyExtensionVisibilitySetting(tester);
+      await _verifyExtensionVisibilitySetting(tester);
 
-    // dart_foo extension.
-    // Enable, test context menu actions, then disable from context menu.
-    await _switchToExtensionScreen(
-      tester,
-      extensionIndex: 0,
-      initialLoad: true,
-    );
-    await _answerEnableExtensionPrompt(tester, enable: true);
-    await _verifyExtensionsSettingsMenu(tester, [
-      ExtensionEnabledState.enabled, // dart_foo
-      ExtensionEnabledState.none, // foo
-      ExtensionEnabledState.none, // standalone_extension
-    ]);
+      // dart_foo extension.
+      // Enable, test context menu actions, then disable from context menu.
+      await _switchToExtensionScreen(
+        tester,
+        extensionIndex: 0,
+        initialLoad: true,
+      );
+      await _answerEnableExtensionPrompt(tester, enable: true);
+      await _verifyExtensionsSettingsMenu(tester, [
+        ExtensionEnabledState.enabled, // dart_foo
+        ExtensionEnabledState.none, // foo
+        ExtensionEnabledState.none, // standalone_extension
+      ]);
 
-    await _verifyContextMenuActionsAndDisable(tester);
+      await _verifyContextMenuActionsAndDisable(tester);
 
-    expect(extensionService.availableExtensions.length, 3);
-    expect(extensionService.visibleExtensions.length, 2);
-    await _verifyExtensionTabVisibility(
-      tester,
-      extensionIndex: 0,
-      visible: false,
-    );
-    await _verifyExtensionsSettingsMenu(tester, [
-      ExtensionEnabledState.disabled, // dart_foo
-      ExtensionEnabledState.none, // foo
-      ExtensionEnabledState.none, // standalone_extension
-    ]);
+      expect(extensionService.availableExtensions.length, 3);
+      expect(extensionService.visibleExtensions.length, 2);
+      await _verifyExtensionTabVisibility(
+        tester,
+        extensionIndex: 0,
+        visible: false,
+      );
+      await _verifyExtensionsSettingsMenu(tester, [
+        ExtensionEnabledState.disabled, // dart_foo
+        ExtensionEnabledState.none, // foo
+        ExtensionEnabledState.none, // standalone_extension
+      ]);
 
-    // foo extension. Hide immediately.
-    await _switchToExtensionScreen(
-      tester,
-      extensionIndex: 1,
-      initialLoad: true,
-    );
-    await _answerEnableExtensionPrompt(tester, enable: false);
+      // foo extension. Hide immediately.
+      await _switchToExtensionScreen(
+        tester,
+        extensionIndex: 1,
+        initialLoad: true,
+      );
+      await _answerEnableExtensionPrompt(tester, enable: false);
 
-    expect(extensionService.availableExtensions.length, 3);
-    expect(extensionService.visibleExtensions.length, 1);
-    await _verifyExtensionTabVisibility(
-      tester,
-      extensionIndex: 1,
-      visible: false,
-    );
-    await _verifyExtensionsSettingsMenu(tester, [
-      ExtensionEnabledState.disabled, // dart_foo
-      ExtensionEnabledState.disabled, // foo
-      ExtensionEnabledState.none, // standalone_extension
-    ]);
+      expect(extensionService.availableExtensions.length, 3);
+      expect(extensionService.visibleExtensions.length, 1);
+      await _verifyExtensionTabVisibility(
+        tester,
+        extensionIndex: 1,
+        visible: false,
+      );
+      await _verifyExtensionsSettingsMenu(tester, [
+        ExtensionEnabledState.disabled, // dart_foo
+        ExtensionEnabledState.disabled, // foo
+        ExtensionEnabledState.none, // standalone_extension
+      ]);
 
-    // Re-enable foo extension from the extensions settings menu.
-    logStatus('verify we can re-enable an extension from the settings menu');
-    await _changeExtensionSetting(tester, extensionIndex: 1, enable: true);
+      // Re-enable foo extension from the extensions settings menu.
+      logStatus('verify we can re-enable an extension from the settings menu');
+      await _changeExtensionSetting(tester, extensionIndex: 1, enable: true);
 
-    expect(extensionService.availableExtensions.length, 3);
-    expect(extensionService.visibleExtensions.length, 2);
-    await _switchToExtensionScreen(tester, extensionIndex: 1);
-    expect(find.byType(EnableExtensionPrompt), findsNothing);
-    expect(find.byType(EmbeddedExtensionView), findsOneWidget);
-    expect(find.byType(HtmlElementView), findsOneWidget);
-    await _verifyExtensionsSettingsMenu(tester, [
-      ExtensionEnabledState.disabled, // dart_foo
-      ExtensionEnabledState.enabled, // foo
-      ExtensionEnabledState.none, // standalone_extension
-    ]);
+      expect(extensionService.availableExtensions.length, 3);
+      expect(extensionService.visibleExtensions.length, 2);
+      await _switchToExtensionScreen(tester, extensionIndex: 1);
+      expect(find.byType(EnableExtensionPrompt), findsNothing);
+      expect(find.byType(EmbeddedExtensionView), findsOneWidget);
+      expect(find.byType(HtmlElementView), findsOneWidget);
+      await _verifyExtensionsSettingsMenu(tester, [
+        ExtensionEnabledState.disabled, // dart_foo
+        ExtensionEnabledState.enabled, // foo
+        ExtensionEnabledState.none, // standalone_extension
+      ]);
 
-    // standalone_extension. Disable directly from settings menu.
-    logStatus(
-      'verify we can disable an extension screen directly from the settings menu',
-    );
-    await _verifyExtensionTabVisibility(
-      tester,
-      extensionIndex: 2,
-      visible: true,
-    );
+      // standalone_extension. Disable directly from settings menu.
+      logStatus(
+        'verify we can disable an extension screen directly from the settings menu',
+      );
+      await _verifyExtensionTabVisibility(
+        tester,
+        extensionIndex: 2,
+        visible: true,
+      );
 
-    logStatus('disable the extension from the settings menu');
-    await _changeExtensionSetting(tester, extensionIndex: 2, enable: false);
-    expect(extensionService.availableExtensions.length, 3);
-    expect(extensionService.visibleExtensions.length, 1);
-    await _verifyExtensionTabVisibility(
-      tester,
-      extensionIndex: 2,
-      visible: false,
-    );
-    await _verifyExtensionsSettingsMenu(tester, [
-      ExtensionEnabledState.disabled, // dart_foo
-      ExtensionEnabledState.enabled, // foo
-      ExtensionEnabledState.disabled, // standalone_extension
-    ]);
-  });
+      logStatus('disable the extension from the settings menu');
+      await _changeExtensionSetting(tester, extensionIndex: 2, enable: false);
+      expect(extensionService.availableExtensions.length, 3);
+      expect(extensionService.visibleExtensions.length, 1);
+      await _verifyExtensionTabVisibility(
+        tester,
+        extensionIndex: 2,
+        visible: false,
+      );
+      await _verifyExtensionsSettingsMenu(tester, [
+        ExtensionEnabledState.disabled, // dart_foo
+        ExtensionEnabledState.enabled, // foo
+        ExtensionEnabledState.disabled, // standalone_extension
+      ]);
+    },
+  );
 }
 
 Future<void> _switchToExtensionScreen(

--- a/packages/devtools_app/integration_test/test/live_connection/devtools_extensions_test.dart
+++ b/packages/devtools_app/integration_test/test/live_connection/devtools_extensions_test.dart
@@ -20,6 +20,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 
+import '../../test_infra/run/_utils.dart';
+
 // To run:
 // dart run integration_test/run_tests.dart --target=integration_test/test/live_connection/devtools_extensions_test.dart
 
@@ -41,129 +43,127 @@ void main() {
     resetDevToolsExtensionEnabledStates();
   });
 
-  testWidgets(
-    'end to end extensions flow',
-    timeout: const Timeout(Duration(minutes: 3)),
-    (tester) async {
-      await pumpDevTools(tester);
+  testWidgets('end to end extensions flow', timeout: mediumTimeout, (
+    tester,
+  ) async {
+    await pumpDevTools(tester);
 
-      // TODO(https://github.com/flutter/devtools/issues/9196): re-enable this
-      // test verification once DTD can be started from the integration test
-      // harness.
-      // logStatus(
-      //   'verify static extensions are available before connecting to an app',
-      // );
-      // expect(extensionService.availableExtensions.length, 2);
-      // expect(extensionService.visibleExtensions.length, 2);
-      // await _verifyExtensionsSettingsMenu(tester, [
-      //   ExtensionEnabledState.none, // dart_foo
-      //   ExtensionEnabledState.none, // standalone_extension
-      // ]);
+    // TODO(https://github.com/flutter/devtools/issues/9196): re-enable this
+    // test verification once DTD can be started from the integration test
+    // harness.
+    // logStatus(
+    //   'verify static extensions are available before connecting to an app',
+    // );
+    // expect(extensionService.availableExtensions.length, 2);
+    // expect(extensionService.visibleExtensions.length, 2);
+    // await _verifyExtensionsSettingsMenu(tester, [
+    //   ExtensionEnabledState.none, // dart_foo
+    //   ExtensionEnabledState.none, // standalone_extension
+    // ]);
 
-      await connectToTestApp(tester, testApp);
+    await connectToTestApp(tester, testApp);
 
-      expect(extensionService.availableExtensions.length, 3);
-      expect(extensionService.visibleExtensions.length, 3);
-      await _verifyExtensionsSettingsMenu(tester, [
-        ExtensionEnabledState.none, // dart_foo
-        ExtensionEnabledState.none, // foo
-        ExtensionEnabledState.none, // standalone_extension
-      ], closeMenuWhenDone: false);
+    expect(extensionService.availableExtensions.length, 3);
+    expect(extensionService.visibleExtensions.length, 3);
+    await _verifyExtensionsSettingsMenu(tester, [
+      ExtensionEnabledState.none, // dart_foo
+      ExtensionEnabledState.none, // foo
+      ExtensionEnabledState.none, // standalone_extension
+    ], closeMenuWhenDone: false);
 
-      await _verifyExtensionVisibilitySetting(tester);
+    await _verifyExtensionVisibilitySetting(tester);
 
-      // dart_foo extension.
-      // Enable, test context menu actions, then disable from context menu.
-      await _switchToExtensionScreen(
-        tester,
-        extensionIndex: 0,
-        initialLoad: true,
-      );
-      await _answerEnableExtensionPrompt(tester, enable: true);
-      await _verifyExtensionsSettingsMenu(tester, [
-        ExtensionEnabledState.enabled, // dart_foo
-        ExtensionEnabledState.none, // foo
-        ExtensionEnabledState.none, // standalone_extension
-      ]);
+    // dart_foo extension.
+    // Enable, test context menu actions, then disable from context menu.
+    await _switchToExtensionScreen(
+      tester,
+      extensionIndex: 0,
+      initialLoad: true,
+    );
+    await _answerEnableExtensionPrompt(tester, enable: true);
+    await _verifyExtensionsSettingsMenu(tester, [
+      ExtensionEnabledState.enabled, // dart_foo
+      ExtensionEnabledState.none, // foo
+      ExtensionEnabledState.none, // standalone_extension
+    ]);
 
-      await _verifyContextMenuActionsAndDisable(tester);
+    await _verifyContextMenuActionsAndDisable(tester);
 
-      expect(extensionService.availableExtensions.length, 3);
-      expect(extensionService.visibleExtensions.length, 2);
-      await _verifyExtensionTabVisibility(
-        tester,
-        extensionIndex: 0,
-        visible: false,
-      );
-      await _verifyExtensionsSettingsMenu(tester, [
-        ExtensionEnabledState.disabled, // dart_foo
-        ExtensionEnabledState.none, // foo
-        ExtensionEnabledState.none, // standalone_extension
-      ]);
+    expect(extensionService.availableExtensions.length, 3);
+    expect(extensionService.visibleExtensions.length, 2);
+    await _verifyExtensionTabVisibility(
+      tester,
+      extensionIndex: 0,
+      visible: false,
+    );
+    await _verifyExtensionsSettingsMenu(tester, [
+      ExtensionEnabledState.disabled, // dart_foo
+      ExtensionEnabledState.none, // foo
+      ExtensionEnabledState.none, // standalone_extension
+    ]);
 
-      // foo extension. Hide immediately.
-      await _switchToExtensionScreen(
-        tester,
-        extensionIndex: 1,
-        initialLoad: true,
-      );
-      await _answerEnableExtensionPrompt(tester, enable: false);
+    // foo extension. Hide immediately.
+    await _switchToExtensionScreen(
+      tester,
+      extensionIndex: 1,
+      initialLoad: true,
+    );
+    await _answerEnableExtensionPrompt(tester, enable: false);
 
-      expect(extensionService.availableExtensions.length, 3);
-      expect(extensionService.visibleExtensions.length, 1);
-      await _verifyExtensionTabVisibility(
-        tester,
-        extensionIndex: 1,
-        visible: false,
-      );
-      await _verifyExtensionsSettingsMenu(tester, [
-        ExtensionEnabledState.disabled, // dart_foo
-        ExtensionEnabledState.disabled, // foo
-        ExtensionEnabledState.none, // standalone_extension
-      ]);
+    expect(extensionService.availableExtensions.length, 3);
+    expect(extensionService.visibleExtensions.length, 1);
+    await _verifyExtensionTabVisibility(
+      tester,
+      extensionIndex: 1,
+      visible: false,
+    );
+    await _verifyExtensionsSettingsMenu(tester, [
+      ExtensionEnabledState.disabled, // dart_foo
+      ExtensionEnabledState.disabled, // foo
+      ExtensionEnabledState.none, // standalone_extension
+    ]);
 
-      // Re-enable foo extension from the extensions settings menu.
-      logStatus('verify we can re-enable an extension from the settings menu');
-      await _changeExtensionSetting(tester, extensionIndex: 1, enable: true);
+    // Re-enable foo extension from the extensions settings menu.
+    logStatus('verify we can re-enable an extension from the settings menu');
+    await _changeExtensionSetting(tester, extensionIndex: 1, enable: true);
 
-      expect(extensionService.availableExtensions.length, 3);
-      expect(extensionService.visibleExtensions.length, 2);
-      await _switchToExtensionScreen(tester, extensionIndex: 1);
-      expect(find.byType(EnableExtensionPrompt), findsNothing);
-      expect(find.byType(EmbeddedExtensionView), findsOneWidget);
-      expect(find.byType(HtmlElementView), findsOneWidget);
-      await _verifyExtensionsSettingsMenu(tester, [
-        ExtensionEnabledState.disabled, // dart_foo
-        ExtensionEnabledState.enabled, // foo
-        ExtensionEnabledState.none, // standalone_extension
-      ]);
+    expect(extensionService.availableExtensions.length, 3);
+    expect(extensionService.visibleExtensions.length, 2);
+    await _switchToExtensionScreen(tester, extensionIndex: 1);
+    expect(find.byType(EnableExtensionPrompt), findsNothing);
+    expect(find.byType(EmbeddedExtensionView), findsOneWidget);
+    expect(find.byType(HtmlElementView), findsOneWidget);
+    await _verifyExtensionsSettingsMenu(tester, [
+      ExtensionEnabledState.disabled, // dart_foo
+      ExtensionEnabledState.enabled, // foo
+      ExtensionEnabledState.none, // standalone_extension
+    ]);
 
-      // standalone_extension. Disable directly from settings menu.
-      logStatus(
-        'verify we can disable an extension screen directly from the settings menu',
-      );
-      await _verifyExtensionTabVisibility(
-        tester,
-        extensionIndex: 2,
-        visible: true,
-      );
+    // standalone_extension. Disable directly from settings menu.
+    logStatus(
+      'verify we can disable an extension screen directly from the settings menu',
+    );
+    await _verifyExtensionTabVisibility(
+      tester,
+      extensionIndex: 2,
+      visible: true,
+    );
 
-      logStatus('disable the extension from the settings menu');
-      await _changeExtensionSetting(tester, extensionIndex: 2, enable: false);
-      expect(extensionService.availableExtensions.length, 3);
-      expect(extensionService.visibleExtensions.length, 1);
-      await _verifyExtensionTabVisibility(
-        tester,
-        extensionIndex: 2,
-        visible: false,
-      );
-      await _verifyExtensionsSettingsMenu(tester, [
-        ExtensionEnabledState.disabled, // dart_foo
-        ExtensionEnabledState.enabled, // foo
-        ExtensionEnabledState.disabled, // standalone_extension
-      ]);
-    },
-  );
+    logStatus('disable the extension from the settings menu');
+    await _changeExtensionSetting(tester, extensionIndex: 2, enable: false);
+    expect(extensionService.availableExtensions.length, 3);
+    expect(extensionService.visibleExtensions.length, 1);
+    await _verifyExtensionTabVisibility(
+      tester,
+      extensionIndex: 2,
+      visible: false,
+    );
+    await _verifyExtensionsSettingsMenu(tester, [
+      ExtensionEnabledState.disabled, // dart_foo
+      ExtensionEnabledState.enabled, // foo
+      ExtensionEnabledState.disabled, // standalone_extension
+    ]);
+  });
 }
 
 Future<void> _switchToExtensionScreen(

--- a/packages/devtools_app/integration_test/test/live_connection/devtools_extensions_test.dart
+++ b/packages/devtools_app/integration_test/test/live_connection/devtools_extensions_test.dart
@@ -20,8 +20,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 
-import '../../test_infra/run/_utils.dart';
-
 // To run:
 // dart run integration_test/run_tests.dart --target=integration_test/test/live_connection/devtools_extensions_test.dart
 

--- a/packages/devtools_app/integration_test/test/live_connection/eval_and_browse_test.dart
+++ b/packages/devtools_app/integration_test/test/live_connection/eval_and_browse_test.dart
@@ -10,7 +10,6 @@ import 'package:devtools_test/integration_test.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 
-import '../../test_infra/run/_utils.dart';
 import 'eval_utils.dart';
 import 'memory_screen_helpers.dart';
 

--- a/packages/devtools_app/integration_test/test/live_connection/eval_and_browse_test.dart
+++ b/packages/devtools_app/integration_test/test/live_connection/eval_and_browse_test.dart
@@ -10,6 +10,7 @@ import 'package:devtools_test/integration_test.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 
+import '../../test_infra/run/_utils.dart';
 import 'eval_utils.dart';
 import 'memory_screen_helpers.dart';
 
@@ -30,34 +31,30 @@ void main() {
     await resetHistory();
   });
 
-  testWidgets(
-    'memory eval and browse',
-    timeout: const Timeout(Duration(minutes: 3)),
-    (tester) async {
-      await pumpAndConnectDevTools(tester, testApp);
+  testWidgets('memory eval and browse', timeout: mediumTimeout, (tester) async {
+    await pumpAndConnectDevTools(tester, testApp);
 
-      final evalTester = EvalTester(tester);
-      await prepareMemoryUI(tester, makeConsoleWider: true);
+    final evalTester = EvalTester(tester);
+    await prepareMemoryUI(tester, makeConsoleWider: true);
 
-      logStatus('test basic evaluation');
-      await testBasicEval(evalTester);
+    logStatus('test basic evaluation');
+    await testBasicEval(evalTester);
 
-      logStatus('test variable assignment');
-      await testAssignment(evalTester);
+    logStatus('test variable assignment');
+    await testAssignment(evalTester);
 
-      logStatus('test dump one instance to console');
-      await _profileOneInstance(evalTester);
+    logStatus('test dump one instance to console');
+    await _profileOneInstance(evalTester);
 
-      logStatus('test dump all instances to console');
-      await _profileAllInstances(evalTester);
+    logStatus('test dump all instances to console');
+    await _profileAllInstances(evalTester);
 
-      logStatus('test take a snapshot');
-      await evalTester.takeSnapshot();
+    logStatus('test take a snapshot');
+    await evalTester.takeSnapshot();
 
-      logStatus('test inbound references are listed on console instance');
-      await _inboundReferencesAreListed(evalTester);
-    },
-  );
+    logStatus('test inbound references are listed on console instance');
+    await _inboundReferencesAreListed(evalTester);
+  });
 }
 
 Future<void> _profileOneInstance(EvalTester tester) async {

--- a/packages/devtools_app/integration_test/test/live_connection/eval_and_browse_test.dart
+++ b/packages/devtools_app/integration_test/test/live_connection/eval_and_browse_test.dart
@@ -30,30 +30,34 @@ void main() {
     await resetHistory();
   });
 
-  testWidgets('memory eval and browse', (tester) async {
-    await pumpAndConnectDevTools(tester, testApp);
+  testWidgets(
+    'memory eval and browse',
+    timeout: const Timeout(Duration(minutes: 3)),
+    (tester) async {
+      await pumpAndConnectDevTools(tester, testApp);
 
-    final evalTester = EvalTester(tester);
-    await prepareMemoryUI(tester, makeConsoleWider: true);
+      final evalTester = EvalTester(tester);
+      await prepareMemoryUI(tester, makeConsoleWider: true);
 
-    logStatus('test basic evaluation');
-    await testBasicEval(evalTester);
+      logStatus('test basic evaluation');
+      await testBasicEval(evalTester);
 
-    logStatus('test variable assignment');
-    await testAssignment(evalTester);
+      logStatus('test variable assignment');
+      await testAssignment(evalTester);
 
-    logStatus('test dump one instance to console');
-    await _profileOneInstance(evalTester);
+      logStatus('test dump one instance to console');
+      await _profileOneInstance(evalTester);
 
-    logStatus('test dump all instances to console');
-    await _profileAllInstances(evalTester);
+      logStatus('test dump all instances to console');
+      await _profileAllInstances(evalTester);
 
-    logStatus('test take a snapshot');
-    await evalTester.takeSnapshot();
+      logStatus('test take a snapshot');
+      await evalTester.takeSnapshot();
 
-    logStatus('test inbound references are listed on console instance');
-    await _inboundReferencesAreListed(evalTester);
-  });
+      logStatus('test inbound references are listed on console instance');
+      await _inboundReferencesAreListed(evalTester);
+    },
+  );
 }
 
 Future<void> _profileOneInstance(EvalTester tester) async {

--- a/packages/devtools_app/integration_test/test/live_connection/eval_and_inspect_test.dart
+++ b/packages/devtools_app/integration_test/test/live_connection/eval_and_inspect_test.dart
@@ -10,7 +10,6 @@ import 'package:devtools_test/integration_test.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 
-import '../../test_infra/run/_utils.dart';
 import 'eval_utils.dart';
 
 // To run the test while connected to a flutter-tester device:

--- a/packages/devtools_app/integration_test/test/live_connection/eval_and_inspect_test.dart
+++ b/packages/devtools_app/integration_test/test/live_connection/eval_and_inspect_test.dart
@@ -32,21 +32,26 @@ void main() {
     await resetHistory();
   });
 
-  testWidgets('eval with scope in inspector window', (tester) async {
-    await pumpAndConnectDevTools(tester, testApp);
+  testWidgets(
+    'eval with scope in inspector window',
+    timeout: const Timeout(Duration(minutes: 3)),
+    (tester) async {
+      await pumpAndConnectDevTools(tester, testApp);
 
-    final evalTester = EvalTester(tester);
-    await evalTester.prepareInspectorUI();
+      final evalTester = EvalTester(tester);
+      await evalTester.prepareInspectorUI();
 
-    logStatus('testing basic evaluation');
-    await testBasicEval(evalTester);
+      logStatus('testing basic evaluation');
+      await testBasicEval(evalTester);
 
-    logStatus('testing variable assignment');
-    await testAssignment(evalTester);
-  });
+      logStatus('testing variable assignment');
+      await testAssignment(evalTester);
+    },
+  );
 
   testWidgets(
     'eval with scope on widget tree node',
+    timeout: const Timeout(Duration(minutes: 3)),
     (tester) async {
       await pumpAndConnectDevTools(tester, testApp);
 

--- a/packages/devtools_app/integration_test/test/live_connection/eval_and_inspect_test.dart
+++ b/packages/devtools_app/integration_test/test/live_connection/eval_and_inspect_test.dart
@@ -10,6 +10,7 @@ import 'package:devtools_test/integration_test.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 
+import '../../test_infra/run/_utils.dart';
 import 'eval_utils.dart';
 
 // To run the test while connected to a flutter-tester device:
@@ -32,26 +33,24 @@ void main() {
     await resetHistory();
   });
 
-  testWidgets(
-    'eval with scope in inspector window',
-    timeout: const Timeout(Duration(minutes: 3)),
-    (tester) async {
-      await pumpAndConnectDevTools(tester, testApp);
+  testWidgets('eval with scope in inspector window', timeout: mediumTimeout, (
+    tester,
+  ) async {
+    await pumpAndConnectDevTools(tester, testApp);
 
-      final evalTester = EvalTester(tester);
-      await evalTester.prepareInspectorUI();
+    final evalTester = EvalTester(tester);
+    await evalTester.prepareInspectorUI();
 
-      logStatus('testing basic evaluation');
-      await testBasicEval(evalTester);
+    logStatus('testing basic evaluation');
+    await testBasicEval(evalTester);
 
-      logStatus('testing variable assignment');
-      await testAssignment(evalTester);
-    },
-  );
+    logStatus('testing variable assignment');
+    await testAssignment(evalTester);
+  });
 
   testWidgets(
     'eval with scope on widget tree node',
-    timeout: const Timeout(Duration(minutes: 3)),
+    timeout: mediumTimeout,
     (tester) async {
       await pumpAndConnectDevTools(tester, testApp);
 

--- a/packages/devtools_app/integration_test/test/live_connection/export_snapshot_test.dart
+++ b/packages/devtools_app/integration_test/test/live_connection/export_snapshot_test.dart
@@ -6,6 +6,7 @@ import 'package:devtools_test/integration_test.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 
+import '../../test_infra/run/_utils.dart';
 import 'memory_screen_helpers.dart';
 
 // To run:
@@ -25,9 +26,7 @@ void main() {
     await resetHistory();
   });
 
-  testWidgets('Export snapshot', timeout: const Timeout(Duration(minutes: 2)), (
-    tester,
-  ) async {
+  testWidgets('Export snapshot', timeout: shortTimeout, (tester) async {
     await pumpAndConnectDevTools(tester, testApp);
     await prepareMemoryUI(tester);
     await takeHeapSnapshot(tester);

--- a/packages/devtools_app/integration_test/test/live_connection/export_snapshot_test.dart
+++ b/packages/devtools_app/integration_test/test/live_connection/export_snapshot_test.dart
@@ -6,7 +6,6 @@ import 'package:devtools_test/integration_test.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 
-import '../../test_infra/run/_utils.dart';
 import 'memory_screen_helpers.dart';
 
 // To run:

--- a/packages/devtools_app/integration_test/test/live_connection/export_snapshot_test.dart
+++ b/packages/devtools_app/integration_test/test/live_connection/export_snapshot_test.dart
@@ -25,7 +25,9 @@ void main() {
     await resetHistory();
   });
 
-  testWidgets('Export snapshot', (tester) async {
+  testWidgets('Export snapshot', timeout: const Timeout(Duration(minutes: 2)), (
+    tester,
+  ) async {
     await pumpAndConnectDevTools(tester, testApp);
     await prepareMemoryUI(tester);
     await takeHeapSnapshot(tester);

--- a/packages/devtools_app/integration_test/test/live_connection/performance_screen_event_recording_test.dart
+++ b/packages/devtools_app/integration_test/test/live_connection/performance_screen_event_recording_test.dart
@@ -11,8 +11,6 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 import 'package:vm_service_protos/vm_service_protos.dart';
 
-import '../../test_infra/run/_utils.dart';
-
 // To run:
 // dart run integration_test/run_tests.dart --target=integration_test/test/live_connection/performance_screen_event_recording_test.dart
 

--- a/packages/devtools_app/integration_test/test/live_connection/performance_screen_event_recording_test.dart
+++ b/packages/devtools_app/integration_test/test/live_connection/performance_screen_event_recording_test.dart
@@ -24,96 +24,102 @@ void main() {
     expect(testApp.vmServiceUri, isNotNull);
   });
 
-  testWidgets('can process and refresh timeline data', (tester) async {
-    await pumpAndConnectDevTools(tester, testApp);
+  testWidgets(
+    'can process and refresh timeline data',
+    timeout: const Timeout(Duration(minutes: 4)),
+    (tester) async {
+      await pumpAndConnectDevTools(tester, testApp);
 
-    logStatus(
-      'Open the Performance screen and switch to the Timeline Events tab',
-    );
+      logStatus(
+        'Open the Performance screen and switch to the Timeline Events tab',
+      );
 
-    await switchToScreen(
-      tester,
-      tabIcon: ScreenMetaData.performance.icon,
-      tabIconAsset: ScreenMetaData.performance.iconAsset,
-      screenId: ScreenMetaData.performance.id,
-    );
-    await tester.pump(safePumpDuration);
+      await switchToScreen(
+        tester,
+        tabIcon: ScreenMetaData.performance.icon,
+        tabIconAsset: ScreenMetaData.performance.iconAsset,
+        screenId: ScreenMetaData.performance.id,
+      );
+      await tester.pump(safePumpDuration);
 
-    await tester.tap(find.widgetWithText(InkWell, 'Timeline Events'));
-    await tester.pumpAndSettle(longPumpDuration);
+      await tester.tap(find.widgetWithText(InkWell, 'Timeline Events'));
+      await tester.pumpAndSettle(longPumpDuration);
 
-    // Find the [PerformanceController] to access its data.
-    final performanceScreenFinder = find.byType(PerformanceScreenBody);
-    expect(performanceScreenFinder, findsOneWidget);
-    final screenState = tester.state<PerformanceScreenBodyState>(
-      performanceScreenFinder,
-    );
-    final performanceController = screenState.controller;
+      // Find the [PerformanceController] to access its data.
+      final performanceScreenFinder = find.byType(PerformanceScreenBody);
+      expect(performanceScreenFinder, findsOneWidget);
+      final screenState = tester.state<PerformanceScreenBodyState>(
+        performanceScreenFinder,
+      );
+      final performanceController = screenState.controller;
 
-    logStatus('Verifying that data is processed upon first load');
-    final initialTrace = Trace.fromBuffer(
-      performanceController.timelineEventsController.fullPerfettoTrace,
-    );
-    final initialTracePacket = List.of(initialTrace.packet, growable: false);
-    final initialTrackDescriptors = initialTracePacket.where(
-      (e) => e.hasTrackDescriptor(),
-    );
-    expect(initialTracePacket, isNotEmpty);
-    expect(initialTrackDescriptors, isNotEmpty);
+      logStatus('Verifying that data is processed upon first load');
+      final initialTrace = Trace.fromBuffer(
+        performanceController.timelineEventsController.fullPerfettoTrace,
+      );
+      final initialTracePacket = List.of(initialTrace.packet, growable: false);
+      final initialTrackDescriptors = initialTracePacket.where(
+        (e) => e.hasTrackDescriptor(),
+      );
+      expect(initialTracePacket, isNotEmpty);
+      expect(initialTrackDescriptors, isNotEmpty);
 
-    final trackEvents = initialTracePacket.where((e) => e.hasTrackEvent());
-    expect(trackEvents, isNotEmpty);
+      final trackEvents = initialTracePacket.where((e) => e.hasTrackEvent());
+      expect(trackEvents, isNotEmpty);
 
-    expect(
-      performanceController
-          .timelineEventsController
-          .perfettoController
-          .processor
-          .uiTrackId,
-      isNotNull,
-      reason: 'Expected uiTrackId to be non-null',
-    );
-    expect(
-      performanceController
-          .timelineEventsController
-          .perfettoController
-          .processor
-          .rasterTrackId,
-      isNotNull,
-      reason: 'Expected rasterTrackId to be non-null',
-    );
-    expect(
-      performanceController
-          .timelineEventsController
-          .perfettoController
-          .processor
-          .frameRangeFromTimelineEvents,
-      isNotNull,
-      reason: 'Expected frameRangeFromTimelineEvents to be non-null',
-    );
+      expect(
+        performanceController
+            .timelineEventsController
+            .perfettoController
+            .processor
+            .uiTrackId,
+        isNotNull,
+        reason: 'Expected uiTrackId to be non-null',
+      );
+      expect(
+        performanceController
+            .timelineEventsController
+            .perfettoController
+            .processor
+            .rasterTrackId,
+        isNotNull,
+        reason: 'Expected rasterTrackId to be non-null',
+      );
+      expect(
+        performanceController
+            .timelineEventsController
+            .perfettoController
+            .processor
+            .frameRangeFromTimelineEvents,
+        isNotNull,
+        reason: 'Expected frameRangeFromTimelineEvents to be non-null',
+      );
 
-    logStatus('toggling the Performance Overlay to trigger new Flutter frames');
-    final performanceOverlayFinder = find.text('Performance Overlay');
-    expect(performanceOverlayFinder, findsOneWidget);
-    await tester.tap(performanceOverlayFinder);
-    await tester.pump(longPumpDuration);
+      logStatus(
+        'toggling the Performance Overlay to trigger new Flutter frames',
+      );
+      final performanceOverlayFinder = find.text('Performance Overlay');
+      expect(performanceOverlayFinder, findsOneWidget);
+      await tester.tap(performanceOverlayFinder);
+      await tester.pump(longPumpDuration);
 
-    logStatus('Refreshing the timeline to load new events');
-    await tester.tap(find.byType(RefreshTimelineEventsButton));
-    await tester.pump(longPumpDuration);
+      logStatus('Refreshing the timeline to load new events');
+      await tester.tap(find.byType(RefreshTimelineEventsButton));
+      await tester.pump(longPumpDuration);
 
-    logStatus('Verifying that we have recorded new events');
-    final refreshedTrace = Trace.fromBuffer(
-      performanceController.timelineEventsController.fullPerfettoTrace,
-    );
-    final refreshedTracePacket = List.of(
-      refreshedTrace.packet,
-      growable: false,
-    );
-    expect(
-      refreshedTracePacket.length,
-      greaterThan(initialTracePacket.length),
-      reason: 'Expected new events to have been recorded, but none were.',
-    );
-  });
+      logStatus('Verifying that we have recorded new events');
+      final refreshedTrace = Trace.fromBuffer(
+        performanceController.timelineEventsController.fullPerfettoTrace,
+      );
+      final refreshedTracePacket = List.of(
+        refreshedTrace.packet,
+        growable: false,
+      );
+      expect(
+        refreshedTracePacket.length,
+        greaterThan(initialTracePacket.length),
+        reason: 'Expected new events to have been recorded, but none were.',
+      );
+    },
+  );
 }

--- a/packages/devtools_app/integration_test/test/live_connection/performance_screen_event_recording_test.dart
+++ b/packages/devtools_app/integration_test/test/live_connection/performance_screen_event_recording_test.dart
@@ -11,6 +11,8 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 import 'package:vm_service_protos/vm_service_protos.dart';
 
+import '../../test_infra/run/_utils.dart';
+
 // To run:
 // dart run integration_test/run_tests.dart --target=integration_test/test/live_connection/performance_screen_event_recording_test.dart
 
@@ -24,102 +26,98 @@ void main() {
     expect(testApp.vmServiceUri, isNotNull);
   });
 
-  testWidgets(
-    'can process and refresh timeline data',
-    timeout: const Timeout(Duration(minutes: 4)),
-    (tester) async {
-      await pumpAndConnectDevTools(tester, testApp);
+  testWidgets('can process and refresh timeline data', timeout: longTimeout, (
+    tester,
+  ) async {
+    await pumpAndConnectDevTools(tester, testApp);
 
-      logStatus(
-        'Open the Performance screen and switch to the Timeline Events tab',
-      );
+    logStatus(
+      'Open the Performance screen and switch to the Timeline Events tab',
+    );
 
-      await switchToScreen(
-        tester,
-        tabIcon: ScreenMetaData.performance.icon,
-        tabIconAsset: ScreenMetaData.performance.iconAsset,
-        screenId: ScreenMetaData.performance.id,
-      );
-      await tester.pump(safePumpDuration);
+    await switchToScreen(
+      tester,
+      tabIcon: ScreenMetaData.performance.icon,
+      tabIconAsset: ScreenMetaData.performance.iconAsset,
+      screenId: ScreenMetaData.performance.id,
+    );
+    await tester.pump(safePumpDuration);
 
-      await tester.tap(find.widgetWithText(InkWell, 'Timeline Events'));
-      await tester.pumpAndSettle(longPumpDuration);
+    await tester.tap(find.widgetWithText(InkWell, 'Timeline Events'));
+    await tester.pumpAndSettle(longPumpDuration);
 
-      // Find the [PerformanceController] to access its data.
-      final performanceScreenFinder = find.byType(PerformanceScreenBody);
-      expect(performanceScreenFinder, findsOneWidget);
-      final screenState = tester.state<PerformanceScreenBodyState>(
-        performanceScreenFinder,
-      );
-      final performanceController = screenState.controller;
+    // Find the [PerformanceController] to access its data.
+    final performanceScreenFinder = find.byType(PerformanceScreenBody);
+    expect(performanceScreenFinder, findsOneWidget);
+    final screenState = tester.state<PerformanceScreenBodyState>(
+      performanceScreenFinder,
+    );
+    final performanceController = screenState.controller;
 
-      logStatus('Verifying that data is processed upon first load');
-      final initialTrace = Trace.fromBuffer(
-        performanceController.timelineEventsController.fullPerfettoTrace,
-      );
-      final initialTracePacket = List.of(initialTrace.packet, growable: false);
-      final initialTrackDescriptors = initialTracePacket.where(
-        (e) => e.hasTrackDescriptor(),
-      );
-      expect(initialTracePacket, isNotEmpty);
-      expect(initialTrackDescriptors, isNotEmpty);
+    logStatus('Verifying that data is processed upon first load');
+    final initialTrace = Trace.fromBuffer(
+      performanceController.timelineEventsController.fullPerfettoTrace,
+    );
+    final initialTracePacket = List.of(initialTrace.packet, growable: false);
+    final initialTrackDescriptors = initialTracePacket.where(
+      (e) => e.hasTrackDescriptor(),
+    );
+    expect(initialTracePacket, isNotEmpty);
+    expect(initialTrackDescriptors, isNotEmpty);
 
-      final trackEvents = initialTracePacket.where((e) => e.hasTrackEvent());
-      expect(trackEvents, isNotEmpty);
+    final trackEvents = initialTracePacket.where((e) => e.hasTrackEvent());
+    expect(trackEvents, isNotEmpty);
 
-      expect(
-        performanceController
-            .timelineEventsController
-            .perfettoController
-            .processor
-            .uiTrackId,
-        isNotNull,
-        reason: 'Expected uiTrackId to be non-null',
-      );
-      expect(
-        performanceController
-            .timelineEventsController
-            .perfettoController
-            .processor
-            .rasterTrackId,
-        isNotNull,
-        reason: 'Expected rasterTrackId to be non-null',
-      );
-      expect(
-        performanceController
-            .timelineEventsController
-            .perfettoController
-            .processor
-            .frameRangeFromTimelineEvents,
-        isNotNull,
-        reason: 'Expected frameRangeFromTimelineEvents to be non-null',
-      );
+    expect(
+      performanceController
+          .timelineEventsController
+          .perfettoController
+          .processor
+          .uiTrackId,
+      isNotNull,
+      reason: 'Expected uiTrackId to be non-null',
+    );
+    expect(
+      performanceController
+          .timelineEventsController
+          .perfettoController
+          .processor
+          .rasterTrackId,
+      isNotNull,
+      reason: 'Expected rasterTrackId to be non-null',
+    );
+    expect(
+      performanceController
+          .timelineEventsController
+          .perfettoController
+          .processor
+          .frameRangeFromTimelineEvents,
+      isNotNull,
+      reason: 'Expected frameRangeFromTimelineEvents to be non-null',
+    );
 
-      logStatus(
-        'toggling the Performance Overlay to trigger new Flutter frames',
-      );
-      final performanceOverlayFinder = find.text('Performance Overlay');
-      expect(performanceOverlayFinder, findsOneWidget);
-      await tester.tap(performanceOverlayFinder);
-      await tester.pump(longPumpDuration);
+    logStatus('toggling the Performance Overlay to trigger new Flutter frames');
+    final performanceOverlayFinder = find.text('Performance Overlay');
+    expect(performanceOverlayFinder, findsOneWidget);
+    await tester.tap(performanceOverlayFinder);
+    await tester.pump(longPumpDuration);
 
-      logStatus('Refreshing the timeline to load new events');
-      await tester.tap(find.byType(RefreshTimelineEventsButton));
-      await tester.pump(longPumpDuration);
+    logStatus('Refreshing the timeline to load new events');
+    await tester.tap(find.byType(RefreshTimelineEventsButton));
+    await tester.pump(longPumpDuration);
 
-      logStatus('Verifying that we have recorded new events');
-      final refreshedTrace = Trace.fromBuffer(
-        performanceController.timelineEventsController.fullPerfettoTrace,
-      );
-      final refreshedTracePacket = List.of(
-        refreshedTrace.packet,
-        growable: false,
-      );
-      expect(
-        refreshedTracePacket.length,
-        greaterThan(initialTracePacket.length),
-        reason: 'Expected new events to have been recorded, but none were.',
-      );
-    },
-  );
+    logStatus('Verifying that we have recorded new events');
+    final refreshedTrace = Trace.fromBuffer(
+      performanceController.timelineEventsController.fullPerfettoTrace,
+    );
+    final refreshedTracePacket = List.of(
+      refreshedTrace.packet,
+      growable: false,
+    );
+    expect(
+      refreshedTracePacket.length,
+      greaterThan(initialTracePacket.length),
+      reason: 'Expected new events to have been recorded, but none were.',
+    );
+  });
 }

--- a/packages/devtools_app/integration_test/test/live_connection/service_connection_test.dart
+++ b/packages/devtools_app/integration_test/test/live_connection/service_connection_test.dart
@@ -10,6 +10,8 @@ import 'package:devtools_test/integration_test.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 
+import '../../test_infra/run/_utils.dart';
+
 // To run:
 // dart run integration_test/run_tests.dart --target=integration_test/test/live_connection/service_connection_test.dart
 
@@ -27,88 +29,83 @@ void main() {
     await resetHistory();
   });
 
-  testWidgets(
-    'initial service connection state',
-    timeout: const Timeout(Duration(minutes: 3)),
-    (tester) async {
-      await pumpAndConnectDevTools(tester, testApp);
+  testWidgets('initial service connection state', timeout: mediumTimeout, (
+    tester,
+  ) async {
+    await pumpAndConnectDevTools(tester, testApp);
 
-      // Await a delay to ensure the service extensions have had a chance to
-      // be called. This delay may be able to be shortened if doing so does
-      // not cause bot flakiness.
-      await tester.pump(longDuration);
+    // Await a delay to ensure the service extensions have had a chance to
+    // be called. This delay may be able to be shortened if doing so does
+    // not cause bot flakiness.
+    await tester.pump(longDuration);
 
-      // Ensure all futures are completed before running checks.
-      await serviceConnection.serviceManager.service!.allFuturesCompleted;
+    // Ensure all futures are completed before running checks.
+    await serviceConnection.serviceManager.service!.allFuturesCompleted;
 
-      logStatus('verify the vm service calls that occur on connect');
-      final vmServiceCallCount =
-          serviceConnection.serviceManager.service!.vmServiceCallCount;
-      expect(
-        // Use a range instead of an exact number because service extension
-        // calls are not consistent. This will still catch any spurious calls
-        // that are unintentionally added at start up.
-        const Range(35, 70).contains(vmServiceCallCount),
-        isTrue,
-        reason:
-            'Unexpected number of vm service calls upon connection: '
-            '$vmServiceCallCount. If this is expected, please update this test '
-            'to the new expected number of calls. Here are the calls for this '
-            'test run:\n ${serviceConnection.serviceManager.service!.vmServiceCalls.toString()}',
+    logStatus('verify the vm service calls that occur on connect');
+    final vmServiceCallCount =
+        serviceConnection.serviceManager.service!.vmServiceCallCount;
+    expect(
+      // Use a range instead of an exact number because service extension
+      // calls are not consistent. This will still catch any spurious calls
+      // that are unintentionally added at start up.
+      const Range(35, 70).contains(vmServiceCallCount),
+      isTrue,
+      reason:
+          'Unexpected number of vm service calls upon connection: '
+          '$vmServiceCallCount. If this is expected, please update this test '
+          'to the new expected number of calls. Here are the calls for this '
+          'test run:\n ${serviceConnection.serviceManager.service!.vmServiceCalls.toString()}',
+    );
+
+    // Check the ordering of the vm service calls we can expect to occur
+    // in a stable order.
+    expect(
+      serviceConnection.serviceManager.service!.vmServiceCalls
+          // Filter out unawaited streamListen calls.
+          .where((call) => call != 'streamListen')
+          .toList()
+          .sublist(0, 8),
+      equals([
+        'getSupportedProtocols',
+        'getVersion',
+        'setFlag',
+        'requirePermissionToResume',
+        'getFlagList',
+        'getDartDevelopmentServiceVersion',
+        'getDartDevelopmentServiceVersion',
+        'getVM',
+      ]),
+      reason:
+          'Unexpected order of vm service calls upon connection. '
+          'Here are the calls for this test run:\n '
+          '${serviceConnection.serviceManager.service!.vmServiceCalls.toString()}',
+    );
+
+    expect(
+      serviceConnection.serviceManager.service!.vmServiceCalls
+          .where((call) => call == 'streamListen')
+          .toList()
+          .length,
+      equals(10),
+    );
+
+    logStatus('verify managers have all been initialized');
+    expect(serviceConnection.serviceManager.serviceExtensionManager, isNotNull);
+    expect(
+      serviceConnection.serviceManager.isolateManager.isolates.value,
+      isNotEmpty,
+    );
+    expect(serviceConnection.vmFlagManager.flags.value, isNotNull);
+
+    final selectedIsolate =
+        serviceConnection.serviceManager.isolateManager.selectedIsolate;
+    if (selectedIsolate.value == null) {
+      await whenValueNonNull(
+        serviceConnection.serviceManager.isolateManager.selectedIsolate,
       );
+    }
 
-      // Check the ordering of the vm service calls we can expect to occur
-      // in a stable order.
-      expect(
-        serviceConnection.serviceManager.service!.vmServiceCalls
-            // Filter out unawaited streamListen calls.
-            .where((call) => call != 'streamListen')
-            .toList()
-            .sublist(0, 8),
-        equals([
-          'getSupportedProtocols',
-          'getVersion',
-          'setFlag',
-          'requirePermissionToResume',
-          'getFlagList',
-          'getDartDevelopmentServiceVersion',
-          'getDartDevelopmentServiceVersion',
-          'getVM',
-        ]),
-        reason:
-            'Unexpected order of vm service calls upon connection. '
-            'Here are the calls for this test run:\n '
-            '${serviceConnection.serviceManager.service!.vmServiceCalls.toString()}',
-      );
-
-      expect(
-        serviceConnection.serviceManager.service!.vmServiceCalls
-            .where((call) => call == 'streamListen')
-            .toList()
-            .length,
-        equals(10),
-      );
-
-      logStatus('verify managers have all been initialized');
-      expect(
-        serviceConnection.serviceManager.serviceExtensionManager,
-        isNotNull,
-      );
-      expect(
-        serviceConnection.serviceManager.isolateManager.isolates.value,
-        isNotEmpty,
-      );
-      expect(serviceConnection.vmFlagManager.flags.value, isNotNull);
-
-      final selectedIsolate =
-          serviceConnection.serviceManager.isolateManager.selectedIsolate;
-      if (selectedIsolate.value == null) {
-        await whenValueNonNull(
-          serviceConnection.serviceManager.isolateManager.selectedIsolate,
-        );
-      }
-
-      await disconnectFromTestApp(tester);
-    },
-  );
+    await disconnectFromTestApp(tester);
+  });
 }

--- a/packages/devtools_app/integration_test/test/live_connection/service_connection_test.dart
+++ b/packages/devtools_app/integration_test/test/live_connection/service_connection_test.dart
@@ -10,8 +10,6 @@ import 'package:devtools_test/integration_test.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 
-import '../../test_infra/run/_utils.dart';
-
 // To run:
 // dart run integration_test/run_tests.dart --target=integration_test/test/live_connection/service_connection_test.dart
 

--- a/packages/devtools_app/integration_test/test/live_connection/service_connection_test.dart
+++ b/packages/devtools_app/integration_test/test/live_connection/service_connection_test.dart
@@ -27,82 +27,88 @@ void main() {
     await resetHistory();
   });
 
-  testWidgets('initial service connection state', (tester) async {
-    await pumpAndConnectDevTools(tester, testApp);
+  testWidgets(
+    'initial service connection state',
+    timeout: const Timeout(Duration(minutes: 3)),
+    (tester) async {
+      await pumpAndConnectDevTools(tester, testApp);
 
-    // Await a delay to ensure the service extensions have had a chance to
-    // be called. This delay may be able to be shortened if doing so does
-    // not cause bot flakiness.
-    await tester.pump(longDuration);
+      // Await a delay to ensure the service extensions have had a chance to
+      // be called. This delay may be able to be shortened if doing so does
+      // not cause bot flakiness.
+      await tester.pump(longDuration);
 
-    // Ensure all futures are completed before running checks.
-    await serviceConnection.serviceManager.service!.allFuturesCompleted;
+      // Ensure all futures are completed before running checks.
+      await serviceConnection.serviceManager.service!.allFuturesCompleted;
 
-    logStatus('verify the vm service calls that occur on connect');
-    final vmServiceCallCount =
-        serviceConnection.serviceManager.service!.vmServiceCallCount;
-    expect(
-      // Use a range instead of an exact number because service extension
-      // calls are not consistent. This will still catch any spurious calls
-      // that are unintentionally added at start up.
-      const Range(35, 70).contains(vmServiceCallCount),
-      isTrue,
-      reason:
-          'Unexpected number of vm service calls upon connection: '
-          '$vmServiceCallCount. If this is expected, please update this test '
-          'to the new expected number of calls. Here are the calls for this '
-          'test run:\n ${serviceConnection.serviceManager.service!.vmServiceCalls.toString()}',
-    );
-
-    // Check the ordering of the vm service calls we can expect to occur
-    // in a stable order.
-    expect(
-      serviceConnection.serviceManager.service!.vmServiceCalls
-          // Filter out unawaited streamListen calls.
-          .where((call) => call != 'streamListen')
-          .toList()
-          .sublist(0, 8),
-      equals([
-        'getSupportedProtocols',
-        'getVersion',
-        'setFlag',
-        'requirePermissionToResume',
-        'getFlagList',
-        'getDartDevelopmentServiceVersion',
-        'getDartDevelopmentServiceVersion',
-        'getVM',
-      ]),
-      reason:
-          'Unexpected order of vm service calls upon connection. '
-          'Here are the calls for this test run:\n '
-          '${serviceConnection.serviceManager.service!.vmServiceCalls.toString()}',
-    );
-
-    expect(
-      serviceConnection.serviceManager.service!.vmServiceCalls
-          .where((call) => call == 'streamListen')
-          .toList()
-          .length,
-      equals(10),
-    );
-
-    logStatus('verify managers have all been initialized');
-    expect(serviceConnection.serviceManager.isolateManager, isNotNull);
-    expect(serviceConnection.serviceManager.serviceExtensionManager, isNotNull);
-    expect(serviceConnection.vmFlagManager, isNotNull);
-    expect(
-      serviceConnection.serviceManager.isolateManager.isolates.value,
-      isNotEmpty,
-    );
-    expect(serviceConnection.vmFlagManager.flags.value, isNotNull);
-
-    if (serviceConnection.serviceManager.isolateManager.selectedIsolate.value ==
-        null) {
-      await whenValueNonNull(
-        serviceConnection.serviceManager.isolateManager.selectedIsolate,
+      logStatus('verify the vm service calls that occur on connect');
+      final vmServiceCallCount =
+          serviceConnection.serviceManager.service!.vmServiceCallCount;
+      expect(
+        // Use a range instead of an exact number because service extension
+        // calls are not consistent. This will still catch any spurious calls
+        // that are unintentionally added at start up.
+        const Range(35, 70).contains(vmServiceCallCount),
+        isTrue,
+        reason:
+            'Unexpected number of vm service calls upon connection: '
+            '$vmServiceCallCount. If this is expected, please update this test '
+            'to the new expected number of calls. Here are the calls for this '
+            'test run:\n ${serviceConnection.serviceManager.service!.vmServiceCalls.toString()}',
       );
-    }
 
-    await disconnectFromTestApp(tester);
-  });
+      // Check the ordering of the vm service calls we can expect to occur
+      // in a stable order.
+      expect(
+        serviceConnection.serviceManager.service!.vmServiceCalls
+            // Filter out unawaited streamListen calls.
+            .where((call) => call != 'streamListen')
+            .toList()
+            .sublist(0, 8),
+        equals([
+          'getSupportedProtocols',
+          'getVersion',
+          'setFlag',
+          'requirePermissionToResume',
+          'getFlagList',
+          'getDartDevelopmentServiceVersion',
+          'getDartDevelopmentServiceVersion',
+          'getVM',
+        ]),
+        reason:
+            'Unexpected order of vm service calls upon connection. '
+            'Here are the calls for this test run:\n '
+            '${serviceConnection.serviceManager.service!.vmServiceCalls.toString()}',
+      );
+
+      expect(
+        serviceConnection.serviceManager.service!.vmServiceCalls
+            .where((call) => call == 'streamListen')
+            .toList()
+            .length,
+        equals(10),
+      );
+
+      logStatus('verify managers have all been initialized');
+      expect(
+        serviceConnection.serviceManager.serviceExtensionManager,
+        isNotNull,
+      );
+      expect(
+        serviceConnection.serviceManager.isolateManager.isolates.value,
+        isNotEmpty,
+      );
+      expect(serviceConnection.vmFlagManager.flags.value, isNotNull);
+
+      final selectedIsolate =
+          serviceConnection.serviceManager.isolateManager.selectedIsolate;
+      if (selectedIsolate.value == null) {
+        await whenValueNonNull(
+          serviceConnection.serviceManager.isolateManager.selectedIsolate,
+        );
+      }
+
+      await disconnectFromTestApp(tester);
+    },
+  );
 }

--- a/packages/devtools_app/integration_test/test/live_connection/service_extensions_test.dart
+++ b/packages/devtools_app/integration_test/test/live_connection/service_extensions_test.dart
@@ -18,6 +18,8 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 import 'package:vm_service/vm_service.dart';
 
+import '../../test_infra/run/_utils.dart';
+
 // To run:
 // dart run integration_test/run_tests.dart --target=integration_test/test/live_connection/service_extensions_test.dart
 
@@ -37,7 +39,7 @@ void main() {
 
   testWidgets(
     'can call services and service extensions',
-    timeout: const Timeout(Duration(minutes: 3)),
+    timeout: mediumTimeout,
     (tester) async {
       await pumpAndConnectDevTools(tester, testApp);
       await tester.pump(longDuration);

--- a/packages/devtools_app/integration_test/test/live_connection/service_extensions_test.dart
+++ b/packages/devtools_app/integration_test/test/live_connection/service_extensions_test.dart
@@ -37,7 +37,7 @@ void main() {
 
   testWidgets(
     'can call services and service extensions',
-
+    timeout: const Timeout(Duration(minutes: 3)),
     (tester) async {
       await pumpAndConnectDevTools(tester, testApp);
       await tester.pump(longDuration);
@@ -75,58 +75,62 @@ void main() {
     skip: true, // https://github.com/flutter/devtools/issues/8107
   );
 
-  testWidgets('loads initial extension states from device', (tester) async {
-    await pumpAndConnectDevTools(tester, testApp);
-    await tester.pump(longDuration);
+  testWidgets(
+    'loads initial extension states from device',
+    timeout: const Timeout(Duration(minutes: 3)),
+    (tester) async {
+      await pumpAndConnectDevTools(tester, testApp);
+      await tester.pump(longDuration);
 
-    // Ensure all futures are completed before running checks.
-    final service = serviceConnection.serviceManager.service!;
-    await service.allFuturesCompleted;
+      // Ensure all futures are completed before running checks.
+      final service = serviceConnection.serviceManager.service!;
+      await service.allFuturesCompleted;
 
-    final serviceExtensionsToEnable = [
-      (extensions.debugPaint.extension, true),
-      (extensions.slowAnimations.extension, 5.0),
-      (extensions.togglePlatformMode.extension, 'iOS'),
-    ];
+      final serviceExtensionsToEnable = [
+        (extensions.debugPaint.extension, true),
+        (extensions.slowAnimations.extension, 5.0),
+        (extensions.togglePlatformMode.extension, 'iOS'),
+      ];
 
-    logStatus('enabling service extensions on the test device');
-    // Enable a service extension of each type (boolean, numeric, string).
-    for (final ext in serviceExtensionsToEnable) {
-      await serviceConnection.serviceManager.serviceExtensionManager
-          .setServiceExtensionState(ext.$1, enabled: true, value: ext.$2);
-    }
+      logStatus('enabling service extensions on the test device');
+      // Enable a service extension of each type (boolean, numeric, string).
+      for (final ext in serviceExtensionsToEnable) {
+        await serviceConnection.serviceManager.serviceExtensionManager
+            .setServiceExtensionState(ext.$1, enabled: true, value: ext.$2);
+      }
 
-    logStatus('disconnecting from the test device');
-    await disconnectFromTestApp(tester);
+      logStatus('disconnecting from the test device');
+      await disconnectFromTestApp(tester);
 
-    for (final ext in serviceExtensionsToEnable) {
-      expect(
-        serviceConnection.serviceManager.serviceExtensionManager
-            .isServiceExtensionAvailable(ext.$1),
-        isFalse,
-      );
-    }
+      for (final ext in serviceExtensionsToEnable) {
+        expect(
+          serviceConnection.serviceManager.serviceExtensionManager
+              .isServiceExtensionAvailable(ext.$1),
+          isFalse,
+        );
+      }
 
-    logStatus('reconnecting to the test device');
-    await connectToTestApp(tester, testApp);
+      logStatus('reconnecting to the test device');
+      await connectToTestApp(tester, testApp);
 
-    logStatus('verify extension states have been restored from the device');
-    for (final ext in serviceExtensionsToEnable) {
-      expect(
-        serviceConnection.serviceManager.serviceExtensionManager
-            .isServiceExtensionAvailable(ext.$1),
-        isTrue,
-        reason: 'Expect ${ext.$1} to be available',
-      );
-      await _verifyExtensionStateInServiceManager(
-        ext.$1,
-        enabled: true,
-        value: ext.$2,
-      );
-    }
+      logStatus('verify extension states have been restored from the device');
+      for (final ext in serviceExtensionsToEnable) {
+        expect(
+          serviceConnection.serviceManager.serviceExtensionManager
+              .isServiceExtensionAvailable(ext.$1),
+          isTrue,
+          reason: 'Expect ${ext.$1} to be available',
+        );
+        await _verifyExtensionStateInServiceManager(
+          ext.$1,
+          enabled: true,
+          value: ext.$2,
+        );
+      }
 
-    await disconnectFromTestApp(tester);
-  });
+      await disconnectFromTestApp(tester);
+    },
+  );
 }
 
 Future<void> _verifyBooleanExtension(WidgetTester tester) async {

--- a/packages/devtools_app/integration_test/test/live_connection/service_extensions_test.dart
+++ b/packages/devtools_app/integration_test/test/live_connection/service_extensions_test.dart
@@ -18,8 +18,6 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 import 'package:vm_service/vm_service.dart';
 
-import '../../test_infra/run/_utils.dart';
-
 // To run:
 // dart run integration_test/run_tests.dart --target=integration_test/test/live_connection/service_extensions_test.dart
 

--- a/packages/devtools_app/integration_test/test/offline/memory_offline_data_test.dart
+++ b/packages/devtools_app/integration_test/test/offline/memory_offline_data_test.dart
@@ -8,34 +8,34 @@ import 'package:devtools_test/test_data.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 
+import '../../test_infra/run/_utils.dart';
+
 // To run:
 // dart run integration_test/run_tests.dart --target=integration_test/test/offline/memory_offline_data_test.dart
 
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
-  testWidgets(
-    'Memory screen can load offline data',
-    timeout: const Timeout(Duration(minutes: 3)),
-    (tester) async {
-      await pumpDevTools(tester);
-      logStatus('1 - pumped devtools');
-      await loadSampleData(tester, memoryFileName);
-      logStatus('2 - loaded sample data');
-      await tester.pumpAndSettle(longPumpDuration);
-      logStatus('3 - pumped and settled');
+  testWidgets('Memory screen can load offline data', timeout: mediumTimeout, (
+    tester,
+  ) async {
+    await pumpDevTools(tester);
+    logStatus('1 - pumped devtools');
+    await loadSampleData(tester, memoryFileName);
+    logStatus('2 - loaded sample data');
+    await tester.pumpAndSettle(longPumpDuration);
+    logStatus('3 - pumped and settled');
 
-      const diffTab = 'Diff Snapshots';
-      const profileTab = 'Profile Memory';
-      const traceTab = 'Trace Instances';
+    const diffTab = 'Diff Snapshots';
+    const profileTab = 'Profile Memory';
+    const traceTab = 'Trace Instances';
 
-      expect(find.text('_MyClass'), findsOneWidget);
-      logStatus('5 - found _MyClass');
+    expect(find.text('_MyClass'), findsOneWidget);
+    logStatus('5 - found _MyClass');
 
-      for (final tab in [diffTab, profileTab, traceTab]) {
-        expect(find.text(tab), findsOneWidget);
-        logStatus('6.$tab - found');
-      }
-    },
-  );
+    for (final tab in [diffTab, profileTab, traceTab]) {
+      expect(find.text(tab), findsOneWidget);
+      logStatus('6.$tab - found');
+    }
+  });
 }

--- a/packages/devtools_app/integration_test/test/offline/memory_offline_data_test.dart
+++ b/packages/devtools_app/integration_test/test/offline/memory_offline_data_test.dart
@@ -14,24 +14,28 @@ import 'package:integration_test/integration_test.dart';
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
-  testWidgets('Memory screen can load offline data', (tester) async {
-    await pumpDevTools(tester);
-    logStatus('1 - pumped devtools');
-    await loadSampleData(tester, memoryFileName);
-    logStatus('2 - loaded sample data');
-    await tester.pumpAndSettle(longPumpDuration);
-    logStatus('3 - pumped and settled');
+  testWidgets(
+    'Memory screen can load offline data',
+    timeout: const Timeout(Duration(minutes: 3)),
+    (tester) async {
+      await pumpDevTools(tester);
+      logStatus('1 - pumped devtools');
+      await loadSampleData(tester, memoryFileName);
+      logStatus('2 - loaded sample data');
+      await tester.pumpAndSettle(longPumpDuration);
+      logStatus('3 - pumped and settled');
 
-    const diffTab = 'Diff Snapshots';
-    const profileTab = 'Profile Memory';
-    const traceTab = 'Trace Instances';
+      const diffTab = 'Diff Snapshots';
+      const profileTab = 'Profile Memory';
+      const traceTab = 'Trace Instances';
 
-    expect(find.text('_MyClass'), findsOneWidget);
-    logStatus('5 - found _MyClass');
+      expect(find.text('_MyClass'), findsOneWidget);
+      logStatus('5 - found _MyClass');
 
-    for (final tab in [diffTab, profileTab, traceTab]) {
-      expect(find.text(tab), findsOneWidget);
-      logStatus('6.$tab - found');
-    }
-  });
+      for (final tab in [diffTab, profileTab, traceTab]) {
+        expect(find.text(tab), findsOneWidget);
+        logStatus('6.$tab - found');
+      }
+    },
+  );
 }

--- a/packages/devtools_app/integration_test/test/offline/memory_offline_data_test.dart
+++ b/packages/devtools_app/integration_test/test/offline/memory_offline_data_test.dart
@@ -8,8 +8,6 @@ import 'package:devtools_test/test_data.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 
-import '../../test_infra/run/_utils.dart';
-
 // To run:
 // dart run integration_test/run_tests.dart --target=integration_test/test/offline/memory_offline_data_test.dart
 

--- a/packages/devtools_app/integration_test/test/offline/perfetto_test.dart
+++ b/packages/devtools_app/integration_test/test/offline/perfetto_test.dart
@@ -19,6 +19,7 @@ void main() {
 
   testWidgets(
     'Perfetto trace viewer loads data and scrolls for Flutter frames',
+    timeout: const Timeout(Duration(minutes: 3)),
     (tester) async {
       await pumpDevTools(tester);
       await loadSampleData(tester, performanceFileName);

--- a/packages/devtools_app/integration_test/test/offline/perfetto_test.dart
+++ b/packages/devtools_app/integration_test/test/offline/perfetto_test.dart
@@ -11,8 +11,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 
-import '../../test_infra/run/_utils.dart';
-
 // To run:
 // dart run integration_test/run_tests.dart --target=integration_test/test/offline/perfetto_test.dart
 

--- a/packages/devtools_app/integration_test/test/offline/perfetto_test.dart
+++ b/packages/devtools_app/integration_test/test/offline/perfetto_test.dart
@@ -11,6 +11,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 
+import '../../test_infra/run/_utils.dart';
+
 // To run:
 // dart run integration_test/run_tests.dart --target=integration_test/test/offline/perfetto_test.dart
 
@@ -19,7 +21,7 @@ void main() {
 
   testWidgets(
     'Perfetto trace viewer loads data and scrolls for Flutter frames',
-    timeout: const Timeout(Duration(minutes: 3)),
+    timeout: mediumTimeout,
     (tester) async {
       await pumpDevTools(tester);
       await loadSampleData(tester, performanceFileName);

--- a/packages/devtools_app/integration_test/test_infra/run/_utils.dart
+++ b/packages/devtools_app/integration_test/test_infra/run/_utils.dart
@@ -4,6 +4,11 @@
 
 // ignore_for_file: avoid_print
 
+/// @docImport 'package:flutter_test/flutter_test.dart';
+library;
+
+import 'package:test/test.dart' show Timeout;
+
 bool debugTestScript = false;
 
 void debugLog(String log) {
@@ -11,3 +16,21 @@ void debugLog(String log) {
     print(log);
   }
 }
+
+/// A timeout for a "short" integration test.
+///
+/// Adjust as needed; this is used to override the 10-minute or infinite timeout
+/// in [testWidgets].
+const Timeout shortTimeout = Timeout(Duration(minutes: 2));
+
+/// A timeout for a "medium" integration test.
+///
+/// Adjust as needed; this is used to override the 10-minute or infinite timeout
+/// in [testWidgets].
+const Timeout mediumTimeout = Timeout(Duration(minutes: 3));
+
+/// A timeout for a "long" integration test.
+///
+/// Adjust as needed; this is used to override the 10-minute or infinite timeout
+/// in [testWidgets].
+const Timeout longTimeout = Timeout(Duration(minutes: 4));

--- a/packages/devtools_app/integration_test/test_infra/run/_utils.dart
+++ b/packages/devtools_app/integration_test/test_infra/run/_utils.dart
@@ -4,11 +4,6 @@
 
 // ignore_for_file: avoid_print
 
-/// @docImport 'package:flutter_test/flutter_test.dart';
-library;
-
-import 'package:test/test.dart' show Timeout;
-
 bool debugTestScript = false;
 
 void debugLog(String log) {
@@ -16,21 +11,3 @@ void debugLog(String log) {
     print(log);
   }
 }
-
-/// A timeout for a "short" integration test.
-///
-/// Adjust as needed; this is used to override the 10-minute or infinite timeout
-/// in [testWidgets].
-const Timeout shortTimeout = Timeout(Duration(minutes: 2));
-
-/// A timeout for a "medium" integration test.
-///
-/// Adjust as needed; this is used to override the 10-minute or infinite timeout
-/// in [testWidgets].
-const Timeout mediumTimeout = Timeout(Duration(minutes: 3));
-
-/// A timeout for a "long" integration test.
-///
-/// Adjust as needed; this is used to override the 10-minute or infinite timeout
-/// in [testWidgets].
-const Timeout longTimeout = Timeout(Duration(minutes: 4));

--- a/packages/devtools_shared/lib/src/test/integration_test_runner.dart
+++ b/packages/devtools_shared/lib/src/test/integration_test_runner.dart
@@ -115,14 +115,12 @@ class IntegrationTestRunner with IOMixin {
       );
 
       bool testTimedOut = false;
-      final timeout = Future.delayed(const Duration(minutes: 8)).then((_) {
+      await process.exitCode.timeout(const Duration(minutes: 8), onTimeout: () {
         testTimedOut = true;
+        // TODO(srawlins): Refactor the retry situation to catch a
+        // TimeoutException, and not recursively call `runTest`.
+        return -1;
       });
-
-      await Future.any([
-        process.exitCode,
-        timeout,
-      ]);
 
       debugLog(
         'shutting down processes because '

--- a/packages/devtools_test/lib/src/integration_test/integration_test_utils.dart
+++ b/packages/devtools_test/lib/src/integration_test/integration_test_utils.dart
@@ -157,3 +157,21 @@ Future<void> verifyScreenshot(
     'last_screenshot': lastScreenshot,
   });
 }
+
+/// A timeout for a "short" integration test.
+///
+/// Adjust as needed; this is used to override the 10-minute or infinite timeout
+/// in [testWidgets].
+const Timeout shortTimeout = Timeout(Duration(minutes: 2));
+
+/// A timeout for a "medium" integration test.
+///
+/// Adjust as needed; this is used to override the 10-minute or infinite timeout
+/// in [testWidgets].
+const Timeout mediumTimeout = Timeout(Duration(minutes: 3));
+
+/// A timeout for a "long" integration test.
+///
+/// Adjust as needed; this is used to override the 10-minute or infinite timeout
+/// in [testWidgets].
+const Timeout longTimeout = Timeout(Duration(minutes: 4));


### PR DESCRIPTION
The 8-minute timeout was being applied to every test, even successful test results.

In this code:

```dart
      await Future.any([
        process.exitCode,
        timeout,
      ]);
```

While this does return the first future that completes, the _process will still wait for any other futures to complete_, including an 8-minute delayed Future.

Additionally, each `testWidgets` call has a timeout, which is either infinite or 10 minutes (according to the docs). Either way, the timeout is longer than the 8-minute timeout, so we need to reduce these too. I chose some timeouts somewhat at random, but I believe conservatively, at 2, 3, or 4 minutes.

This change brings the following GitHub Action times down as follows:

* "macos-latest devtools_app integration-test integration_dart2js - flutter - shard 1/3" - 11m 20s &rarr; 4m 43s
* "macos-latest devtools_app integration-test integration_dart2js - flutter - shard 2/3" - 14m 05s &rarr; 7m 55s
* "macos-latest devtools_app integration-test integration_dart2js - flutter - shard 3/3" - 16m 21s &rarr; 8m 44s
* "macos-latest devtools_app integration-test integration_dart2js - flutter-web - shard 1/2" - 13m 15s &rarr; 5m 58s
* "macos-latest devtools_app integration-test integration_dart2js - flutter-web - shard 2/2" - 12m 46s &rarr; 7m 34s
* "macos-latest devtools_app integration-test integration_dart2js - dart-cli - shard 1/1" - 13m 20s &rarr; 7m 42s
* "windows-latest devtools_app integration-test integration_dart2js - flutter - shard 1/3" - 15m 28s &rarr; 7m 44s
* "windows-latest devtools_app integration-test integration_dart2js - flutter - shard 2/3" - 13m 11s &rarr; 6m 18s
* "windows-latest devtools_app integration-test integration_dart2js - flutter - shard 3/3" - 17m 16s &rarr; 11m 43s
* "windows-latest devtools_app integration-test integration_dart2js - flutter-web - shard 1/2" - 14m 36s &rarr; 8m 30s
* "windows-latest devtools_app integration-test integration_dart2js - flutter-web - shard 2/2" - 14m 10s &rarr; 7m 05s
* "windows-latest devtools_app integration-test integration_dart2js - dart-cli - shard 1/1" - 14m 57s &rarr; 8m 47s
* "ubuntu-latest devtools_extensions integration-test integration_dart2js" - 10m 41s &rarr; 3m 18s
* "windows-latest devtools_extensions integration-test integration_dart2js" - 12m 03s &rarr; 4m 56s