### PR TITLE
Fix benchmark test failures erroneously passing on CI (again)

### DIFF
--- a/packages/devtools_app/benchmark/devtools_benchmarks_test.dart
+++ b/packages/devtools_app/benchmark/devtools_benchmarks_test.dart
@@ -43,7 +43,7 @@ void main() {
         await _runBenchmarks(useWasm: useWasm);
       },
       timeout: const Timeout(Duration(minutes: 15)),
-      retry: 1,
+      retry: 0,
     );
   }
 }


### PR DESCRIPTION
Work towards https://github.com/flutter/devtools/issues/9397

The DevTools benchmark tests are still erroneously passing on commits to master, even after https://github.com/flutter/devtools/pull/9403

My next guess is perhaps our retries are causing a race condition.