### PR TITLE
Export dtd.dart in dtd_manager.dart

### DIFF
--- a/packages/devtools_app_shared/CHANGELOG.md
+++ b/packages/devtools_app_shared/CHANGELOG.md
@@ -6,6 +6,7 @@ found in the LICENSE file or at https://developers.google.com/open-source/licens
 ## 0.4.1 (not released)
 * Ignore expected exceptions from the `navigateToCode` extension method.
 * Add `RpcErrorExtension` extension with an `isServiceDisposedError` getter.
+* Export `package:dtd/dtd.dart` from `dtd_manager.dart`.
 
 ## 0.4.0
 * Bump `dtd` dependency to `^4.0.0`.

--- a/packages/devtools_app_shared/lib/src/service/dtd_manager.dart
+++ b/packages/devtools_app_shared/lib/src/service/dtd_manager.dart
@@ -6,6 +6,8 @@ import 'package:dtd/dtd.dart';
 import 'package:flutter/foundation.dart';
 import 'package:logging/logging.dart';
 
+export 'package:dtd/dtd.dart';
+
 final _log = Logger('dtd_manager');
 
 /// Manages a connection to the Dart Tooling Daemon.


### PR DESCRIPTION
Since the DTD services are written as extensions on the `DartToolingDaemon` it is very hard to discover the available methods without having access to the `dtd` package. This change exports `dtd` so that the extension methods are easily accessible without needing to know that they come from the `dtd` package.

*List which issues are fixed by this PR.*

N/A

*Please add a note to `packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md` if your change requires release notes. Otherwise, add the 'release-notes-not-required' label to the PR.*

I don't think this requires release notes there? It probably needs them in the `devtools_app_shared` changelog though.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or there is a reason for not adding tests.