### PR TITLE
Do not autofocus on filter fields 

### DIFF
--- a/packages/devtools_app/lib/src/shared/ui/filter.dart
+++ b/packages/devtools_app/lib/src/shared/ui/filter.dart
@@ -655,7 +655,6 @@ class _StandaloneFilterFieldState<T> extends State<StandaloneFilterField<T>>
             valueListenable: widget.controller.useRegExp,
             builder: (context, useRegExp, _) {
               return DevToolsClearableTextField(
-                autofocus: true,
                 hintText: 'Filter',
                 controller: queryTextFieldController,
                 prefixIcon: widget.controller.settingFilters.isNotEmpty


### PR DESCRIPTION
Fixes https://github.com/flutter/devtools/issues/9320

Prevents the filter field in the Property Editor from stealing focus (see https://github.com/flutter/devtools/issues/8909#issuecomment-3072943262)

The network panel and logging panel are also using the same filter field which can steal focus. This sets `autofocus` to the default value (`false`) for all of them.