### PR TITLE
Small fix to DevTools release notes generator 

### DIFF
--- a/tool/lib/commands/release_notes_helper.dart
+++ b/tool/lib/commands/release_notes_helper.dart
@@ -146,7 +146,7 @@ class ReleaseNotesCommand extends Command {
 title: DevTools $releaseNotesVersion release notes
 shortTitle: $releaseNotesVersion release notes
 breadcrumb: $releaseNotesVersion
-toc: false
+showToc: false
 ---
 
 ''';


### PR DESCRIPTION
The Flutter website 

1. expects the "short title" key to use camel case not kebab case, e.g. [2.52.0 release notes](https://github.com/flutter/website/blob/d565ff4595952f89fda3c9677d942554358f777d/src/content/tools/devtools/release-notes/release-notes-2.52.0.md?plain=1#L3)
2. expect the "table of contents" key to be `showToc` not `toc`, e.g. [2.52.0 release notes](https://github.com/flutter/website/blob/d565ff4595952f89fda3c9677d942554358f777d/src/content/tools/devtools/release-notes/release-notes-2.52.0.md?plain=1#L5)