### PR TITLE
[DRAFT] Get Github Health check workflow to run

### DIFF
--- a/.github/workflows/health.yaml
+++ b/.github/workflows/health.yaml
@@ -3,8 +3,6 @@ name: Health
 on:
   pull_request:
     types: [synchronize, opened, reopened, labeled, unlabeled]
-    paths:
-      - "**/*.dart"
 
 jobs:
   health:


### PR DESCRIPTION
Follow up to https://github.com/flutter/devtools/pull/9653 since the Health check workflow added in that PR doesn't seem to be triggered.