### PR TITLE
Delete unused `wasmByDefault` feature flag

### DIFF
--- a/packages/devtools_app/lib/src/shared/feature_flags.dart
+++ b/packages/devtools_app/lib/src/shared/feature_flags.dart
@@ -119,8 +119,7 @@ extension FeatureFlags on Never {
   ///
   /// When adding a new Flutter channel flag, you are responsible for adding it
   /// to this map as well.
-  static final _flutterChannelFlags = <FlutterChannelFeatureFlag>{
-  };
+  static final _flutterChannelFlags = <FlutterChannelFeatureFlag>{};
 
   /// A helper to print the status of all the feature flags.
   static void debugPrintFeatureFlags({ConnectedApp? connectedApp}) {


### PR DESCRIPTION
Fixes https://github.com/flutter/devtools/issues/9575
