### PR TITLE
Update release note generation and instructions for the new Flutter website

### DIFF
--- a/packages/devtools_app/lib/src/framework/release_notes.dart
+++ b/packages/devtools_app/lib/src/framework/release_notes.dart
@@ -27,7 +27,7 @@ bool debugTestReleaseNotes = false;
 // To load markdown from a staged flutter website, set this string to the url
 // from the flutter/website PR, which has a GitHub action that automatically
 // stages commits to firebase. Example:
-// https://flutter-docs-prod--pr8928-dt-notes-links-b0b33er1.web.app/tools/devtools/release-notes/release-notes-2.24.0-src.md.
+// https://flutter-docs-prod--pr12652-devtools-release-notes-2-52-3bbb8c0u.web.app/tools/devtools/release-notes/release-notes-2.52.0.md.
 String? _debugReleaseNotesUrl;
 
 const releaseNotesKey = Key('release_notes');

--- a/packages/devtools_app/release_notes/README.md
+++ b/packages/devtools_app/release_notes/README.md
@@ -70,11 +70,10 @@ Clean up the drafted notes on your local `flutter/website` branch and open a PR.
 Once you push up your branch to `flutter/website` and open your PR,
 wait for the `github-actions` bot to stage your changes to Firebase.
 Open the link it comments and navigate to the release notes you want to test.
-Be sure to add `-src.md` to the url to get the raw json.
 The url should look something like:
 
 ```
-https://flutter-docs-prod--pr8928-dt-notes-links-b0b33er1.web.app/tools/devtools/release-notes/release-notes-2.24.0-src.md
+https://flutter-docs-prod--pr12652-devtools-release-notes-2-52-3bbb8c0u.web.app/tools/devtools/release-notes/release-notes-2.52.0.md
 ```
 
 - Copy this url and set `_debugReleaseNotesUrl` in

--- a/tool/lib/commands/release_notes_helper.dart
+++ b/tool/lib/commands/release_notes_helper.dart
@@ -107,27 +107,10 @@ class ReleaseNotesCommand extends Command {
     }
 
     // Write the 'release-notes-<x.y.z>.md' file.
-    File(
-        p.join(
-          websiteReleaseNotesDir.path,
-          'release-notes-$releaseNotesVersion.md',
-        ),
-      )
-      ..createSync()
-      ..writeAsStringSync('''---
-short-title: $releaseNotesVersion release notes
-description: Release notes for Dart and Flutter DevTools version $releaseNotesVersion.
-toc: false
----
-
-{% include ./release-notes-$releaseNotesVersion-src.md %}
-''', flush: true);
-
-    // Create the 'release-notes-<x.y.z>-src.md' file.
-    final releaseNotesSrcMd = File(
+    final releaseNotesMd = File(
       p.join(
         websiteReleaseNotesDir.path,
-        'release-notes-$releaseNotesVersion-src.md',
+        'release-notes-$releaseNotesVersion.md',
       ),
     )..createSync();
 
@@ -159,29 +142,21 @@ toc: false
       }
     }
 
-    // Write the 'release-notes-<x.y.z>-src.md' file, including any updates for
+    final metadataHeader = '''---
+title: DevTools $releaseNotesVersion release notes
+short-title: $releaseNotesVersion release notes
+breadcrumb: $releaseNotesVersion
+toc: false
+---
+
+''';
+
+    // Write the 'release-notes-<x.y.z>.md' file, including any updates for
     // image paths.
-    releaseNotesSrcMd.writeAsStringSync(
-      srcLines.joinWithNewLine(),
+    releaseNotesMd.writeAsStringSync(
+      metadataHeader + srcLines.joinWithNewLine(),
       flush: true,
     );
-
-    // Write the 'devtools_releases.yml' file.
-    final releasesYml = File(
-      p.join(websiteRepoPath, 'src', '_data', 'devtools_releases.yml'),
-    );
-    if (!releasesYml.existsSync()) {
-      throw FileSystemException(
-        'The devtools_releases.yml file does not exist.',
-        releasesYml.path,
-      );
-    }
-    final releasesYmlContent = releasesYml.readAsStringSync().replaceFirst(
-      'releases:',
-      '''releases:
-  - '$releaseNotesVersion\'''',
-    );
-    releasesYml.writeAsStringSync(releasesYmlContent, flush: true);
 
     const firstPartInstructions =
         'Release notes successfully drafted in a local flutter/website branch. '
@@ -192,7 +167,7 @@ toc: false
 $firstPartInstructions
 
 cd $websiteRepoPath;
-code ${releaseNotesSrcMd.absolute.path}
+code ${releaseNotesMd.absolute.path}
 
 Create a PR on the flutter/website repo when you are finished.
 ''');


### PR DESCRIPTION
Fixes https://github.com/flutter/devtools/issues/9513
Fixes https://github.com/flutter/devtools/issues/9510

Now that the Flutter website is using Jaspr, some of the files we were using for the DevTools release notes have been moved. 

This updates our instructions and release generator script to handle the new website architecture. 

- Example PR for previous architecture: https://github.com/flutter/website/pull/12258/files
- Example PR for new architecture: https://github.com/flutter/website/pull/12652/files 
