### PR TITLE
Add a "copy-to-clipboard may not work" banner

### DIFF
--- a/packages/devtools_app/lib/src/screens/deep_link_validation/deep_links_screen.dart
+++ b/packages/devtools_app/lib/src/screens/deep_link_validation/deep_links_screen.dart
@@ -8,6 +8,7 @@ import '../../shared/analytics/analytics.dart' as ga;
 import '../../shared/analytics/constants.dart' as gac;
 import '../../shared/framework/screen.dart';
 import '../../shared/globals.dart';
+import '../../shared/managers/banner_messages.dart';
 import 'deep_link_list_view.dart';
 import 'deep_links_controller.dart';
 import 'deep_links_model.dart';
@@ -46,6 +47,7 @@ class _DeepLinkPageState extends State<DeepLinkPage> {
     super.initState();
     ga.screen(gac.deeplink);
     controller = screenControllers.lookup<DeepLinksController>();
+    maybePushCopyToClipboardNotWorkingMessage();
   }
 
   @override

--- a/packages/devtools_app/lib/src/screens/dtd/dtd_tools_screen.dart
+++ b/packages/devtools_app/lib/src/screens/dtd/dtd_tools_screen.dart
@@ -12,6 +12,7 @@ import 'package:flutter/material.dart';
 import '../../shared/development_helpers.dart';
 import '../../shared/framework/screen.dart';
 import '../../shared/globals.dart';
+import '../../shared/managers/banner_messages.dart';
 import 'dtd_tools_controller.dart';
 import 'events.dart';
 import 'services.dart';
@@ -80,6 +81,7 @@ class _DtdConnectedViewState extends State<DtdConnectedView> {
     _registeredServicesController = ServicesController();
     _eventsController = EventsController();
     _initForDtdConnection();
+    maybePushCopyToClipboardNotWorkingMessage();
   }
 
   @override

--- a/packages/devtools_app/lib/src/screens/inspector_shared/inspector_screen.dart
+++ b/packages/devtools_app/lib/src/screens/inspector_shared/inspector_screen.dart
@@ -9,6 +9,7 @@ import 'package:flutter/material.dart';
 import '../../shared/feature_flags.dart';
 import '../../shared/framework/screen.dart';
 import '../../shared/globals.dart';
+import '../../shared/managers/banner_messages.dart';
 import '../inspector/inspector_screen_body.dart' as legacy;
 import '../inspector_v2/inspector_screen_body.dart' as v2;
 import 'inspector_screen_controller.dart';
@@ -64,6 +65,7 @@ class _InspectorScreenSwitcherState extends State<InspectorScreenSwitcher>
         );
       },
     );
+    maybePushCopyToClipboardNotWorkingMessage();
   }
 
   @override

--- a/packages/devtools_app/lib/src/screens/logging/logging_screen.dart
+++ b/packages/devtools_app/lib/src/screens/logging/logging_screen.dart
@@ -10,6 +10,7 @@ import '../../shared/analytics/analytics.dart' as ga;
 import '../../shared/analytics/constants.dart' as gac;
 import '../../shared/framework/screen.dart';
 import '../../shared/globals.dart';
+import '../../shared/managers/banner_messages.dart';
 import '../../shared/ui/utils.dart';
 import '_log_details.dart';
 import '_logs_table.dart';
@@ -58,6 +59,7 @@ class _LoggingScreenState extends State<LoggingScreenBody>
     ga.screen(gac.logging);
     controller = screenControllers.lookup<LoggingController>();
     addAutoDisposeListener(controller.filteredData);
+    maybePushCopyToClipboardNotWorkingMessage();
   }
 
   @override

--- a/packages/devtools_app/lib/src/screens/memory/framework/memory_screen.dart
+++ b/packages/devtools_app/lib/src/screens/memory/framework/memory_screen.dart
@@ -9,6 +9,7 @@ import 'package:flutter/material.dart';
 
 import '../../../shared/analytics/analytics.dart' as ga;
 import '../../../shared/framework/screen.dart';
