### PR TITLE
Specify that widget rebuilds is only available in debug-mode

### DIFF
--- a/packages/devtools_app/lib/src/screens/performance/panes/rebuild_stats/rebuild_stats.dart
+++ b/packages/devtools_app/lib/src/screens/performance/panes/rebuild_stats/rebuild_stats.dart
@@ -92,6 +92,19 @@ class _RebuildStatsViewState extends State<RebuildStatsView>
 
   @override
   Widget build(BuildContext context) {
+    final isProfileBuild =
+        serviceConnection.serviceManager.connectedApp?.isProfileBuildNow ??
+        false;
+    if (isProfileBuild) {
+      return const Center(
+        child: Text(
+          'Rebuild information is not available for this frame.\n'
+          'Widget rebuild counts are only available when running '
+          'an app in debug-mode.',
+          textAlign: TextAlign.center,
+        ),
+      );
+    }
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
@@ -138,7 +151,7 @@ class _RebuildStatsViewState extends State<RebuildStatsView>
               if (metrics.isEmpty) {
                 return const Center(
                   child: Text('Interact with the app to trigger rebuilds.'),
-                ); // No data to display but there should be data soon.
+                );
               }
               return RebuildTable(
                 key: const Key('Rebuild Table'),


### PR DESCRIPTION
Fixes https://github.com/flutter/devtools/issues/9730

## Description

When running an app in profile-mode, the Performance panel previously showed a disabled "Count widget builds" checkbox without explaining why it was disabled. The `trackRebuildDirtyWidgets` service extension relies on `debugOnRebuildDirtyWidget`, which is only available in debug-mode.

This change checks whether the connected app is a profile build using `connectedApp?.isProfileBuildNow` (consistent with the approach in `more_debugging_options.dart`). When it is a profile build, the checkbox and clear button are removed and replaced with a centered message:

> Rebuild information is not available for this frame.
> Widget rebuild counts are only available when running an app in debug-mode.

When running in debug-mode, the existing checkbox and rebuild stats table remain unchanged.

## Changes

- `packages/devtools_app/lib/src/screens/performance/panes/rebuild_stats/rebuild_stats.dart`: Added an early return in `_RebuildStatsViewState.build()` that shows an informational message when the connected app is a profile build.