### PR TITLE
[CPU Profiler] Delete the "Profile app start up" button

### DIFF
--- a/packages/devtools_app/lib/src/screens/profiler/panes/controls/profiler_screen_controls.dart
+++ b/packages/devtools_app/lib/src/screens/profiler/panes/controls/profiler_screen_controls.dart
@@ -7,7 +7,6 @@ import 'package:flutter/material.dart';
 
 import '../../../../shared/analytics/constants.dart' as gac;
 import '../../../../shared/framework/screen.dart';
-import '../../../../shared/globals.dart';
 import '../../../../shared/ui/common_widgets.dart';
 import '../../../../shared/ui/file_import.dart';
 import '../../../../shared/ui/vm_flag_widgets.dart';
@@ -103,25 +102,6 @@ class _SecondaryControls extends StatelessWidget {
     return Row(
       mainAxisAlignment: MainAxisAlignment.end,
       children: [
-        if (serviceConnection
-            .serviceManager
-            .connectedApp!
-            .isFlutterNativeAppNow)
-          GaDevToolsButton(
-            icon: Icons.timer,
-            label: 'Profile app start up',
-            tooltip:
-                'Load all Dart CPU samples that occurred before \n'
-                'the first Flutter frame was drawn (if available)',
-            tooltipPadding: const EdgeInsets.all(denseSpacing),
-            gaScreen: gac.cpuProfiler,
-            gaSelection: gac.CpuProfilerEvents.profileAppStartUp.name,
-            minScreenWidthForText: _profilingControlsMinScreenWidthForText,
-            onPressed: !profilerBusy
-                ? controller.cpuProfilerController.loadAppStartUpProfile
-                : null,
-          ),
-        const SizedBox(width: denseSpacing),
         RefreshButton(
           label: 'Load all CPU samples',
           tooltip:

--- a/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
+++ b/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
@@ -29,7 +29,9 @@ TODO: Remove this section if there are not any general updates.
 
 ## CPU profiler updates
 
-TODO: Remove this section if there are not any general updates.
+- Deleted the "Profile app start up" button in favor of the new Dart/Flutter
+  `--profile-startup` CLI flags. -
+  [#9358](https://github.com/flutter/devtools/pull/9358)
 
 ## Memory updates
 

--- a/packages/devtools_app/test/screens/cpu_profiler/profiler_screen_test.dart
+++ b/packages/devtools_app/test/screens/cpu_profiler/profiler_screen_test.dart
@@ -34,13 +34,6 @@ void main() {
       expect(find.byType(StartStopRecordingButton), findsOneWidget);
       expect(find.byType(ClearButton), findsOneWidget);
       expect(find.text('Load all CPU samples'), findsOneWidget);
-      if (scene
-          .fakeServiceConnection
-          .serviceManager
-          .connectedApp!
-          .isFlutterNativeAppNow) {
-        expect(find.text('Profile app start up'), findsOneWidget);
-      }
       expect(find.byType(CpuSamplingRateDropdown), findsOneWidget);
       expect(find.byType(OpenSaveButtonGroup), findsOneWidget);
       expect(find.byType(ProfileRecordingInstructions), findsOneWidget);


### PR DESCRIPTION
For context: the VM team has learned that the implementation of CPU sample streaming in the VM can sometimes cause it to crash. We have concluded that the best way to proceed is by removing support for CPU sample streaming from the VM. Removing support for CPU sample streaming will mean that DevTools will no longer be able to use that support for its "Profile app start up" feature. We discussed this with @kenzieschmoll, and she approved of the plan to have users pass the `--profile-startup` [Dart CLI flag](https://github.com/dart-lang/sdk/blob/aa8f15fe481bdbfa8d29fecbdd92fe49c28fe46b/runtime/vm/profiler.cc#L68) or [Flutter CLI flag](https://github.com/flutter/flutter/blob/28481edd6b5d979f6a6f9ef5a6f1a75f9b62c75f/packages/flutter_tools/lib/src/commands/run.dart#L173) instead when they want to see startup CPU samples.