### PR TITLE
Fix auto select main isolate

### DIFF
--- a/packages/devtools_app/lib/src/framework/observer/_memory_web.dart
+++ b/packages/devtools_app/lib/src/framework/observer/_memory_web.dart
@@ -65,7 +65,8 @@ extension type _UserAgentSpecificMemoryBreakdownAttributionElement._(JSObject _)
 @JS()
 extension type _UserAgentSpecificMemoryBreakdownAttributionContainerElement._(
   JSObject _
-) implements JSObject {
+)
+    implements JSObject {
   external String get id;
 
   external String get url;

--- a/packages/devtools_app/lib/src/framework/observer/_memory_web.dart
+++ b/packages/devtools_app/lib/src/framework/observer/_memory_web.dart
@@ -65,8 +65,7 @@ extension type _UserAgentSpecificMemoryBreakdownAttributionElement._(JSObject _)
 @JS()
 extension type _UserAgentSpecificMemoryBreakdownAttributionContainerElement._(
   JSObject _
-)
-    implements JSObject {
+) {
   external String get id;
 
   external String get url;

--- a/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
+++ b/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
@@ -27,7 +27,7 @@ TODO: Remove this section if there are not any updates.
 
 ## CPU profiler updates
 
-TODO: Remove this section if there are not any updates.
+- Fixed an issue where DevTools would auto-select the test runner isolate instead of the test suite isolate when connecting to a test run, causing CPU profiling and other tools to show no data (#9747). [#9747](https://github.com/flutter/devtools/pull/9747)
 
 ## Memory updates
 

--- a/packages/devtools_app_shared/lib/src/service/isolate_manager.dart
+++ b/packages/devtools_app_shared/lib/src/service/isolate_manager.dart
@@ -166,23 +166,25 @@ final class IsolateManager with DisposerMixin {
         !event.isolate!.isSystemIsolate!) {
       await _registerIsolate(event.isolate!);
       _isolateCreatedController.add(event.isolate);
-      // TODO(jacobr): we assume the first isolate started is the main isolate
-      // but that may not always be a safe assumption.
-      // TODO(https://github.com/flutter/devtools/issues/9747): Detect main
-      // isolate using root library information for test connections here too,
-      // not just in _computeMainIsolate().
-      if (_mainIsolate.value == null) {
+
+      // Recompute whenever a new isolate starts so test connections can move
+      // from the runner isolate to the user test-suite isolate when available.
+      final previousMain = _mainIsolate.value;
+      final computedMain = await _computeMainIsolate();
+      if (computedMain != null) {
+        _mainIsolate.value = computedMain;
+      } else if (_mainIsolate.value == null) {
         _mainIsolate.value = event.isolate;
-        if (_shouldReselectMainIsolate) {
-          // Assume the main isolate has come back up after a hot restart, so
-          // select it.
-          _shouldReselectMainIsolate = false;
-          _setSelectedIsolate(event.isolate);
-        }
       }
 
-      if (_selectedIsolate.value == null) {
-        _setSelectedIsolate(event.isolate);
+      if (_mainIsolate.value != null &&
+          (_shouldReselectMainIsolate ||
+              _selectedIsolate.value == null ||
+              _selectedIsolate.value == previousMain)) {
+        // If the previous main exited and returned (hot restart) or we were
+        // following the previous main, follow the newly computed main isolate.
+        _shouldReselectMainIsolate = false;
+        _setSelectedIsolate(_mainIsolate.value);
       }
     } else if (event.kind == EventKind.kServiceExtensionAdded) {
       // Check to see if there is a new isolate.
@@ -226,13 +228,11 @@ final class IsolateManager with DisposerMixin {
 
     final service = _service;
     for (final isolateState in _isolateStates.values) {
-      if (_selectedIsolate.value == null) {
-        final isolate = await isolateState.isolate;
-        if (service != _service) return null;
-        for (final extensionName in isolate?.extensionRPCs ?? <String>[]) {
-          if (extensions.isFlutterExtension(extensionName)) {
-            return isolateState.isolateRef;
-          }
+      final isolate = await isolateState.isolate;
+      if (service != _service) return null;
+      for (final extensionName in isolate?.extensionRPCs ?? <String>[]) {
+        if (extensions.isFlutterExtension(extensionName)) {
+          return isolateState.isolateRef;
         }
       }
     }

--- a/packages/devtools_app_shared/lib/src/service/isolate_manager.dart
+++ b/packages/devtools_app_shared/lib/src/service/isolate_manager.dart
@@ -181,8 +181,9 @@ final class IsolateManager with DisposerMixin {
           (_shouldReselectMainIsolate ||
               _selectedIsolate.value == null ||
               _selectedIsolate.value == previousMain)) {
-        // If the previous main exited and returned (hot restart) or we were
-        // following the previous main, follow the newly computed main isolate.
+        // If the previous main exited and returned (hot restart), or if the
+        // selected isolate was previously the main isolate, update selection to
+        // the newly computed main isolate.
         _shouldReselectMainIsolate = false;
         _setSelectedIsolate(_mainIsolate.value);
       }

--- a/packages/devtools_app_shared/lib/src/service/isolate_manager.dart
+++ b/packages/devtools_app_shared/lib/src/service/isolate_manager.dart
@@ -168,6 +168,9 @@ final class IsolateManager with DisposerMixin {
       _isolateCreatedController.add(event.isolate);
       // TODO(jacobr): we assume the first isolate started is the main isolate
       // but that may not always be a safe assumption.
+      // TODO(https://github.com/flutter/devtools/issues/9747): Detect main
+      // isolate using root library information for test connections here too,
+      // not just in _computeMainIsolate().
       if (_mainIsolate.value == null) {
         _mainIsolate.value = event.isolate;
         if (_shouldReselectMainIsolate) {
@@ -236,10 +239,58 @@ final class IsolateManager with DisposerMixin {
 
     final ref = _isolateStates.keys.firstWhereOrNull((IsolateRef ref) {
       // 'foo.dart:main()'
-      return ref.name!.contains(':main(');
+      return ref.name?.contains(':main(') ?? false;
     });
 
+    if (ref == null) {
+      final rootLibraryTestSuiteRef =
+          await _findTestSuiteByRootLibrary(service);
+      if (rootLibraryTestSuiteRef != null) return rootLibraryTestSuiteRef;
+
+      // When connecting to a test run, the test package (package:test_core)
+      // spawns each test suite in a separate isolate with a debug name
+      // prefixed with 'test_suite:'. DevTools should connect to this isolate
+      // rather than the test runner isolate ('main'), since the test suite
+      // isolate is where user code actually runs.
+      // See: https://github.com/flutter/devtools/issues/9747
+      final testSuiteRef = _isolateStates.keys.firstWhereOrNull(
+        (IsolateRef ref) => ref.name?.startsWith('test_suite:') ?? false,
+      );
+      if (testSuiteRef != null) return testSuiteRef;
+    }
+
     return ref ?? _isolateStates.keys.first;
+  }
+
+  Future<IsolateRef?> _findTestSuiteByRootLibrary(VmService? service) async {
+    for (final isolateState in _isolateStates.values) {
+      final isolate = await isolateState.isolate;
+      if (service != _service) return null;
+
+      final rootLibraryUri = isolate?.rootLib?.uri;
+      if (rootLibraryUri == null) continue;
+
+      if (_isDartTestRunnerRootLibrary(rootLibraryUri)) continue;
+
+      if (_isLikelyUserTestRootLibrary(rootLibraryUri)) {
+        return isolateState.isolateRef;
+      }
+    }
+
+    return null;
+  }
+
+  bool _isDartTestRunnerRootLibrary(String uri) {
+    return uri.contains('dart_test.kernel') ||
+        uri.startsWith('package:test_core/') ||
+        uri.startsWith('package:test_api/');
+  }
+
+  bool _isLikelyUserTestRootLibrary(String uri) {
+    return (uri.endsWith('_test.dart') ||
+            uri.contains('/test/') ||
+            uri.contains('\\test\\')) &&
+        !uri.startsWith('dart:');
   }
 
   void _setSelectedIsolate(IsolateRef? ref) {

--- a/packages/devtools_app_shared/lib/src/service/isolate_manager.dart
+++ b/packages/devtools_app_shared/lib/src/service/isolate_manager.dart
@@ -264,6 +264,19 @@ final class IsolateManager with DisposerMixin {
   }
 
   Future<IsolateRef?> _findTestSuiteByRootLibrary(VmService? service) async {
+    String? projectRootUri;
+    if (service != null) {
+      try {
+        final vm = await service.getVM();
+        if (service != _service) return null;
+        // `rootUri` is not a typed field on `VM` in the current vm_service
+        // version, so read it from the raw JSON response.
+        projectRootUri = vm.json?['rootUri'] as String?;
+      } catch (_) {
+        // If getVM() fails, proceed without project-root scoping.
+      }
+    }
+
     for (final isolateState in _isolateStates.values) {
       final isolate = await isolateState.isolate;
       if (service != _service) return null;
@@ -273,7 +286,10 @@ final class IsolateManager with DisposerMixin {
 
       if (_isDartTestRunnerRootLibrary(rootLibraryUri)) continue;
 
-      if (_isLikelyUserTestRootLibrary(rootLibraryUri)) {
+      if (_isLikelyUserTestRootLibrary(
+        rootLibraryUri,
+        projectRootUri: projectRootUri,
+      )) {
         return isolateState.isolateRef;
       }
     }
@@ -281,17 +297,37 @@ final class IsolateManager with DisposerMixin {
     return null;
   }
 
+  /// Returns true if [uri] looks like the root library of a dart:test runner
+  /// isolate (as opposed to the user's test suite isolate).
+  ///
+  /// Note: 'dart_test.kernel', 'package:test_core/', and 'package:test_api/'
+  /// are implementation details of package:test that DevTools depends on.
+  /// Changing these in package:test will break this logic.
   bool _isDartTestRunnerRootLibrary(String uri) {
     return uri.contains('dart_test.kernel') ||
         uri.startsWith('package:test_core/') ||
         uri.startsWith('package:test_api/');
   }
 
-  bool _isLikelyUserTestRootLibrary(String uri) {
-    return (uri.endsWith('_test.dart') ||
-            uri.contains('/test/') ||
-            uri.contains('\\test\\')) &&
-        !uri.startsWith('dart:');
+  /// Returns true if [uri] looks like the root library of a user test isolate.
+  ///
+  /// When [projectRootUri] is provided, `file://` URIs must be under it to
+  /// avoid false positives from other packages in the workspace that happen to
+  /// contain '/test/' or end with '_test.dart'.
+  bool _isLikelyUserTestRootLibrary(String uri, {String? projectRootUri}) {
+    if (uri.startsWith('dart:')) return false;
+
+    // Scope file:// URIs to the current project to avoid matching test files
+    // from other packages in a workspace.
+    if (projectRootUri != null &&
+        uri.startsWith('file:') &&
+        !uri.startsWith(projectRootUri)) {
+      return false;
+    }
+
+    return uri.endsWith('_test.dart') ||
+        uri.contains('/test/') ||
+        uri.contains('\\test\\');
   }
 
   void _setSelectedIsolate(IsolateRef? ref) {

--- a/packages/devtools_app_shared/test/service/isolate_manager_test.dart
+++ b/packages/devtools_app_shared/test/service/isolate_manager_test.dart
@@ -1,0 +1,186 @@
+// Copyright 2026 The Flutter Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
+
+import 'dart:async';
+
+import 'package:devtools_app_shared/src/service/isolate_manager.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:vm_service/vm_service.dart';
+
+/// Minimal fake VmService for IsolateManager tests.
+class _FakeVmService extends Fake implements VmService {
+  /// Map of isolate id -> Isolate to return from getIsolate().
+  final Map<String, Isolate> isolates;
+
+  _FakeVmService(this.isolates);
+
+  @override
+  Stream<Event> get onIsolateEvent => const Stream.empty();
+
+  @override
+  Stream<Event> get onDebugEvent => const Stream.empty();
+
+  @override
+  Future<Isolate> getIsolate(String isolateId) async {
+    return isolates[isolateId] ??
+        Isolate.parse({
+          'id': isolateId,
+          'runnable': true,
+          'extensionRPCs': <String>[],
+        })!;
+  }
+
+  @override
+  Future<Success> resume(String isolateId, {String? step, int? frameIndex}) =>
+      Future.value(Success());
+}
+
+/// Creates a minimal runnable [Isolate] for a given [IsolateRef].
+Isolate _makeIsolate(IsolateRef ref, {String? rootLibraryUri}) {
+  final json = <String, Object?>{
+    'id': ref.id,
+    'name': ref.name,
+    'type': '@Isolate',
+    'runnable': true,
+    'extensionRPCs': <String>[],
+    if (rootLibraryUri != null)
+      'rootLib': {
+        'type': '@Library',
+        'id': 'libraries/0',
+        'uri': rootLibraryUri,
+      },
+  };
+
+  return Isolate.parse(json)!;
+}
+
+/// Creates an [IsolateRef] with the given name and id.
+IsolateRef _makeRef(String name, String id) {
+  return IsolateRef.parse({'name': name, 'id': id, 'isSystemIsolate': false})!;
+}
+
+void main() {
+  group('IsolateManager._computeMainIsolate', () {
+    late IsolateManager manager;
+
+    setUp(() {
+      manager = IsolateManager();
+    });
+
+    tearDown(() {
+      manager.handleVmServiceClosed();
+    });
+
+    test(
+      'selects test_suite isolate instead of test runner when running tests',
+      () async {
+        // Simulates the isolate list seen when connecting to a test run:
+        // - 'main' is the test runner isolate (wrong choice)
+        // - 'test_suite:...' is where user code actually runs (correct choice)
+        // - 'vm-service' is infrastructure
+        final testRunnerRef = _makeRef('main', 'isolates/1');
+        final testSuiteRef = _makeRef(
+          'test_suite:file:///tmp/dart_test.kernel.dill',
+          'isolates/2',
+        );
+        final vmServiceRef = _makeRef('vm-service', 'isolates/3');
+
+        final fakeService = _FakeVmService({
+          'isolates/1': _makeIsolate(testRunnerRef),
+          'isolates/2': _makeIsolate(testSuiteRef),
+          'isolates/3': _makeIsolate(vmServiceRef),
+        });
+
+        manager.vmServiceOpened(fakeService);
+        await manager.init([testRunnerRef, testSuiteRef, vmServiceRef]);
+
+        expect(
+          manager.selectedIsolate.value?.name,
+          equals('test_suite:file:///tmp/dart_test.kernel.dill'),
+          reason:
+              'Should auto-select the test_suite isolate, not the test runner',
+        );
+        expect(
+          manager.mainIsolate.value?.name,
+          equals('test_suite:file:///tmp/dart_test.kernel.dill'),
+          reason:
+              'Main isolate should also resolve to the test_suite isolate',
+        );
+      },
+    );
+
+    test('selects main isolate for normal (non-test) app runs', () async {
+      final mainRef = _makeRef('main', 'isolates/1');
+      final vmServiceRef = _makeRef('vm-service', 'isolates/2');
+
+      final fakeService = _FakeVmService({
+        'isolates/1': _makeIsolate(mainRef),
+        'isolates/2': _makeIsolate(vmServiceRef),
+      });
+
+      manager.vmServiceOpened(fakeService);
+      await manager.init([mainRef, vmServiceRef]);
+
+      expect(
+        manager.selectedIsolate.value?.name,
+        equals('main'),
+        reason: 'Should select the main isolate for normal app runs',
+      );
+    });
+
+    test('selects isolate containing :main( for dart scripts', () async {
+      final scriptRef = _makeRef('foo.dart:main()', 'isolates/1');
+
+      final fakeService = _FakeVmService({
+        'isolates/1': _makeIsolate(scriptRef),
+      });
+
+      manager.vmServiceOpened(fakeService);
+      await manager.init([scriptRef]);
+
+      expect(
+        manager.selectedIsolate.value?.name,
+        equals('foo.dart:main()'),
+      );
+    });
+
+    test(
+      'selects test isolate by root library when test_suite prefix is absent',
+      () async {
+        final testRunnerRef = _makeRef('main', 'isolates/1');
+        final userTestRef = _makeRef('isolate-2', 'isolates/2');
+        final vmServiceRef = _makeRef('vm-service', 'isolates/3');
+
+        final fakeService = _FakeVmService({
+          'isolates/1': _makeIsolate(
+            testRunnerRef,
+            rootLibraryUri: 'file:///tmp/dart_test.kernel.abcd/test.dart',
+          ),
+          'isolates/2': _makeIsolate(
+            userTestRef,
+            rootLibraryUri: 'package:my_app/foo_test.dart',
+          ),
+          'isolates/3': _makeIsolate(
+            vmServiceRef,
+            rootLibraryUri: 'dart:developer',
+          ),
+        });
+
+        manager.vmServiceOpened(fakeService);
+        await manager.init([testRunnerRef, userTestRef, vmServiceRef]);
+
+        expect(
+          manager.selectedIsolate.value?.name,
+          equals('isolate-2'),
+          reason:
+              'Should choose user test isolate using root library metadata',
+        );
+        expect(
+          manager.mainIsolate.value?.name,
+          equals('isolate-2'),
+        );
+      },
+    );
+  });
+}

--- a/packages/devtools_app_shared/test/service/isolate_manager_test.dart
+++ b/packages/devtools_app_shared/test/service/isolate_manager_test.dart
@@ -13,10 +13,12 @@ class _FakeVmService extends Fake implements VmService {
   /// Map of isolate id -> Isolate to return from getIsolate().
   final Map<String, Isolate> isolates;
 
+  final _isolateEventController = StreamController<Event>.broadcast();
+
   _FakeVmService(this.isolates);
 
   @override
-  Stream<Event> get onIsolateEvent => const Stream.empty();
+  Stream<Event> get onIsolateEvent => _isolateEventController.stream;
 
   @override
   Stream<Event> get onDebugEvent => const Stream.empty();
@@ -34,6 +36,26 @@ class _FakeVmService extends Fake implements VmService {
   @override
   Future<Success> resume(String isolateId, {String? step, int? frameIndex}) =>
       Future.value(Success());
+
+  Future<void> emitIsolateStart(IsolateRef isolateRef) async {
+    _isolateEventController.add(
+      Event.parse({
+        'type': 'Event',
+        'kind': EventKind.kIsolateStart,
+        'isolate': {
+          'type': '@Isolate',
+          'id': isolateRef.id,
+          'name': isolateRef.name,
+          'isSystemIsolate': isolateRef.isSystemIsolate,
+        },
+      })!,
+    );
+    await Future<void>.delayed(Duration.zero);
+  }
+
+  Future<void> dispose() async {
+    await _isolateEventController.close();
+  }
 }
 
 /// Creates a minimal runnable [Isolate] for a given [IsolateRef].
@@ -63,6 +85,7 @@ IsolateRef _makeRef(String name, String id) {
 void main() {
   group('IsolateManager._computeMainIsolate', () {
     late IsolateManager manager;
+    final fakeServices = <_FakeVmService>[];
 
     setUp(() {
       manager = IsolateManager();
@@ -70,6 +93,10 @@ void main() {
 
     tearDown(() {
       manager.handleVmServiceClosed();
+      for (final fakeService in fakeServices) {
+        fakeService.dispose();
+      }
+      fakeServices.clear();
     });
 
     test(
@@ -91,6 +118,7 @@ void main() {
           'isolates/2': _makeIsolate(testSuiteRef),
           'isolates/3': _makeIsolate(vmServiceRef),
         });
+        fakeServices.add(fakeService);
 
         manager.vmServiceOpened(fakeService);
         await manager.init([testRunnerRef, testSuiteRef, vmServiceRef]);
@@ -118,6 +146,7 @@ void main() {
         'isolates/1': _makeIsolate(mainRef),
         'isolates/2': _makeIsolate(vmServiceRef),
       });
+      fakeServices.add(fakeService);
 
       manager.vmServiceOpened(fakeService);
       await manager.init([mainRef, vmServiceRef]);
@@ -135,6 +164,7 @@ void main() {
       final fakeService = _FakeVmService({
         'isolates/1': _makeIsolate(scriptRef),
       });
+      fakeServices.add(fakeService);
 
       manager.vmServiceOpened(fakeService);
       await manager.init([scriptRef]);
@@ -166,6 +196,7 @@ void main() {
             rootLibraryUri: 'dart:developer',
           ),
         });
+        fakeServices.add(fakeService);
 
         manager.vmServiceOpened(fakeService);
         await manager.init([testRunnerRef, userTestRef, vmServiceRef]);
@@ -179,6 +210,41 @@ void main() {
         expect(
           manager.mainIsolate.value?.name,
           equals('isolate-2'),
+        );
+      },
+    );
+
+    test(
+      'promotes main isolate from test runner to test suite on isolate start',
+      () async {
+        final testRunnerRef = _makeRef('main', 'isolates/1');
+        final testSuiteRef = _makeRef(
+          'test_suite:file:///tmp/dart_test.kernel.dill',
+          'isolates/2',
+        );
+
+        final fakeService = _FakeVmService({
+          'isolates/1': _makeIsolate(testRunnerRef),
+          'isolates/2': _makeIsolate(testSuiteRef),
+        });
+        fakeServices.add(fakeService);
+
+        manager.vmServiceOpened(fakeService);
+        await manager.init(const []);
+
+        await fakeService.emitIsolateStart(testRunnerRef);
+        expect(manager.selectedIsolate.value?.name, equals('main'));
+        expect(manager.mainIsolate.value?.name, equals('main'));
+
+        await fakeService.emitIsolateStart(testSuiteRef);
+        expect(
+          manager.selectedIsolate.value?.name,
+          equals('test_suite:file:///tmp/dart_test.kernel.dill'),
+          reason: 'Should switch selection to test_suite isolate once it starts',
+        );
+        expect(
+          manager.mainIsolate.value?.name,
+          equals('test_suite:file:///tmp/dart_test.kernel.dill'),
         );
       },
     );

--- a/packages/devtools_app_shared/test/service/isolate_manager_test.dart
+++ b/packages/devtools_app_shared/test/service/isolate_manager_test.dart
@@ -10,12 +10,12 @@ import 'package:vm_service/vm_service.dart';
 
 /// Minimal fake VmService for IsolateManager tests.
 class _FakeVmService extends Fake implements VmService {
+  _FakeVmService(this.isolates);
+
   /// Map of isolate id -> Isolate to return from getIsolate().
   final Map<String, Isolate> isolates;
 
   final _isolateEventController = StreamController<Event>.broadcast();
-
-  _FakeVmService(this.isolates);
 
   @override
   Stream<Event> get onIsolateEvent => _isolateEventController.stream;
@@ -53,6 +53,7 @@ class _FakeVmService extends Fake implements VmService {
     await Future<void>.delayed(Duration.zero);
   }
 
+  @override
   Future<void> dispose() async {
     await _isolateEventController.close();
   }
@@ -94,7 +95,7 @@ void main() {
     tearDown(() {
       manager.handleVmServiceClosed();
       for (final fakeService in fakeServices) {
-        fakeService.dispose();
+        unawaited(fakeService.dispose());
       }
       fakeServices.clear();
     });
@@ -132,8 +133,7 @@ void main() {
         expect(
           manager.mainIsolate.value?.name,
           equals('test_suite:file:///tmp/dart_test.kernel.dill'),
-          reason:
-              'Main isolate should also resolve to the test_suite isolate',
+          reason: 'Main isolate should also resolve to the test_suite isolate',
         );
       },
     );
@@ -204,8 +204,7 @@ void main() {
         expect(
           manager.selectedIsolate.value?.name,
           equals('isolate-2'),
-          reason:
-              'Should choose user test isolate using root library metadata',
+          reason: 'Should choose user test isolate using root library metadata',
         );
         expect(
           manager.mainIsolate.value?.name,
@@ -240,7 +239,8 @@ void main() {
         expect(
           manager.selectedIsolate.value?.name,
           equals('test_suite:file:///tmp/dart_test.kernel.dill'),
-          reason: 'Should switch selection to test_suite isolate once it starts',
+          reason:
+              'Should switch selection to test_suite isolate once it starts',
         );
         expect(
           manager.mainIsolate.value?.name,

--- a/packages/devtools_app_shared/test/service/isolate_manager_test.dart
+++ b/packages/devtools_app_shared/test/service/isolate_manager_test.dart
@@ -8,6 +8,174 @@ import 'package:devtools_app_shared/src/service/isolate_manager.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:vm_service/vm_service.dart';
 
+void main() {
+  group('IsolateManager._computeMainIsolate', () {
+    late IsolateManager manager;
+    final fakeServices = <_FakeVmService>[];
+
+    setUp(() {
+      manager = IsolateManager();
+    });
+
+    tearDown(() {
+      manager.handleVmServiceClosed();
+      for (final fakeService in fakeServices) {
+        unawaited(fakeService.dispose());
+      }
+      fakeServices.clear();
+    });
+
+    test(
+      'selects test_suite isolate instead of test runner when running tests',
+      () async {
+        // Simulates the isolate list seen when connecting to a test run:
+        // - 'main' is the test runner isolate (wrong choice)
+        // - 'test_suite:...' is where user code actually runs (correct choice)
+        // - 'vm-service' is infrastructure
+        final testRunnerRef = _makeRef('main', 'isolates/1');
+        final testSuiteRef = _makeRef(
+          'test_suite:file:///tmp/dart_test.kernel.dill',
+          'isolates/2',
+        );
+        final vmServiceRef = _makeRef('vm-service', 'isolates/3');
+
+        final fakeService = _FakeVmService({
+          testRunnerRef.id!: _makeIsolate(testRunnerRef),
+          testSuiteRef.id!: _makeIsolate(testSuiteRef),
+          vmServiceRef.id!: _makeIsolate(vmServiceRef),
+        });
+        fakeServices.add(fakeService);
+
+        manager.vmServiceOpened(fakeService);
+        await manager.init([testRunnerRef, testSuiteRef, vmServiceRef]);
+
+        expect(
+          manager.selectedIsolate.value?.name,
+          equals('test_suite:file:///tmp/dart_test.kernel.dill'),
+          reason:
+              'Should auto-select the test_suite isolate, not the test runner',
+        );
+        expect(
+          manager.mainIsolate.value?.name,
+          equals('test_suite:file:///tmp/dart_test.kernel.dill'),
+          reason: 'Main isolate should also resolve to the test_suite isolate',
+        );
+      },
+    );
+
+    test('selects main isolate for normal (non-test) app runs', () async {
+      final mainRef = _makeRef('main', 'isolates/1');
+      final vmServiceRef = _makeRef('vm-service', 'isolates/2');
+
+      final fakeService = _FakeVmService({
+        mainRef.id!: _makeIsolate(mainRef),
+        vmServiceRef.id!: _makeIsolate(vmServiceRef),
+      });
+      fakeServices.add(fakeService);
+
+      manager.vmServiceOpened(fakeService);
+      await manager.init([mainRef, vmServiceRef]);
+
+      expect(
+        manager.selectedIsolate.value?.name,
+        equals('main'),
+        reason: 'Should select the main isolate for normal app runs',
+      );
+    });
+
+    test('selects isolate containing :main( for dart scripts', () async {
+      final scriptRef = _makeRef('foo.dart:main()', 'isolates/1');
+
+      final fakeService = _FakeVmService({
+        scriptRef.id!: _makeIsolate(scriptRef),
+      });
+      fakeServices.add(fakeService);
+
+      manager.vmServiceOpened(fakeService);
+      await manager.init([scriptRef]);
+
+      expect(
+        manager.selectedIsolate.value?.name,
+        equals('foo.dart:main()'),
+      );
+    });
+
+    test(
+      'selects test isolate by root library when test_suite prefix is absent',
+      () async {
+        final testRunnerRef = _makeRef('main', 'isolates/1');
+        final userTestRef = _makeRef('isolate-2', 'isolates/2');
+        final vmServiceRef = _makeRef('vm-service', 'isolates/3');
+
+        final fakeService = _FakeVmService({
+          testRunnerRef.id!: _makeIsolate(
+            testRunnerRef,
+            rootLibraryUri: 'file:///tmp/dart_test.kernel.abcd/test.dart',
+          ),
+          userTestRef.id!: _makeIsolate(
+            userTestRef,
+            rootLibraryUri: 'package:my_app/foo_test.dart',
+          ),
+          vmServiceRef.id!: _makeIsolate(
+            vmServiceRef,
+            rootLibraryUri: 'dart:developer',
+          ),
+        });
+        fakeServices.add(fakeService);
+
+        manager.vmServiceOpened(fakeService);
+        await manager.init([testRunnerRef, userTestRef, vmServiceRef]);
+
+        expect(
+          manager.selectedIsolate.value?.name,
+          equals('isolate-2'),
+          reason: 'Should choose user test isolate using root library metadata',
+        );
+        expect(
+          manager.mainIsolate.value?.name,
+          equals('isolate-2'),
+        );
+      },
+    );
+
+    test(
+      'promotes main isolate from test runner to test suite on isolate start',
+      () async {
+        final testRunnerRef = _makeRef('main', 'isolates/1');
+        final testSuiteRef = _makeRef(
+          'test_suite:file:///tmp/dart_test.kernel.dill',
+          'isolates/2',
+        );
+
+        final fakeService = _FakeVmService({
+          testRunnerRef.id!: _makeIsolate(testRunnerRef),
+          testSuiteRef.id!: _makeIsolate(testSuiteRef),
+        });
+        fakeServices.add(fakeService);
+
+        manager.vmServiceOpened(fakeService);
+        await manager.init(const []);
+
+        await fakeService.emitIsolateStart(testRunnerRef);
+        expect(manager.selectedIsolate.value?.name, equals('main'));
+        expect(manager.mainIsolate.value?.name, equals('main'));
+
+        await fakeService.emitIsolateStart(testSuiteRef);
+        expect(
+          manager.selectedIsolate.value?.name,
+          equals('test_suite:file:///tmp/dart_test.kernel.dill'),
+          reason:
+              'Should switch selection to test_suite isolate once it starts',
+        );
+        expect(
+          manager.mainIsolate.value?.name,
+          equals('test_suite:file:///tmp/dart_test.kernel.dill'),
+        );
+      },
+    );
+  });
+}
+
 /// Minimal fake VmService for IsolateManager tests.
 class _FakeVmService extends Fake implements VmService {
   _FakeVmService(this.isolates);
@@ -81,172 +249,4 @@ Isolate _makeIsolate(IsolateRef ref, {String? rootLibraryUri}) {
 /// Creates an [IsolateRef] with the given name and id.
 IsolateRef _makeRef(String name, String id) {
   return IsolateRef.parse({'name': name, 'id': id, 'isSystemIsolate': false})!;
-}
-
-void main() {
-  group('IsolateManager._computeMainIsolate', () {
-    late IsolateManager manager;
-    final fakeServices = <_FakeVmService>[];
-
-    setUp(() {
-      manager = IsolateManager();
-    });
-
-    tearDown(() {
-      manager.handleVmServiceClosed();
-      for (final fakeService in fakeServices) {
-        unawaited(fakeService.dispose());
-      }
-      fakeServices.clear();
-    });
-
-    test(
-      'selects test_suite isolate instead of test runner when running tests',
-      () async {
-        // Simulates the isolate list seen when connecting to a test run:
-        // - 'main' is the test runner isolate (wrong choice)
-        // - 'test_suite:...' is where user code actually runs (correct choice)
-        // - 'vm-service' is infrastructure
-        final testRunnerRef = _makeRef('main', 'isolates/1');
-        final testSuiteRef = _makeRef(
-          'test_suite:file:///tmp/dart_test.kernel.dill',
-          'isolates/2',
-        );
-        final vmServiceRef = _makeRef('vm-service', 'isolates/3');
-
-        final fakeService = _FakeVmService({
-          'isolates/1': _makeIsolate(testRunnerRef),
-          'isolates/2': _makeIsolate(testSuiteRef),
-          'isolates/3': _makeIsolate(vmServiceRef),
-        });
-        fakeServices.add(fakeService);
-
-        manager.vmServiceOpened(fakeService);
-        await manager.init([testRunnerRef, testSuiteRef, vmServiceRef]);
-
-        expect(
-          manager.selectedIsolate.value?.name,
-          equals('test_suite:file:///tmp/dart_test.kernel.dill'),
-          reason:
-              'Should auto-select the test_suite isolate, not the test runner',
-        );
-        expect(
-          manager.mainIsolate.value?.name,
-          equals('test_suite:file:///tmp/dart_test.kernel.dill'),
-          reason: 'Main isolate should also resolve to the test_suite isolate',
-        );
-      },
-    );
-
-    test('selects main isolate for normal (non-test) app runs', () async {
-      final mainRef = _makeRef('main', 'isolates/1');
-      final vmServiceRef = _makeRef('vm-service', 'isolates/2');
-
-      final fakeService = _FakeVmService({
-        'isolates/1': _makeIsolate(mainRef),
-        'isolates/2': _makeIsolate(vmServiceRef),
-      });
-      fakeServices.add(fakeService);
-
-      manager.vmServiceOpened(fakeService);
-      await manager.init([mainRef, vmServiceRef]);
-
-      expect(
-        manager.selectedIsolate.value?.name,
-        equals('main'),
-        reason: 'Should select the main isolate for normal app runs',
-      );
-    });
-
-    test('selects isolate containing :main( for dart scripts', () async {
-      final scriptRef = _makeRef('foo.dart:main()', 'isolates/1');
-
-      final fakeService = _FakeVmService({
-        'isolates/1': _makeIsolate(scriptRef),
-      });
-      fakeServices.add(fakeService);
-
-      manager.vmServiceOpened(fakeService);
-      await manager.init([scriptRef]);
-
-      expect(
-        manager.selectedIsolate.value?.name,
-        equals('foo.dart:main()'),
-      );
-    });
-
-    test(
-      'selects test isolate by root library when test_suite prefix is absent',
-      () async {
-        final testRunnerRef = _makeRef('main', 'isolates/1');
-        final userTestRef = _makeRef('isolate-2', 'isolates/2');
-        final vmServiceRef = _makeRef('vm-service', 'isolates/3');
-
-        final fakeService = _FakeVmService({
-          'isolates/1': _makeIsolate(
-            testRunnerRef,
-            rootLibraryUri: 'file:///tmp/dart_test.kernel.abcd/test.dart',
-          ),
-          'isolates/2': _makeIsolate(
-            userTestRef,
-            rootLibraryUri: 'package:my_app/foo_test.dart',
-          ),
-          'isolates/3': _makeIsolate(
-            vmServiceRef,
-            rootLibraryUri: 'dart:developer',
-          ),
-        });
-        fakeServices.add(fakeService);
-
-        manager.vmServiceOpened(fakeService);
-        await manager.init([testRunnerRef, userTestRef, vmServiceRef]);
-
-        expect(
-          manager.selectedIsolate.value?.name,
-          equals('isolate-2'),
-          reason: 'Should choose user test isolate using root library metadata',
-        );
-        expect(
-          manager.mainIsolate.value?.name,
-          equals('isolate-2'),
-        );
-      },
-    );
-
-    test(
-      'promotes main isolate from test runner to test suite on isolate start',
-      () async {
-        final testRunnerRef = _makeRef('main', 'isolates/1');
-        final testSuiteRef = _makeRef(
-          'test_suite:file:///tmp/dart_test.kernel.dill',
-          'isolates/2',
-        );
-
-        final fakeService = _FakeVmService({
-          'isolates/1': _makeIsolate(testRunnerRef),
-          'isolates/2': _makeIsolate(testSuiteRef),
-        });
-        fakeServices.add(fakeService);
-
-        manager.vmServiceOpened(fakeService);
-        await manager.init(const []);
-
-        await fakeService.emitIsolateStart(testRunnerRef);
-        expect(manager.selectedIsolate.value?.name, equals('main'));
-        expect(manager.mainIsolate.value?.name, equals('main'));
-
-        await fakeService.emitIsolateStart(testSuiteRef);
-        expect(
-          manager.selectedIsolate.value?.name,
-          equals('test_suite:file:///tmp/dart_test.kernel.dill'),
-          reason:
-              'Should switch selection to test_suite isolate once it starts',
-        );
-        expect(
-          manager.mainIsolate.value?.name,
-          equals('test_suite:file:///tmp/dart_test.kernel.dill'),
-        );
-      },
-    );
-  });
 }

--- a/packages/devtools_app_shared/test/service/isolate_manager_test.dart
+++ b/packages/devtools_app_shared/test/service/isolate_manager_test.dart
@@ -178,10 +178,14 @@ void main() {
 
 /// Minimal fake VmService for IsolateManager tests.
 class _FakeVmService extends Fake implements VmService {
-  _FakeVmService(this.isolates);
+  _FakeVmService(this.isolates, {this.vmRootUri});
 
   /// Map of isolate id -> Isolate to return from getIsolate().
   final Map<String, Isolate> isolates;
+
+  /// Optional root URI returned by [getVM], used to scope test library
+  /// detection to the current project.
+  final String? vmRootUri;
 
   final _isolateEventController = StreamController<Event>.broadcast();
 
@@ -190,6 +194,14 @@ class _FakeVmService extends Fake implements VmService {
 
   @override
   Stream<Event> get onDebugEvent => const Stream.empty();
+
+  @override
+  Future<VM> getVM() async {
+    return VM.parse({
+      'type': 'VM',
+      if (vmRootUri != null) 'rootUri': vmRootUri,
+    })!;
+  }
 
   @override
   Future<Isolate> getIsolate(String isolateId) async {


### PR DESCRIPTION
Fixes https://github.com/flutter/devtools/issues/9747

When DevTools connects to a test run, three isolates are present: the test runner (`main`), the test suite isolate where user code actually runs (`test_suite:...`), and `vm-service`. Previously, DevTools fell through to selecting the first isolate (`main`) as a fallback, so CPU profiling and other tools showed no data and the user's test code was running in a completely different isolate.

This changes `_computeMainIsolate` in `IsolateManager` to prefer the`test_suite:` isolate when no Flutter extension or `:main(` isolate is found. The `test_suite:` prefix is set as a `debugName` by `package:test_core` when it spawns each test suite isolate, making it a reliable signal to detect test runs.

**Before:** CPU profiler showed empty results when connected to a test run.
**After:** CPU profiler correctly captures samples from the test suite isolate.

## Pre-launch Checklist
### General checklist
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I updated/added relevant documentation (doc comments with `///`).
### Issues checklist
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I listed at least one issue which has the [`contributions-welcome`] or [`good-first-issue`] label. 
- [x] I did not list at least one issue with the [`contributions-welcome`] or [`good-first-issue`] label. I understand this means my PR might take longer to be reviewed. 
### Tests checklist
- [x] I added new tests to check the change I am making...
- [ ] OR there is a reason for not adding tests, which I explained in the PR description.
### AI-tooling checklist
- [ ] I did not use any AI tooling in creating this PR.
- [x] OR I did use AI tooling, and...
    * [x] I read the [AI contributions guidelines] and agree to follow them.
    * [x] I reviewed all AI-generated code before opening this PR.
    * [x] I understand and am able to discuss the code in this PR.
    * [x] I have verifed the accuracy of any AI-generated text included in the PR description.
    * [x] I commit to verifying the accuracy of any AI-generated code or text that I upload in response to review comments.
### Feature-change checklist 
- [ ] This PR does not change the DevTools UI or behavior and...
    * [ ] I added the `release-notes-not-required` label or left a comment requesting the label be added.
- [x] OR this PR does change the DevTools UI or behavior and...
    * [x] I added an entry to `packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md`.
    * [ ] I included before/after screenshots and/or a GIF demo of the new UI to my PR description.
    * [x] I ran the DevTools app locally to manually verify my changes.