### PR TITLE
Minor tidy up extracted from auto-reconnect change

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,4 +2,7 @@
     // Set current working directory to devtools_app.
     "terminal.integrated.cwd": "packages/devtools_app",
     "dart.showTodos": false,
+    "dart.analysisExcludedFolders": [
+        "tool/flutter-sdk"
+    ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -5,7 +5,7 @@
 			"label": "Start DTD on Port 8500",
 			"detail": "Starts a DTD instance running on port 8500",
 			"type": "shell",
-			"command": "${workspaceFolder}/../tool/flutter-sdk/bin/cache/dart-sdk/bin/dart",
+			"command": "${workspaceFolder}/tool/flutter-sdk/bin/cache/dart-sdk/bin/dart",
 			"args": [
 				"tooling-daemon",
 				"--disable-service-auth-codes",

--- a/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
+++ b/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
@@ -15,7 +15,7 @@ To learn more about DevTools, check out the
 
 ## General updates
 
-TODO: Remove this section if there are not any general updates.
+TODO: Remove this section if there are not any updates.
 
 ## Inspector updates
 
@@ -24,11 +24,11 @@ TODO: Remove this section if there are not any general updates.
 
 ## Performance updates
 
-TODO: Remove this section if there are not any general updates.
+TODO: Remove this section if there are not any updates.
 
 ## CPU profiler updates
 
-TODO: Remove this section if there are not any general updates.
+TODO: Remove this section if there are not any updates.
 
 ## Memory updates
 
@@ -37,19 +37,19 @@ TODO: Remove this section if there are not any general updates.
 
 ## Debugger updates
 
-TODO: Remove this section if there are not any general updates.
+TODO: Remove this section if there are not any updates.
 
 ## Network profiler updates
 
-TODO: Remove this section if there are not any general updates.
+TODO: Remove this section if there are not any updates.
 
 ## Logging updates
 
-TODO: Remove this section if there are not any general updates.
+TODO: Remove this section if there are not any updates.
 
 ## App size tool updates
 
-TODO: Remove this section if there are not any general updates.
+TODO: Remove this section if there are not any updates.
 
 ## Deep links tool updates
 
@@ -61,15 +61,15 @@ TODO: Remove this section if there are not any general updates.
 
 ## VS Code Sidebar updates
 
-TODO: Remove this section if there are not any general updates.
+TODO: Remove this section if there are not any updates.
 
 ## DevTools Extension updates
 
-TODO: Remove this section if there are not any general updates.
+TODO: Remove this section if there are not any updates.
 
 ## Advanced developer mode updates
 
-TODO: Remove this section if there are not any general updates.
+TODO: Remove this section if there are not any updates.
 
 ## Full commit history
 

--- a/packages/devtools_app/release_notes/helpers/release_notes_template.md
+++ b/packages/devtools_app/release_notes/helpers/release_notes_template.md
@@ -15,55 +15,55 @@ To learn more about DevTools, check out the
 
 ## General updates
 
-TODO: Remove this section if there are not any general updates.
+TODO: Remove this section if there are not any updates.
 
 ## Inspector updates
 
-TODO: Remove this section if there are not any general updates.
+TODO: Remove this section if there are not any updates.
 
 ## Performance updates
 
-TODO: Remove this section if there are not any general updates.
+TODO: Remove this section if there are not any updates.
 
 ## CPU profiler updates
 
-TODO: Remove this section if there are not any general updates.
+TODO: Remove this section if there are not any updates.
 
 ## Memory updates
 
-TODO: Remove this section if there are not any general updates.
+TODO: Remove this section if there are not any updates.
 
 ## Debugger updates
 
-TODO: Remove this section if there are not any general updates.
+TODO: Remove this section if there are not any updates.
 
 ## Network profiler updates
 
-TODO: Remove this section if there are not any general updates.
+TODO: Remove this section if there are not any updates.
 
 ## Logging updates
 
-TODO: Remove this section if there are not any general updates.
+TODO: Remove this section if there are not any updates.
 
 ## App size tool updates
 
-TODO: Remove this section if there are not any general updates.
+TODO: Remove this section if there are not any updates.
 
 ## Deep links tool updates
 
-TODO: Remove this section if there are not any general updates.
+TODO: Remove this section if there are not any updates.
 
 ## VS Code Sidebar updates
 
-TODO: Remove this section if there are not any general updates.
+TODO: Remove this section if there are not any updates.
 
 ## DevTools Extension updates
 
-TODO: Remove this section if there are not any general updates.
+TODO: Remove this section if there are not any updates.
 
 ## Advanced developer mode updates
 
-TODO: Remove this section if there are not any general updates.
+TODO: Remove this section if there are not any updates.
 
 ## Full commit history
 

--- a/tool/lib/commands/release_notes_helper.dart
+++ b/tool/lib/commands/release_notes_helper.dart
@@ -208,7 +208,7 @@ class _DevToolsReleaseNotes {
 
     // TODO(kenz): one nice polish task could be to remove sections that are
     // empty (i.e. sections that have the line
-    // "TODO: Remove this section if there are not any general updates.").
+    // "TODO: Remove this section if there are not any updates.").
     final srcLines = rawLines.sublist(titleLineIndex);
     final imageLineIndices = <int>{};
     for (int i = 0; i < srcLines.length; i++) {


### PR DESCRIPTION
Some minor changes extracted from https://github.com/flutter/devtools/pull/9587, since that review got quite big and I want to simplify it a bit.

- Exclude nested SDK from being analyzed in VS Code
- Fix path in DTD task (it was correct for inside the `packages` folder but was moved to the root without updating)
- Update release notes + template to not say "general updates" in all sections (when only one of them was general)

