### PR TITLE
Decrease ring buffer size to 2^31 - 1 which is wasm limit

### DIFF
--- a/packages/devtools_app/lib/src/screens/performance/panes/timeline_events/timeline_events_controller.dart
+++ b/packages/devtools_app/lib/src/screens/performance/panes/timeline_events/timeline_events_controller.dart
@@ -82,13 +82,12 @@ class TimelineEventsController extends PerformanceFeatureController
   @visibleForTesting
   late final Uint8ListRingBuffer traceRingBuffer;
 
-  /// Size limit in GB for [traceRingBuffer] that determines when traces should
-  /// be removed from the queue.
-  final _traceRingBufferSize = convertBytes(
-    1,
-    from: ByteUnit.gb,
-    to: ByteUnit.byte,
-  ).round() - 1;
+  /// Size limit for [traceRingBuffer] that determines when traces should be
+  /// removed from the queue.
+  ///
+  /// Wasm sets a size limit on byte arrays of int32 max which is specifically
+  /// 1 less than 1 << 31.
+  final _traceRingBufferSize = (1 << 31) - 1;
 
   /// Track events that we have received from the VM, but have not yet
   /// processed.

--- a/packages/devtools_app/lib/src/screens/performance/panes/timeline_events/timeline_events_controller.dart
+++ b/packages/devtools_app/lib/src/screens/performance/panes/timeline_events/timeline_events_controller.dart
@@ -88,7 +88,7 @@ class TimelineEventsController extends PerformanceFeatureController
     1,
     from: ByteUnit.gb,
     to: ByteUnit.byte,
-  ).round();
+  ).round() - 1;
 
   /// Track events that we have received from the VM, but have not yet
   /// processed.


### PR DESCRIPTION
Wasm sets a hard limit of 2^31 - 1 bytes on Uint8Lists:
https://github.com/dart-lang/sdk/blob/main/sdk/lib/_internal/wasm/lib/typed_data.dart#L38

This is 1 more than the value that was previously specified here. When these buffers were reaching their max size this was causing a range check error:
```
RangeError: Invalid value: Not in inclusive range 0..2147483647: 2147483648
```
