### PR TITLE
Prepare `devtools_app_shared` and `devtools_extensions` for publishing to 0.5.0

### DIFF
--- a/packages/devtools_app_shared/CHANGELOG.md
+++ b/packages/devtools_app_shared/CHANGELOG.md
@@ -3,9 +3,22 @@ Copyright 2025 The Flutter Authors
 Use of this source code is governed by a BSD-style license that can be
 found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
 -->
-## 0.4.1 (not released)
+## 0.5.0
+* **Breaking change:** remove `scaleByFontFactor`.
+* **Breaking change:** remove `IdeTheme.fontSize` and `IdeTheme.fontSizeFactor`.
+* **Breaking change:** replace `minScreenWidthForTextBeforeScaling` with `minScreenWidthForText`.
+* **Breaking change:** replace `defaultIconSizeBeforeScaling` with `defaultIconSize`.
+* **Breaking change:** replace `defaultActionsIconSizeBeforeScaling` with `actionsIconSize`.
+* **Breaking change:** replace `unscaledLargeFontSize` with `largeFontSize`.
+* **Breaking change:** replace `unscaledDefaultFontSize` with `defaultFontSize`.
+* **Breaking change:** replace `unscaledSmallFontSize` with `smallFontSize`.
 * Ignore expected exceptions from the `navigateToCode` extension method.
 * Add `RpcErrorExtension` extension with an `isServiceDisposedError` getter.
+* `FormattedJson` uses `SelectionArea` instead of `SelectableText` to make multiple lines selectable.
+* Add `identifyChannel` helper to `FlutterVersion`. 
+* Add `webReload` to URL utilities.
+* `DTDManager` attempts to reconnect to DTD automatically if the connection drops.
+* Add `serviceRegistrationBroadcastStream` to `DTDManager`.
 
 ## 0.4.0
 * Bump `dtd` dependency to `^4.0.0`.

--- a/packages/devtools_app_shared/pubspec.yaml
+++ b/packages/devtools_app_shared/pubspec.yaml
@@ -3,7 +3,7 @@
 # found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
 name: devtools_app_shared
 description: Package of Dart & Flutter structures shared between devtools_app and devtools extensions.
-version: 0.4.1
+version: 0.5.0
 repository: https://github.com/flutter/devtools/tree/master/packages/devtools_app_shared
 
 environment:

--- a/packages/devtools_extensions/CHANGELOG.md
+++ b/packages/devtools_extensions/CHANGELOG.md
@@ -3,6 +3,9 @@ Copyright 2025 The Flutter Authors
 Use of this source code is governed by a BSD-style license that can be
 found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
 -->
+## 0.5.0
+* Bump `devtools_app_shared` dependency to `0.5.0`.
+
 ## 0.4.0
 * Bump `devtools_app_shared` dependency to `0.4.0`.
 * Add `ShowBannerMessageExtensionEvent.dismissOnConnectionChanges` field. This

--- a/packages/devtools_extensions/pubspec.yaml
+++ b/packages/devtools_extensions/pubspec.yaml
@@ -19,7 +19,7 @@ executables:
 dependencies:
   args: ^2.4.2
   devtools_shared: ^12.0.0
-  devtools_app_shared: ^0.4.0
+  devtools_app_shared: ^0.5.0
   flutter:
     sdk: flutter
   io: ^1.0.4


### PR DESCRIPTION
The following changes have been made to `devtools_app_shared` since we last published version 0.4.0:

9fd93387d DTDManager handles the subscription to the service stream (#9635)
04b74a87c Add webdriver test for compiler query parameter (#9608)
d2a145865 AI assistant pane is displayed for supported screens when the AI assistant feature flag is enabled  (#9591)
1af3032fa Attempt to reconnect to DTD automatically if the connection drops (#9587)
1f8b3f50a Disable screens not compatible with DWDS websocket mode (#9481)
1b39a2e3a Add basic support for Flutter web applications served with `-d web-server` (#9468)
032783044 Enable WASM experiment for Flutter beta branches (#9455)
98a52a862 Add feature flag scaffolding to support experiments restricted to a specific Flutter channel (#9440)
941b48035 Use SelectionArea instead of SelectableText (#9333)
600d83537 Remove `scaleByFontFactor` method and usages (#9304)
c736de376 ServiceExtensionManager: avoid switching on runtime type (#9286)
9510c7dd1 ServiceExtensionManager: simplify code around service state and availability (#9288)
4bebd6219 ServiceExtensionManager: return early... earlier (#9287)
92fbb33ed devtools_app_shared: add CHANGELOG entry (#9289)
495c66d5d Do not mark service extensions as 'added' so eagerly (#9271)
e6d85577a Small readability tweak in forEachIsolateHelper (#9273)
644b28319 Ignore expected exceptions from the `navigateToCode` extension method. (#9266)

**This PR adds CHANGELOG entries for those changes and does a `minor` version patch to indicate this version contains breaking changes.**

Note: Opened https://github.com/flutter/devtools/issues/9650 so that we catch missing CHANGELOG entries and breaking changes in the future.