### PR TITLE
Add basic support for Flutter web applications served with `-d web-server`

### DIFF
--- a/packages/devtools_app_shared/lib/src/service/connected_app.dart
+++ b/packages/devtools_app_shared/lib/src/service/connected_app.dart
@@ -30,6 +30,8 @@ class ConnectedApp {
   static const isRunningOnDartVMKey = 'isRunningOnDartVM';
   static const operatingSystemKey = 'operatingSystem';
   static const flutterVersionKey = 'flutterVersion';
+  static const dwdsChromeDebugProxyDeviceName = 'ChromeDebugProxy';
+  static const dwdsWebSocketDebugProxyDeviceName = 'WebSocketDebugProxy';
 
   final ServiceManager? serviceManager;
 
@@ -102,7 +104,8 @@ class ConnectedApp {
   bool? get isRunningOnDartVM {
     final name = serviceManager!.vm!.name;
     // These are the two possible VM names returned by DWDS.
-    return name != 'ChromeDebugProxy' && name != 'WebSocketDebugProxy';
+    return name != dwdsChromeDebugProxyDeviceName &&
+        name != dwdsWebSocketDebugProxyDeviceName;
   }
 
   Future<bool> get isDartCliApp async =>


### PR DESCRIPTION
Fixes issues where DevTools tries to perform expression evaluation on `dart:io` to determine profile mode status.

The DWDS web socket protocol is used with the web-server device, which allows for a subset of the VM service protocol to be made available when a Chrome debug port is unavailable.