### PR TITLE
Remove intermediary JSON conversion from `generateFromCpuSamples`

### DIFF
--- a/packages/devtools_app/lib/src/screens/profiler/cpu_profile_model.dart
+++ b/packages/devtools_app/lib/src/screens/profiler/cpu_profile_model.dart
@@ -1455,8 +1455,7 @@ class _CpuStackFrameGenerator {
           nameParts.insert(0, className);
       }
 
-      nameParts.removeWhere((element) => element == null);
-      return nameParts.join('.');
+      return nameParts.nonNulls.join('.');
     }
     return current.name;
   }

--- a/packages/devtools_app/lib/src/screens/profiler/cpu_profile_model.dart
+++ b/packages/devtools_app/lib/src/screens/profiler/cpu_profile_model.dart
@@ -571,7 +571,7 @@ class CpuProfileData with Serializable {
     // dependant upon.
     //
     // TODO(https://github.com/flutter/devtools/issues/9353): Refactor the
-    // implementation avoid the side effects described above.
+    // implementation to avoid the side effects described above.
     final profileMetaData = _createProfileMetadata(cpuSamples: cpuSamples);
 
     final stackFrames =
@@ -1286,8 +1286,8 @@ class _CpuProfileTimelineTree {
   ) => _timelineTreeExpando[sample];
 
   String id(String isolateId) {
-    // Assertion to guard that the _CpuStackFrameGenerator.generate has been
-    // called before getting the frame ID.
+    // Assertion to guard that _CpuStackFrameGenerator.generate has been called
+    // before getting the frame ID.
     assert(
       frameId != kNoFrameId,
       'Frame ID does not exist, have the stack frames been generated?',

--- a/packages/devtools_app/lib/src/screens/profiler/cpu_profile_model.dart
+++ b/packages/devtools_app/lib/src/screens/profiler/cpu_profile_model.dart
@@ -579,7 +579,6 @@ class CpuProfileData with Serializable {
           isolateId: isolateId,
           cpuSamples: cpuSamples,
           profileMetaData: profileMetaData,
-          buildCodeTree: buildCodeTree,
         ).generate(
           treeRoot: _CpuProfileTimelineTree.fromCpuSamples(
             cpuSamples,
@@ -1335,13 +1334,11 @@ class _CpuStackFrameGenerator {
     required this.isolateId,
     required this.cpuSamples,
     required this.profileMetaData,
-    this.buildCodeTree = false,
   });
 
   final String isolateId;
   final vm_service.CpuSamples cpuSamples;
   final CpuProfileMetaData profileMetaData;
-  final bool buildCodeTree;
 
   final _stackFrames = <String, CpuStackFrame>{};
   final _stackFramesWaitingOnPackageUri = <CpuStackFrame>[];

--- a/packages/devtools_app/pubspec.yaml
+++ b/packages/devtools_app/pubspec.yaml
@@ -61,6 +61,7 @@ dependencies:
 
 dev_dependencies:
   args: ^2.4.2
+  benchmark_harness: ^2.3.1
   build_runner: ^2.5.4
   devtools_test:
     path: ../devtools_test

--- a/packages/devtools_app/test/screens/cpu_profiler/cpu_profile_benchmark_test.dart
+++ b/packages/devtools_app/test/screens/cpu_profiler/cpu_profile_benchmark_test.dart
@@ -35,9 +35,9 @@ void main() {
       final score = await benchmark.measure();
       expect(
         score,
-        lessThan(40000),
+        lessThan(100000),
         reason: 'Exceeded benchmark for run $i: $score',
-      ); // 40 ms
+      );
     }
   });
 }

--- a/packages/devtools_app/test/screens/cpu_profiler/cpu_profile_benchmark_test.dart
+++ b/packages/devtools_app/test/screens/cpu_profiler/cpu_profile_benchmark_test.dart
@@ -1,0 +1,57 @@
+// Copyright 2025 The Flutter Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:benchmark_harness/benchmark_harness.dart';
+import 'package:devtools_app/src/screens/profiler/cpu_profile_model.dart';
+import 'package:devtools_app/src/service/service_manager.dart';
+import 'package:devtools_app_shared/utils.dart';
+import 'package:devtools_test/devtools_test.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:vm_service/vm_service.dart' as vm_service;
+
+void main() {
+  test('GenerateFromCpuSamplesBenchmark Test', () async {
+    final benchmark = GenerateFromCpuSamplesBenchmark();
+    final score = await benchmark.measure();
+
+    expect(score, lessThan(40000)); // 40 ms
+  });
+}
+
+class GenerateFromCpuSamplesBenchmark extends AsyncBenchmarkBase {
+  GenerateFromCpuSamplesBenchmark()
+    : super('CpuProfileData.generateFromCpuSamples');
+
+  late final vm_service.CpuSamples cpuSamples;
+
+  static Future<void> main() async {
+    await GenerateFromCpuSamplesBenchmark().report();
+  }
+
+  @override
+  Future<void> setup() async {
+    setGlobal(
+      ServiceConnectionManager,
+      FakeServiceConnectionManager(
+        service: FakeServiceManager.createFakeService(),
+      ),
+    );
+    final cpuSamplesFile = File(
+      'test/test_infra/test_data/cpu_profiler/cpu_samples.json',
+    );
+    final cpuSamplesJson = jsonDecode(cpuSamplesFile.readAsStringSync());
+    cpuSamples = vm_service.CpuSamples.parse(cpuSamplesJson)!;
+  }
+
+  @override
+  Future<void> run() async {
+    await CpuProfileData.generateFromCpuSamples(
+      isolateId: 'test-isolate',
+      cpuSamples: cpuSamples,
+    );
+  }
+}

