### PR TITLE
Add a SKILL for adding and verifying copyright headers

### DIFF
--- a/.agents/skills/adding-copyright-headers/SKILL.md
+++ b/.agents/skills/adding-copyright-headers/SKILL.md
@@ -5,8 +5,6 @@ description: Adds copyright headers to files based on file type. Use when creati
 
 # Adding Copyright Headers
 
-This skill provides instructions for adding copyright headers to source files in this repository based on their file type.
-
 ## Formats
 
 ### Dart Files (`.dart`)

--- a/.agents/skills/adding-copyright-headers/SKILL.md
+++ b/.agents/skills/adding-copyright-headers/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: adding-copyright-headers
+description: Adds copyright headers to files based on file type. Use when creating new files or when asked to verify copyright headers.
+---
+
+# Adding Copyright Headers
+
+This skill provides instructions for adding copyright headers to source files in this repository based on their file type.
+
+## Formats
+
+### Dart Files (`.dart`)
+
+```dart
+// Copyright 20?? The Flutter Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
+```
+
+### YAML Files (`.yaml`)
+
+```yaml
+# Copyright 20?? The Flutter Authors
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
+```
+
+### HTML Files (`.html`) and Markdown Files (`.md`)
+
+```html
+<!--
+Copyright 20?? The Flutter Authors
+Use of this source code is governed by a BSD-style license that can be
+found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
+-->
+```
+
+## Instructions
+
+1. **New Files**: When creating a new file, you MUST add the appropriate copyright header at the very top of the file based on its file extension.
+   - Replace `20??` with the current year (e.g., 2026).
+2. **Existing Files**: When editing an existing file, do NOT modify the year in the copyright header. Leave it as it is.
+3. **Subsequent Edits**: Subsequent edits should not modify the year.
+
+## Examples (for 2026)
+
+### Dart
+```dart
+// Copyright 2026 The Flutter Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
+```
+
+### YAML
+```yaml
+# Copyright 2026 The Flutter Authors
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
+```
+
+### HTML / Markdown
+```html
+<!--
+Copyright 2026 The Flutter Authors
+Use of this source code is governed by a BSD-style license that can be
+found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
+-->
+```

--- a/.agents/skills/adding-copyright-headers/SKILL.md
+++ b/.agents/skills/adding-copyright-headers/SKILL.md
@@ -35,34 +35,42 @@ found in the LICENSE file or at https://developers.google.com/open-source/licens
 -->
 ```
 
+### Shell Scripts (`.sh`)
+
+```bash
+# Copyright 20?? The Flutter Authors
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
+```
+
 ## Instructions
 
-1. **New Files**: When creating a new file, you MUST add the appropriate copyright header at the very top of the file based on its file extension.
+1. **New Files**: When creating a new file, you MUST add the appropriate copyright header based on its file extension.
    - Replace `20??` with the current year (e.g., 2026).
-2. **Existing Files**: When editing an existing file, do NOT modify the year in the copyright header. Leave it as it is.
-3. **Subsequent Edits**: Subsequent edits should not modify the year.
+2. **Placement**:
+   - The copyright header should be at the very top of the file by default.
+   - **Exception**: If the file requires a shebang (e.g., `#!/bin/bash` in `.sh` files) or other necessary frontmatter, the copyright header must come **after** the frontmatter, separated by a blank line.
+3. **Exclusions**: Copyright headers are **not necessary** in directories that begin with a dot (`.`), such as:
+   - `.agents/`
+   - `.gemini/`
+   - `.github/`
+4. **Existing Files**: When editing an existing file, do NOT modify the year in the copyright header. Leave it as it is.
+5. **Subsequent Edits**: Subsequent edits should not modify the year.
 
 ## Examples (for 2026)
 
-### Dart
-```dart
-// Copyright 2026 The Flutter Authors
-// Use of this source code is governed by a BSD-style license that can be
-// found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
-```
+### Shell Script with Shebang
+```bash
+#!/bin/bash
 
-### YAML
-```yaml
 # Copyright 2026 The Flutter Authors
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
 ```
 
-### HTML / Markdown
-```html
-<!--
-Copyright 2026 The Flutter Authors
-Use of this source code is governed by a BSD-style license that can be
-found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
--->
+### Dart File
+```dart
+// Copyright 2026 The Flutter Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
 ```

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -863,26 +863,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "8d9ceddbab833f180fbefed08afa76d7c03513dfdba87ffcec2718b02bbcbf20"
+      sha256: "280d6d890011ca966ad08df7e8a4ddfab0fb3aa49f96ed6de56e3521347a9ae7"
       url: "https://pub.dev"
     source: hosted
-    version: "1.31.0"
+    version: "1.30.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.11"
+    version: "0.7.10"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "1991d4cfe85d5043241acac92962c3977c8d2f2add1ee73130c7b286417d1d34"
+      sha256: "0381bd1585d1a924763c308100f2138205252fb90c9d4eeaf28489ee65ccde51"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.17"
+    version: "0.6.16"
   typed_data:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -863,26 +863,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "280d6d890011ca966ad08df7e8a4ddfab0fb3aa49f96ed6de56e3521347a9ae7"
+      sha256: "8d9ceddbab833f180fbefed08afa76d7c03513dfdba87ffcec2718b02bbcbf20"
       url: "https://pub.dev"
     source: hosted
-    version: "1.30.0"
+    version: "1.31.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.11"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "0381bd1585d1a924763c308100f2138205252fb90c9d4eeaf28489ee65ccde51"
+      sha256: "1991d4cfe85d5043241acac92962c3977c8d2f2add1ee73130c7b286417d1d34"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.16"
+    version: "0.6.17"
   typed_data:
     dependency: transitive
     description:


### PR DESCRIPTION
Adds a SKILL for copyright headers - hopefully will prevent agentic changes like the following:

<img width="923" height="611" alt="Screenshot 2026-04-17 at 1 43 06 PM" src="https://github.com/user-attachments/assets/414f9355-2171-41f2-8090-2e83f3c9e82e" />
