### PR TITLE
Require analyzer ^8.0.0 in devtools_app

### DIFF
--- a/packages/devtools_app/pubspec.yaml
+++ b/packages/devtools_app/pubspec.yaml
@@ -84,7 +84,7 @@ dependency_overrides:
   # when `stager` allows `source_gen` 3.0.0.
   analyzer: ^8.0.0
   build: ^3.0.0
-  source_gen: ^3.0.0
+  source_gen: ^4.0.0
 
 flutter:
   uses-material-design: true


### PR DESCRIPTION
This is required for some incompatibilities between analyzer 7.7.1 and Dart 3.11-dev.