--- a/packages/devtools_app/test/screens/cpu_profiler/cpu_profile_model_test.dart
+++ b/packages/devtools_app/test/screens/cpu_profiler/cpu_profile_model_test.dart
@@ -4,7 +4,6 @@
 
 import 'package:devtools_app/src/screens/profiler/cpu_profile_model.dart';
 import 'package:devtools_app/src/service/service_manager.dart';
-import 'package:devtools_app/src/shared/primitives/trace_event.dart';
 import 'package:devtools_app/src/shared/primitives/utils.dart';
 import 'package:devtools_app_shared/utils.dart';
 import 'package:devtools_test/devtools_test.dart';
@@ -430,44 +429,26 @@ void main() {
   });
 
   group('observedSamplePeriod', () {
-    CpuSampleEvent sampleEventWithTimestamp(int timestampMicros) {
-      return CpuSampleEvent.fromJson({
-        CpuProfileData.stackFrameIdKey: '0',
-        ChromeTraceEvent.timestampKey: timestampMicros,
-      });
-    }
-
     test('returns null if less than 100 samples', () {
       expect(observedSamplePeriod([]), isNull);
-      expect(
-        observedSamplePeriod(List.filled(99, sampleEventWithTimestamp(1))),
-        isNull,
-      );
-      expect(
-        observedSamplePeriod(
-          List.generate(100, (i) => sampleEventWithTimestamp(i)),
-        ),
-        1,
-      );
+      expect(observedSamplePeriod(List.filled(99, 1)), isNull);
+      expect(observedSamplePeriod(List.generate(100, (i) => i)), 1);
     });
 
     test('asserts that samples are sorted', () {
       expect(
         () => observedSamplePeriod([
-          sampleEventWithTimestamp(10),
-          sampleEventWithTimestamp(5),
+          10,
+          5,
           // Need at least 100 elements for anything to happen.
-          ...List.filled(100, sampleEventWithTimestamp(1)),
+          ...List.filled(100, 1),
         ]),
         throwsA(isA<AssertionError>()),
       );
     });
 
     test('computes an approximate time difference median', () {
-      final samples = List.generate(
-        100,
-        (i) => sampleEventWithTimestamp(i * i),
-      );
+      final samples = List.generate(100, (i) => i * i);
       // Better to hard code this than rely on computing the median correctly.
       const actualMedianSamplePeriod = 50 * 50 - 49 * 49;
       expect(


### PR DESCRIPTION
Work towards https://github.com/flutter/devtools/issues/7917

Refactors `generateFromCpuSamples` to remove the intermediary JSON conversion step. 

### Before this PR:
`generateFromCpuSamples` went from `vm_service.CpuSamples` -> serialized to JSON -> deserialized to `CpuProfileData`:
- generates a JSON representation of the stack frames (and as a side effect the timeline tree)
    - processes each node in the timeline tree, creates a JSON representation of the stack frame and assigns the frame ID to the node
    - keeps track of any frames missing package URIs
- creates a JSON representation of the trace events
- creates a JSON representation for the trace object, which includes the stack frames and trace events
- does a bulk request for all the missing package URIs and updates the trace object with those URIs
- deserializes the JSON trace object to a CpuProfileData object
    - As part of this, determines the median sample period
    - creates a CpuStackFrame object from the JSON stack frame representation

### With this PR:
`generateFromCpuSamples` goes from `vm_service.CpuSamples` -> `CpuProfileData`
- creates the profile metadata object
   - as part of this, determines the median sample period
- generates the stack frames (and as a side effect the timeline tree)
   - processes each node in the timeline tree, creates a CpuStackFrame for it and assigns the frame ID to the node
   - keeps track of any frames missing package URIs, then at the end does a bulk request for all the missing package URIs and updates the frames with those URIs
- converts the CPU samples to sample events
   - trace events are included in the sample events
- finally, constructs the CpuProfileData object

Note: I filed https://github.com/flutter/devtools/issues/9353 to refactor this method more to avoid side-effects - the call to generate the stack frames creates the timeline tree and assigns frame IDs to every node in the tree. This was true before this change as well. However, I didn't want to change too much at once in this PR.