### PR TITLE
Use service extension in networking integration test

### DIFF
--- a/packages/devtools_app/integration_test/test/live_connection/network_screen_test.dart
+++ b/packages/devtools_app/integration_test/test/live_connection/network_screen_test.dart
@@ -10,7 +10,6 @@ import 'package:devtools_app/src/shared/table/table.dart' show DevToolsTable;
 import 'package:devtools_test/helpers.dart';
 import 'package:devtools_test/integration_test.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:http/http.dart' as http;
 import 'package:integration_test/integration_test.dart';
 
 // To run:
@@ -28,62 +27,65 @@ void main() {
 
   tearDown(() async {
     await resetHistory();
-    await http.get(Uri.parse('http://localhost:${testApp.controlPort}/exit/'));
   });
 
-  testWidgets('nnn', (tester) async {
-    await pumpAndConnectDevTools(tester, testApp);
-    await _prepareNetworkScreen(tester);
+  testWidgets(
+    'network screen test',
+    timeout: const Timeout(Duration(minutes: 3)),
+    (tester) async {
+      await pumpAndConnectDevTools(tester, testApp);
+      await _prepareNetworkScreen(tester);
 
-    final helper = _NetworkScreenHelper(tester, testApp.controlPort!);
+      final helper = _NetworkScreenHelper(tester);
 
-    // Instruct the app to make a GET request via the dart:io HttpClient.
-    await helper.triggerRequest('get/');
-    _expectInRequestTable('GET');
-    await helper.clear();
+      // Instruct the app to make a GET request via the dart:io HttpClient.
+      await helper.triggerRequest('get');
+      _expectInRequestTable('GET');
+      await helper.clear();
 
-    // Instruct the app to make a POST request via the dart:io HttpClient.
-    await helper.triggerRequest('post/');
-    _expectInRequestTable('POST');
-    await helper.clear();
+      // Instruct the app to make a POST request via the dart:io HttpClient.
+      await helper.triggerRequest('post');
+      _expectInRequestTable('POST');
+      await helper.clear();
 
-    // Instruct the app to make a PUT request via the dart:io HttpClient.
-    await helper.triggerRequest('put/');
-    _expectInRequestTable('PUT');
-    await helper.clear();
+      // Instruct the app to make a PUT request via the dart:io HttpClient.
+      await helper.triggerRequest('put');
+      _expectInRequestTable('PUT');
+      await helper.clear();
 
-    // Instruct the app to make a DELETE request via the dart:io HttpClient.
-    await helper.triggerRequest('delete/');
-    _expectInRequestTable('DELETE');
-    await helper.clear();
+      // Instruct the app to make a DELETE request via the dart:io HttpClient.
+      await helper.triggerRequest('delete');
+      _expectInRequestTable('DELETE');
+      await helper.clear();
 
-    // Instruct the app to make a GET request via the 'http' package.
-    await helper.triggerRequest('packageHttp/get/');
-    _expectInRequestTable('GET');
-    await helper.clear();
+      // Instruct the app to make a GET request via the 'http' package.
+      await helper.triggerRequest('packageHttpGet');
+      _expectInRequestTable('GET');
+      await helper.clear();
 
-    // Instruct the app to make a POST request via the 'http' package.
-    await helper.triggerRequest('packageHttp/post/');
-    _expectInRequestTable('POST');
-    await helper.clear();
+      // Instruct the app to make a POST request via the 'http' package.
+      await helper.triggerRequest('packageHttpPost');
+      _expectInRequestTable('POST');
+      await helper.clear();
 
-    // Instruct the app to make a GET request via Dio.
-    await helper.triggerRequest('dio/get/');
-    _expectInRequestTable('GET');
-    await helper.clear();
+      // Instruct the app to make a GET request via Dio.
+      await helper.triggerRequest('dioGet');
+      _expectInRequestTable('GET');
+      await helper.clear();
 
-    // Instruct the app to make a POST request via Dio.
-    await helper.triggerRequest('dio/post/');
-    _expectInRequestTable('POST');
-  });
+      // Instruct the app to make a POST request via Dio.
+      await helper.triggerRequest('dioPost');
+      _expectInRequestTable('POST');
+
+      await helper.triggerExit();
+    },
+  );
 }
 
 final class _NetworkScreenHelper {
-  _NetworkScreenHelper(this._tester, this._controlPort);
+  _NetworkScreenHelper(this._tester);
 
   final WidgetTester _tester;
-
-  final int _controlPort;
 
   Future<void> clear() async {
     // Press the 'Clear' button between tests.
@@ -95,8 +97,26 @@ final class _NetworkScreenHelper {
     );
   }
 
-  Future<void> triggerRequest(String path) async {
-    await http.get(Uri.parse('http://localhost:$_controlPort/$path'));
+  Future<void> triggerExit() async {
+    final response = await serviceConnection.serviceManager
+        .callServiceExtensionOnMainIsolate('ext.networking_app.exit');
+    logStatus(response.toString());
+
+    await Future.delayed(const Duration(milliseconds: 200));
+    await _tester.pump(safePumpDuration);
+  }
+
+  Future<void> triggerRequest(
+    String requestType, {
+    bool hasBody = false,
+  }) async {
+    final response = await serviceConnection.serviceManager
+        .callServiceExtensionOnMainIsolate(
+          'ext.networking_app.makeRequest',
+          args: {'requestType': requestType, 'hasBody': hasBody},
+        );
+    logStatus(response.toString());
+
     await Future.delayed(const Duration(milliseconds: 200));
     await _tester.pump(safePumpDuration);
   }

--- a/packages/devtools_app/integration_test/test_infra/run/run_test.dart
+++ b/packages/devtools_app/integration_test/test_infra/run/run_test.dart
@@ -115,10 +115,7 @@ Future<void> runFlutterIntegrationTest(
   // Run the flutter integration test.
   final testRunner = IntegrationTestRunner();
   try {
-    final testArgs = <String, Object?>{
-      if (!offline) 'service_uri': testAppUri,
-      if (testApp is TestDartCliApp) 'control_port': testApp.controlPort,
-    };
+    final testArgs = <String, Object?>{if (!offline) 'service_uri': testAppUri};
     final testTarget = testRunnerArgs.testTarget!;
     debugLog('starting test run for $testTarget');
     await testRunner.run(

--- a/packages/devtools_extensions/lib/src/template/devtools_extension.dart
+++ b/packages/devtools_extensions/lib/src/template/devtools_extension.dart
@@ -89,7 +89,7 @@ T _accessGlobalOrThrow<T>({required String globalName}) {
     throw StateError(
       "'$globalName' has not been initialized yet. You can only access "
       "'$globalName' below the 'DevToolsExtension' widget in the widget "
-      "tree, since it is initialized as part of the 'DevToolsExtension'"
+      "tree, since it is initialized as part of the 'DevToolsExtension' "
       "state's 'initState' lifecycle method.",
     );
   }

--- a/packages/devtools_test/lib/src/integration_test/integration_test_utils.dart
+++ b/packages/devtools_test/lib/src/integration_test/integration_test_utils.dart
@@ -118,15 +118,14 @@ Future<void> disconnectFromTestApp(WidgetTester tester) async {
 }
 
 class TestApp {
-  TestApp._({required this.vmServiceUri, required this.controlPort});
+  TestApp._({required this.vmServiceUri});
 
   factory TestApp._fromJson(Map<String, Object> json) {
     final serviceUri = json[serviceUriKey] as String?;
     if (serviceUri == null) {
       throw Exception('Cannot create a TestApp with a null service uri.');
     }
-    final controlPort = json[controlPortKey] as int?;
-    return TestApp._(vmServiceUri: serviceUri, controlPort: controlPort);
+    return TestApp._(vmServiceUri: serviceUri);
   }
 
   factory TestApp.fromEnvironment() {
@@ -137,11 +136,7 @@ class TestApp {
 
   static const serviceUriKey = 'service_uri';
 
-  static const controlPortKey = 'control_port';
-
   final String vmServiceUri;
-
-  final int? controlPort;
 }
 
 Future<void> verifyScreenshot(


### PR DESCRIPTION
This change is a no-op. We change the communication between the integration test itself and the test app, from an HTTP connection to a VM service extension system. This _vastly_ simplifies the test.

The motivation for this PR is to support a "test app" hot restart, in the integration test. Since this PR is quite large already, I'm saving that for the next PR.