### PR TITLE
Fix unsupported devices not showing "Enable x" if there are no other devices

### DIFF
--- a/packages/devtools_app/lib/src/standalone_ui/vs_code/devices.dart
+++ b/packages/devtools_app/lib/src/standalone_ui/vs_code/devices.dart
@@ -41,8 +41,9 @@ class Devices extends StatelessWidget {
       children: [
         Text('Devices', style: theme.textTheme.titleMedium),
         if (supportedDevices.isEmpty)
-          const Text('Connect a device or enable web/desktop platforms.')
-        else
+          const Text('Connect a device or enable a platform'),
+        if (supportedDevices.isNotEmpty ||
+            unsupportedDevicePlatformTypes.isNotEmpty)
           Table(
             defaultVerticalAlignment: TableCellVerticalAlignment.middle,
             children: [


### PR DESCRIPTION
In the list of devices we include devices that are not supported/enabled for the current platform, allowing you to enable them. However, the logic here would skip the entire device table if there are no enabled/supported devices, which would cause nothing to show up if there are none already enabled.

This changes the logic so the table is always shown if there are either kind of device, and only shows the help text if none are enabled.

Fixes https://github.com/Dart-Code/Dart-Code/issues/5661

Before:

<img width="398" height="143" alt="Screenshot 2025-09-08 152214" src="https://github.com/user-attachments/assets/8a590c1c-680f-40ca-b34f-1f5a18853aa1" />

After:

<img width="445" height="174" alt="Screenshot 2025-09-08 152112" src="https://github.com/user-attachments/assets/7f3e394e-f026-43bb-9b44-71d65147f0f8" />
