### PR TITLE
Replace pub run with dart run

### DIFF
--- a/packages/devtools_app/test/test_infra/scenes/README.md
+++ b/packages/devtools_app/test/test_infra/scenes/README.md
@@ -8,7 +8,7 @@ run as an application.
 
 To generate scene runners:
 ```
-flutter pub run build_runner build --delete-conflicting-outputs
+dart run build_runner build --delete-conflicting-outputs
 ```
 
 To run:


### PR DESCRIPTION
Following up on https://github.com/dart-lang/pub/issues/4737, this PR replaces deprecated `pub run` commands with `dart run`.