### PR TITLE
Explicitly opt out of Flutter Icon Tree Shaking

### DIFF
--- a/packages/devtools_app/lib/src/extensions/extension_screen.dart
+++ b/packages/devtools_app/lib/src/extensions/extension_screen.dart
@@ -132,6 +132,8 @@ class ExtensionView extends StatelessWidget {
 
 extension ExtensionConfigExtension on DevToolsExtensionConfig {
   IconData get icon =>
+      // The code point is dynamic. Flutter Icon Tree Shaking disabled.
+      // ignore: non_const_argument_for_const_parameter
       IconData(materialIconCodePoint, fontFamily: 'MaterialIcons');
 
   String get screenId => '${name}_ext';

--- a/packages/devtools_app/lib/src/shared/ui/icons.dart
+++ b/packages/devtools_app/lib/src/shared/ui/icons.dart
@@ -271,6 +271,8 @@ class FlutterMaterialIcons {
 
   static Icon getIconForCodePoint(int charCode, ColorScheme colorScheme) {
     return Icon(
+      // The code point is dynamic. Flutter Icon Tree Shaking disabled.
+      // ignore: non_const_argument_for_const_parameter
       IconData(charCode, fontFamily: 'MaterialIcons'),
       color: colorScheme.onSurface,
     );


### PR DESCRIPTION
Fixing the lints for:

* https://github.com/flutter/flutter/pull/181345

This PR only adds two lint ignores.

The Flutter Icon Tree Shaker will bail out on dynamic values. The adoption of the `@mustBeConst` annotation will force a lint-ignore so that you explicitly opt out of tree-shaking.

The test is the bot downstream that will throw lint violations without the ignores as in: https://logs.chromium.org/logs/flutter/buildbucket/cr-buildbucket/8687149784108999329/+/u/run_test.dart_for_customer_testing_shard_and_subshard_None/stdout

## Pre-launch Checklist

### General checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I updated/added relevant documentation (doc comments with `///`).

### Issues checklist

- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I listed at least one issue which has the [`contributions-welcome`] or [`good-first-issue`] label. 
- [ ] I did not list at least one issue with the [`contributions-welcome`] or [`good-first-issue`] label. I understand this means my PR might take longer to be reviewed. 

### Tests checklist

- [ ] I added new tests to check the change I am making...
- [x] OR there is a reason for not adding tests, which I explained in the PR description.

### AI-tooling checklist

- [ ] I did not use any AI tooling in creating this PR.
- [x] OR I did use AI tooling, and...
    * [x] I read the [AI contributions guidelines] and agree to follow them.
    * [x] I reviewed all AI-generated code before opening this PR.
    * [x] I understand and am able to discuss the code in this PR.
    * [x] I have verifed the accuracy of any AI-generated text included in the PR description.
    * [x] I commit to verifying the accuracy of any AI-generated code or text that I upload in response to review comments.

### Feature-change checklist 

- [x] This PR does not change the DevTools UI or behavior and...
    * [x] I added the `release-notes-not-required` label or left a comment requesting the label be added.
- [ ] OR this PR does change the DevTools UI or behavior and...
    * [ ] I added an entry to `packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md`.
    * [ ] I included before/after screenshots and/or a GIF demo of the new UI to my PR description.
    * [ ] I ran the DevTools app locally to manually verify my changes.
