### PR TITLE
update vm_service_protos package to version 2

### DIFF
--- a/packages/devtools_app/pubspec.yaml
+++ b/packages/devtools_app/pubspec.yaml
@@ -54,7 +54,7 @@ dependencies:
   string_scanner: ^1.4.0
   unified_analytics: ^7.0.0
   vm_service: ^15.0.2
-  vm_service_protos: ^1.0.0
+  vm_service_protos: ^2.0.0
   vm_snapshot_analysis: ^0.7.6
   web: ^1.0.0
   web_socket_channel: ^3.0.0


### PR DESCRIPTION
Update to vm_service_protos version ^2.0.0, this allows us to update protobuf from 3.1.0 -> 4.2.0 (this is only a transitive dep).

Should unlock the fix for https://github.com/flutter/devtools/issues/9534, although we still need a new version of `vm_service_protos` to be published which allows `protobuf` ^5.0.0 (we need 5.1.0 to get the default size increase).

*Please add a note to `packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md` if your change requires release notes. Otherwise, add the 'release-notes-not-required' label to the PR.*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or there is a reason for not adding tests.


![build.yaml badge]

If you need help, consider asking for help on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/devtools/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[build.yaml badge]: https://github.com/flutter/devtools/actions/workflows/build.yaml/badge.svg
