### PR TITLE
Include stacktrace when `dt` command fails

### DIFF
--- a/tool/bin/dt.dart
+++ b/tool/bin/dt.dart
@@ -16,13 +16,17 @@ void main(List<String> args) async {
         .whenComplete(sharedStdIn.terminate);
 
     exit(result is int ? result : 0);
-  } catch (e) {
+  } catch (e, st) {
     if (e is UsageException) {
       stderr.writeln('$e');
+      stderr.writeln(st);
+
       // Return an exit code representing a usage error.
       exit(64);
     } else {
       stderr.writeln('$e');
+      stderr.writeln(st);
+
       // Return a general failure exit code.
       exit(1);
     }


### PR DESCRIPTION
Work towards https://github.com/flutter/devtools/issues/9377

Our `dt` commands are failing at a high rate on CI with a segfault error. Currently we are capturing the exception but not the stacktrace. This adds the stacktrace to help debug these failures.
