### PR TITLE
Temporarily disable benchmark tests while investigating flakiness

### DIFF
--- a/packages/devtools_app/benchmark/devtools_benchmarks_test.dart
+++ b/packages/devtools_app/benchmark/devtools_benchmarks_test.dart
@@ -44,6 +44,8 @@ void main() {
       },
       timeout: const Timeout(Duration(minutes: 15)),
       retry: 0,
+      // TODO(elliette): Re-enable once flakiness is addressed.
+      skip: 'https://github.com/flutter/devtools/issues/9674',
     );
   }
 }


### PR DESCRIPTION
Work towards https://github.com/flutter/devtools/issues/9674

I was hoping https://github.com/flutter/devtools/pull/9675 and https://github.com/flutter/devtools/pull/9518 would fix some of the flakiness we are experiencing with our benchmark tests but that doesn't appear to be the case. Temporarily disabling them for now while I investigate a fix.