### PR TITLE
Fix alignment of icons and links in DevTools footer

### DIFF
--- a/packages/devtools_app/lib/src/shared/ui/common_widgets.dart
+++ b/packages/devtools_app/lib/src/shared/ui/common_widgets.dart
@@ -1308,14 +1308,9 @@ class LinkIconLabel extends StatelessWidget {
         children: [
           Icon(icon, size: defaultIconSize, color: color),
           const SizedBox(width: densePadding),
-          Padding(
-            padding: const EdgeInsets.only(bottom: densePadding),
-            child: RichText(
-              text: TextSpan(
-                text: link.display,
-                style: Theme.of(context).linkTextStyle.copyWith(color: color),
-              ),
-            ),
+          Text.rich(
+            TextSpan(text: link.display),
+            style: Theme.of(context).linkTextStyle.copyWith(color: color),
           ),
         ],
       ),


### PR DESCRIPTION
Fixes https://github.com/flutter/devtools/issues/9098

Before:

<img width="627" height="59" alt="image" src="https://github.com/user-attachments/assets/4ffe3478-3c4d-49a8-ae3a-8e7ce04918fe" />


After:


<img width="399" height="39" alt="Screenshot 2025-09-12 at 1 01 11 PM" src="https://github.com/user-attachments/assets/b80897f2-2cdc-49db-be55-3890db817fd9" />