+import '../../../shared/managers/banner_messages.dart';
 import '../../../shared/primitives/listenable.dart';
 import '../panes/diff/controller/diff_pane_controller.dart';
 import '../panes/diff/diff_pane.dart';
@@ -52,6 +53,7 @@ class MemoryScreenBodyState extends State<MemoryScreenBody> {
   void initState() {
     super.initState();
     ga.screen(MemoryScreen.id);
+    maybePushCopyToClipboardNotWorkingMessage();
   }
 
   @override

--- a/packages/devtools_app/lib/src/screens/network/network_screen.dart
+++ b/packages/devtools_app/lib/src/screens/network/network_screen.dart
@@ -19,6 +19,7 @@ import '../../shared/framework/screen.dart';
 import '../../shared/globals.dart';
 import '../../shared/http/curl_command.dart';
 import '../../shared/http/http_request_data.dart';
+import '../../shared/managers/banner_messages.dart';
 import '../../shared/primitives/utils.dart';
 import '../../shared/table/table.dart';
 import '../../shared/table/table_data.dart';
@@ -138,6 +139,7 @@ class _NetworkScreenBodyState extends State<NetworkScreenBody>
     super.initState();
     ga.screen(NetworkScreen.id);
     controller = screenControllers.lookup<NetworkController>();
+    maybePushCopyToClipboardNotWorkingMessage();
   }
 
   @override

--- a/packages/devtools_app/lib/src/screens/profiler/profiler_screen.dart
+++ b/packages/devtools_app/lib/src/screens/profiler/profiler_screen.dart
@@ -91,6 +91,7 @@ class _ProfilerScreenBodyState extends State<ProfilerScreenBody>
         });
       },
     );
+    maybePushCopyToClipboardNotWorkingMessage();
   }
 
   @override

--- a/packages/devtools_app/lib/src/shared/managers/banner_messages.dart
+++ b/packages/devtools_app/lib/src/shared/managers/banner_messages.dart
@@ -15,6 +15,7 @@ import '../analytics/constants.dart' as gac;
 import '../framework/screen.dart';
 import '../globals.dart';
 import '../http/http_service.dart' as http_service;
+import '../primitives/query_parameters.dart';
 import '../primitives/utils.dart';
 import '../ui/common_widgets.dart';
 
@@ -612,6 +613,38 @@ void pushWelcomeToNewInspectorMessage(String screenId) {
 
 void pushWasmWelcomeMessage() {
   bannerMessages.addMessage(WasmWelcomeMessage());
+}
+
+class CopyToClipboardNotWorkingMessage extends BannerWarning {
+  CopyToClipboardNotWorkingMessage()
+    : super(
+        key: const Key('CopyToClipboardNotWorkingMessage'),
+        screenId: universalScreenId,
+        buildTextSpans: (context) => [
+          const TextSpan(
+            text:
+                'Copy-to-clipboard may not work when DevTools is embedded in VS Code. See ',
+          ),
+          GaLinkTextSpan(
+            link: const GaLink(
+              display: 'microsoft/vscode#129178',
+              url: 'https://github.com/microsoft/vscode/issues/129178',
+              gaScreenName: universalScreenId,
+              gaSelectedItemDescription: 'copy-to-clipboard-issue',
+            ),
+            context: context,
+            style: Theme.of(context).warningMessageLinkStyle,
+          ),
+          const TextSpan(text: ' for details.'),
+        ],
+      );
+}
+
+void maybePushCopyToClipboardNotWorkingMessage() {
+  final queryParams = DevToolsQueryParams.load();
+  if (queryParams.embedMode.embedded && queryParams.ide == 'VSCode') {
+    bannerMessages.addMessage(CopyToClipboardNotWorkingMessage());
+  }
 }
 
 extension BannerMessageThemeExtension on ThemeData {


### PR DESCRIPTION
This is work towards https://github.com/flutter/devtools/issues/8190.

Since copy-to-clipboard has issues with VS Code on Mac, one mitigation is to note this with a banner. I added this banner to each individual screen that is available for embedding in VS Code.

Another mitigation is to add copy-to-clipboard buttons, which will be a separate PR.