### PR TITLE
Fix `dt serve` command as part of the release process

### DIFF
--- a/tool/lib/commands/serve.dart
+++ b/tool/lib/commands/serve.dart
@@ -154,7 +154,8 @@ class ServeCommand extends Command {
         results[SharedCommandArgs.updatePerfetto.flagName] as bool;
     final useWasm = results[SharedCommandArgs.wasm.flagName] as bool;
     final noStripWasm = results[SharedCommandArgs.noStripWasm.flagName] as bool;
-    final noMinifyWasm = results[SharedCommandArgs.noMinifyWasm.flagName] as bool;
+    final noMinifyWasm =
+        results[SharedCommandArgs.noMinifyWasm.flagName] as bool;
     final runPubGet = results[SharedCommandArgs.pubGet.flagName] as bool;
     final devToolsAppBuildMode =
         results[SharedCommandArgs.buildMode.flagName] as String;
@@ -241,10 +242,10 @@ class ServeCommand extends Command {
       logStatus('completed building DevTools: $devToolsBuildLocation');
     }
 
-    logStatus('running pub get for DDS in the local dart sdk');
+    logStatus('running gclient sync in the local dart sdk');
     await processManager.runProcess(
-      CliCommand.dart(['pub', 'get']),
-      workingDirectory: path.join(localDartSdkLocation, 'pkg', 'dds'),
+      CliCommand.gclient(['sync']),
+      workingDirectory: localDartSdkLocation,
     );
 
     logStatus('serving DevTools with a local devtools server...');

--- a/tool/lib/utils.dart
+++ b/tool/lib/utils.dart
@@ -81,6 +81,14 @@ class CliCommand {
     return CliCommand('git', args, throwOnException: throwOnException);
   }
 
+  /// CliCommand helper for running gclient commands.
+  factory CliCommand.gclient(
+    List<String> args, {
+    bool throwOnException = true,
+  }) {
+    return CliCommand('gclient', args, throwOnException: throwOnException);
+  }
+
   factory CliCommand.tool(List<String> args, {bool throwOnException = true}) {
     var toolPath = Platform.script.toFilePath();
     if (!File(toolPath).existsSync()) {


### PR DESCRIPTION
Fixes https://github.com/flutter/devtools/issues/9602

With the introduction of `perf_witness` (which is currently using [Dart SDK version 3.11.0-edge](https://github.com/dart-lang/sdk/blob/3ebbaf08fb9236023b8f37bb9e9de85a9be8e281/pkg/perf_witness/pubspec.yaml#L9)), running `dt serve` fails with:

```
[serve] running pub get for DDS in the local dart sdk
/Users/elliottbrooks/dev/dart-sdk/sdk/pkg/dds > /Users/elliottbrooks/dev/devtools/tool/flutter-sdk/bin/dart pub get
Resolving dependencies in `/Users/elliottbrooks/dev/dart-sdk/sdk`...
The current Dart SDK version is 3.11.0-285.0.dev.

Because perf_witness requires SDK version ^3.11.0-edge, version solving failed.
ProcessException: Failed with exit code: 1.
```

**Why?**

This is because the `dt serve` command runs `dart pub get` inside the `pkg/dds` directory of the engineer's local Dart SDK.

However, the `dart` executable it uses is from the Flutter version specified in https://github.com/flutter/devtools/blob/b9d7fc1a4119b3d214a77939f9d75b0c0b25d36a/flutter-candidate.txt.

**The fix:**

We shouldn't be running `dart pub get` inside Dart SDK packages, instead we should run `gclient sync` to fetch dependencies.



