### PR TITLE
Disable failing integration tests

### DIFF
--- a/packages/devtools_app/integration_test/run_tests.dart
+++ b/packages/devtools_app/integration_test/run_tests.dart
@@ -42,6 +42,10 @@ final _disabledTestsForDevice = <String, Set<String>>{
     'devtools_extensions_test.dart',
     // https://github.com/flutter/devtools/issues/9642
     'perfetto_test.dart',
+    // https://github.com/flutter/devtools/issues/9645
+    'app_test.dart',
+    // https://github.com/flutter/devtools/issues/9646
+    'service_extensions_test.dart',
   },
   TestAppDevice.flutterChrome.name: {
     // TODO(https://github.com/flutter/devtools/issues/7145): Figure out why


### PR DESCRIPTION
Work towards https://github.com/flutter/devtools/issues/9643

Temporarily disables the integration tests that have begun failing so that we can fix them.
