### PR TITLE
Fixes to missing or stale dimensions in DevTools analytics

### DIFF
--- a/packages/devtools_app/lib/src/shared/analytics/_analytics_web.dart
+++ b/packages/devtools_app/lib/src/shared/analytics/_analytics_web.dart
@@ -746,7 +746,7 @@ set flutterClientId(String newFlutterClientId) {
   _flutterClientId = newFlutterClientId;
 }
 
-Completer<bool>? _computingDimensionsSucceededCompleter;
+Completer<void>? _computingDimensionsCompleter;
 
 // Computes the running application.
 void _computeUserApplicationCustomGTagData() {
@@ -829,22 +829,19 @@ Future<void> computeFlutterClientId() async {
 }
 
 Future<void> setupDimensions() async {
-  if (_computingDimensionsSucceededCompleter != null) {
-    await _computingDimensionsSucceededCompleter!.future;
-    return;
+  if (_computingDimensionsCompleter != null) {
+    return _computingDimensionsCompleter!.future;
   }
 
-  _computingDimensionsSucceededCompleter = Completer<bool>();
-  bool success = false;
+  _computingDimensionsCompleter = Completer<void>();
   try {
     computeDevToolsCustomGTagsData();
     computeDevToolsQueryParams();
     await computeFlutterClientId();
-    success = true;
   } catch (e, st) {
     _log.warning('Failed to compute dimensions', e, st);
   } finally {
-    _computingDimensionsSucceededCompleter!.complete(success);
+    _computingDimensionsCompleter!.complete();
   }
 }
 


### PR DESCRIPTION
## Fixes https://github.com/flutter/devtools/issues/9622

Fixes a potential race condition in `setupDimensions` where, if it was called twice in a row the first call would set `_computingDimensions = true` and the second call would immediately return, regardless of whether the first call had completed leading to missing data in our analytics.

## Also fixes https://github.com/flutter/devtools/issues/9623:

Removes guards to `setupUserApplicationDimensions` (and `_computeUserApplicationCustomGTagData`, which it calls). This function is called every time the VM service connection changes, therefore we were not re-computing the dimensions for a newly connected app leading to incorrect data in our analytics.

Note: catches errors in both methods so that if setting up our analytics fails in any way we won't crash the app. 