### PR TITLE
Add `compiler=js` escape hatch to revert to dart2js compilation 

### DIFF
--- a/packages/devtools_app/benchmark/test_infra/common.dart
+++ b/packages/devtools_app/benchmark/test_infra/common.dart
@@ -10,7 +10,7 @@
 /// found" in DevTools.
 const _benchmarkInitialPage = '';
 
-const _wasmQueryParameters = {'wasm': 'true'};
+const _wasmQueryParameters = {'compiler': 'wasm'};
 
 String benchmarkPath({required bool useWasm}) => Uri(
   path: _benchmarkInitialPage,

--- a/packages/devtools_app/lib/src/shared/preferences/preferences.dart
+++ b/packages/devtools_app/lib/src/shared/preferences/preferences.dart
@@ -210,12 +210,6 @@ class PreferencesController extends DisposableController
       defaultsTo: false,
     );
     final queryParams = DevToolsQueryParams.load();
-
-    final jsEnabledFromQueryParams = queryParams.useJs;
-    if (jsEnabledFromQueryParams) {
-      // TODO set in storage as well.
-    }
-
     final enabledFromQueryParams = queryParams.useWasm;
 
     if (enabledFromQueryParams && !kIsWasm) {

--- a/packages/devtools_app/lib/src/shared/preferences/preferences.dart
+++ b/packages/devtools_app/lib/src/shared/preferences/preferences.dart
@@ -171,6 +171,16 @@ class PreferencesController extends DisposableController
 
   Future<void> _initWasmEnabled() async {
     wasmEnabled.value = kIsWasm;
+
+    // If the user forced the dart2js-compiled DevTools via query parameter,
+    // then set the storage value to match. This will persist across multiple
+    // sessions of DevTools.
+    if (DevToolsQueryParams.load().useJs) {
+      safeUnawaited(
+        storage.setValue(_ExperimentPreferences.wasm.storageKey, 'false'),
+      );
+    }
+
     addAutoDisposeListener(wasmEnabled, () async {
       final enabled = wasmEnabled.value;
       _log.fine('preference update (wasmEnabled = $enabled)');
@@ -188,8 +198,8 @@ class PreferencesController extends DisposableController
           'Reloading DevTools for Wasm preference update (enabled = $enabled)',
         );
         updateQueryParameter(
-          DevToolsQueryParams.wasmKey,
-          enabled ? 'true' : null,
+          DevToolsQueryParams.compilerKey,
+          enabled ? 'wasm' : null,
           reload: true,
         );
       }
@@ -200,6 +210,12 @@ class PreferencesController extends DisposableController
       defaultsTo: false,
     );
     final queryParams = DevToolsQueryParams.load();
+
+    final jsEnabledFromQueryParams = queryParams.useJs;
+    if (jsEnabledFromQueryParams) {
+      // TODO set in storage as well.
+    }
+
     final enabledFromQueryParams = queryParams.useWasm;
 
     if (enabledFromQueryParams && !kIsWasm) {
@@ -207,7 +223,7 @@ class PreferencesController extends DisposableController
       // back to JS. We know this because the flutter_bootstrap.js logic always
       // sets the 'wasm' query parameter to 'true' when attempting to load
       // DevTools with wasm. Remove the wasm query parameter and return early.
-      updateQueryParameter(DevToolsQueryParams.wasmKey, null);
+      updateQueryParameter(DevToolsQueryParams.compilerKey, null);
       ga.impression(gac.devToolsMain, gac.jsFallback);
 
       // Do not show the JS fallback notification when embedded in VS Code

--- a/packages/devtools_app/lib/src/shared/primitives/query_parameters.dart
+++ b/packages/devtools_app/lib/src/shared/primitives/query_parameters.dart
@@ -64,7 +64,14 @@ extension type DevToolsQueryParams(Map<String, String?> params) {
 
   /// Whether DevTools should be loaded using dart2wasm + skwasm instead of
   /// dart2js + canvaskit.
-  bool get useWasm => params[wasmKey] == 'true';
+  bool get useWasm => params[compilerKey] == 'wasm';
+
+  /// Whether DevTools should be loaded using dart2js + canvaskit instead of
+  /// dart2wasm + skwasm.
+  ///
+  /// This should only ever be explicitly set by the user if their app fails to
+  /// load using wasm.
+  bool get useJs => params[compilerKey] == 'js';
 
   static const vmServiceUriKey = 'uri';
   static const hideScreensKey = 'hide';
@@ -75,10 +82,14 @@ extension type DevToolsQueryParams(Map<String, String?> params) {
   static const ideKey = 'ide';
   static const ideFeatureKey = 'ideFeature';
 
-  // This query parameter must match the String value in the Flutter bootstrap
-  // logic that is used to select a web renderer. See
-  // devtools/packages/devtools_app/web/flutter_bootstrap.js.
-  static const wasmKey = 'wasm';
+  /// Query parameter key to determine whether to use dart2wasm or dart2js.
+  ///
+  ///  This query parameter must match the String value in the Flutter bootstrap
+  ///  logic that is used to select a web renderer. See
+  /// devtools/packages/devtools_app/web/flutter_bootstrap.js.
+  ///
+  /// Valid values are "js" or "wasm".
+  static const compilerKey = 'compiler';
 
   // TODO(kenz): remove legacy value in May of 2025 when all IDEs are not using
   // these and 12 months have passed to allow users ample upgrade time.


### PR DESCRIPTION
Addresses https://github.com/flutter/devtools/issues/9398

Adds an "escape hatch" that allows a user to force the dart2js-compiled DevTools even when the dart2wasm-compiled DevTools fails to load (see for example https://github.com/flutter/devtools/issues/9118). This "escape hatch" is adding the query parameter `compiler=js` and forcing a reload. 

FYI @mdebbar - I'm trying to figure out a good way to test this (not sure if `integration_test` could be made to work, or if `package:webdriver` is better, or...?) See https://github.com/flutter/devtools/issues/9405. Would love to hear your thoughts if you have any suggestions. Thanks!