### PR TITLE
Remove unused FakeTicker and FakeTickerProvider

### DIFF
--- a/packages/devtools_app/test/test_infra/utils/rendering_tester.dart
+++ b/packages/devtools_app/test/test_infra/utils/rendering_tester.dart
@@ -369,65 +369,6 @@ class RenderSizedBox extends RenderBox {
   bool hitTestSelf(Offset position) => true;
 }
 
-class FakeTickerProvider implements TickerProvider {
-  @override
-  Ticker createTicker(TickerCallback onTick, [bool disableAnimations = false]) {
-    return FakeTicker();
-  }
-}
-
-class FakeTicker implements Ticker {
-  @override
-  bool muted = false;
-
-  @override
-  void absorbTicker(Ticker originalTicker) {}
-
-  @override
-  String? get debugLabel => null;
-
-  @override
-  bool get isActive => throw UnimplementedError();
-
-  @override
-  bool get isTicking => throw UnimplementedError();
-
-  @override
-  bool get scheduled => throw UnimplementedError();
-
-  @override
-  bool get shouldScheduleTick => throw UnimplementedError();
-
-  @override
-  void dispose() {}
-
-  @override
-  void scheduleTick({bool rescheduling = false}) {}
-
-  @override
-  TickerFuture start() {
-    throw UnimplementedError();
-  }
-
-  @override
-  void stop({bool canceled = false}) {}
-
-  @override
-  void unscheduleTick() {}
-
-  @override
-  String toString({bool debugIncludeStack = false}) => super.toString();
-
-  @override
-  DiagnosticsNode describeForError(String name) {
-    return DiagnosticsProperty<Ticker>(
-      name,
-      this,
-      style: DiagnosticsTreeStyle.errorProperty,
-    );
-  }
-}
-
 class TestClipPaintingContext extends PaintingContext {
   TestClipPaintingContext() : super(ContainerLayer(), Rect.zero);
 


### PR DESCRIPTION
This removes `FakeTicker` and `FakeTickerProvider` from devtools's tests as they are unused.

This change does not require release notes since it only affects devtools's tests.

## Motivation

`FakeTicker` and `FakeTickerProvider` implement `Ticker` and `TickerProvider` respectively. Since the devtools repo is in Flutter's customer tests, this effectively blocks us from adding any new members to `Ticker` and `TickerProvider`.

For example, https://github.com/flutter/flutter/pull/173862 adds a new member to `Ticker`. This caused customer test failures: [link](https://logs.chromium.org/logs/flutter/buildbucket/cr-buildbucket/8701683354292711105/+/u/run_test.dart_for_customer_testing_shard_and_subshard_None/stdout)

```
| Analyzing devtools_app...
|
|   error - test/test_infra/utils/rendering_tester.dart:377:7 - Missing concrete implementations of 'getter class Ticker.forceFrames' and 'setter class Ticker.forceFrames'. Try implementing the missing methods, or make the class abstract. - non_abstract_class_inherits_abstract_member
```

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or there is a reason for not adding tests.


![build.yaml badge]

If you need help, consider asking for help on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/devtools/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[build.yaml badge]: https://github.com/flutter/devtools/actions/workflows/build.yaml/badge.svg
