### PR TITLE
Bump devtools_extensions to version 0.5.0

### DIFF
--- a/packages/devtools_extensions/pubspec.yaml
+++ b/packages/devtools_extensions/pubspec.yaml
@@ -3,7 +3,7 @@
 # found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
 name: devtools_extensions
 description: A package for building and supporting extensions for Dart DevTools.
-version: 0.4.0
+version: 0.5.0
 
 repository: https://github.com/flutter/devtools/tree/master/packages/devtools_extensions
 


### PR DESCRIPTION
Follow up to https://github.com/flutter/devtools/pull/9652

I missed bumping `devtools_extensions` version to 0.5.0