### PR TITLE
Remove legacy `devtools_tool` executables

### DIFF
--- a/tool/bin/devtools_tool
+++ b/tool/bin/devtools_tool
@@ -1,8 +1,0 @@
-#!/bin/bash -e
-
-# This file serves as an alias for the 'dt' executable so that
-# the legacy `dt` can be used.
-# TODO(kenz): remove this file in ~6 months (April 2025).
-
-echo Warning: devtools_tool has been replaced by dt. Please use dt instead.
-dt $@

--- a/tool/bin/devtools_tool.bat
+++ b/tool/bin/devtools_tool.bat
@@ -1,7 +1,0 @@
-REM Copyright 2025 The Flutter Authors
-REM Use of this source code is governed by a BSD-style license that can be
-REM found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
-@echo off
-
-echo Warning: devtools_tool has been replaced by dt. Please use dt instead.
-%~dp0/dt.bat %*


### PR DESCRIPTION
The `dt` command has been in use for ~18 months so this can be removed now.