### PR TITLE
Don't assume footer is present in _ConsoleOutputState builder.

### DIFF
--- a/packages/devtools_app/lib/src/shared/console/console.dart
+++ b/packages/devtools_app/lib/src/shared/console/console.dart
@@ -211,7 +211,7 @@ class _ConsoleOutputState extends State<_ConsoleOutput>
               // consider constraining a max height.
               Padding(
                 padding: const EdgeInsets.only(top: denseSpacing),
-                child: widget.footer!,
+                child: widget.footer,
               ),
             ],
           ),


### PR DESCRIPTION
Resolves this errors:
```
Null check operator used on a null value
file:///b/s/w/ir/x/w/devtools/packages/devtools_app/lib/src/shared/console/console.dart 214:37 \| build
file:///b/s/w/ir/x/w/rc/flutter/packages/flutter/lib/src/widgets/framework.dart 5824:27 \| build
file:///b/s/w/ir/x/w/rc/flutter/packages/flutter/lib/src/widgets/framework.dart 5875:11 \| performRebuild
file:///b/s/w/ir/x/w/rc/flutter/packages/flutter/lib/src/widgets/framework.dart 5866:11 \| _firstBuild
file:///b/s/w/ir/x/w/rc/flutter/packages/flutter/lib/src/widgets/framework.dart 5692:5 \| mount
```

