### PR TITLE
Pluralize domain and path label in deep links panel

### DIFF
--- a/packages/devtools_app/lib/src/screens/deep_link_validation/deep_link_list_view.dart
+++ b/packages/devtools_app/lib/src/screens/deep_link_validation/deep_link_list_view.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
 
 import 'package:devtools_app_shared/ui.dart';
+import 'package:devtools_app_shared/utils.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
@@ -439,7 +440,7 @@ class _NotificationCardSection extends StatelessWidget {
           children: [
             if (domainErrorCount > 0)
               NotificationCard(
-                title: '$domainErrorCount domain not verified',
+               title: '$domainErrorCount ${pluralize('domain', domainErrorCount)} not verified',
                 description:
                     'This affects all deep links. Fix issues to make users go directly to your app.',
                 actionButton: TextButton(

--- a/packages/devtools_app/lib/src/screens/deep_link_validation/deep_link_list_view.dart
+++ b/packages/devtools_app/lib/src/screens/deep_link_validation/deep_link_list_view.dart
@@ -440,7 +440,8 @@ class _NotificationCardSection extends StatelessWidget {
           children: [
             if (domainErrorCount > 0)
               NotificationCard(
-               title: '$domainErrorCount ${pluralize('domain', domainErrorCount)} not verified',
+               title: 
+                   '$domainErrorCount ${pluralize('domain', domainErrorCount)} not verified',
                 description:
                     'This affects all deep links. Fix issues to make users go directly to your app.',
                 actionButton: TextButton(
@@ -462,7 +463,8 @@ class _NotificationCardSection extends StatelessWidget {
               const SizedBox(width: defaultSpacing),
             if (pathErrorCount > 0)
               NotificationCard(
-                title: '$pathErrorCount path not working',
+                title:
+                    '$pathErrorCount ${pluralize('path', pathErrorCount)} not working',
                 description:
                     'Fix these path to make sure users are directed to your app',
                 actionButton: TextButton(

--- a/packages/devtools_app/lib/src/screens/deep_link_validation/deep_link_list_view.dart
+++ b/packages/devtools_app/lib/src/screens/deep_link_validation/deep_link_list_view.dart
@@ -440,8 +440,8 @@ class _NotificationCardSection extends StatelessWidget {
           children: [
             if (domainErrorCount > 0)
               NotificationCard(
-               title: 
-                   '$domainErrorCount ${pluralize('domain', domainErrorCount)} not verified',
+                title:
+                    '$domainErrorCount ${pluralize('domain', domainErrorCount)} not verified',
                 description:
                     'This affects all deep links. Fix issues to make users go directly to your app.',
                 actionButton: TextButton(

--- a/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
+++ b/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
@@ -51,7 +51,7 @@ TODO: Remove this section if there are not any updates.
 
 ## Deep links tool updates
 
-TODO: Remove this section if there are not any updates.
+- Pluralized "domain" and "path" in the validation summary notification titles when multiple errors are present.[#9790](https://github.com/flutter/devtools/pull/9790)
 
 ## VS Code sidebar updates
 

--- a/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
+++ b/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
@@ -51,7 +51,7 @@ TODO: Remove this section if there are not any updates.
 
 ## Deep links tool updates
 
-- Pluralized "domain" and "path" in the validation summary notification titles when multiple errors are present.[#9790](https://github.com/flutter/devtools/pull/9790)
+- Pluralized "domain" and "path" in the validation summary notification titles when multiple errors are present. [#9790](https://github.com/flutter/devtools/pull/9790)
 
 ## VS Code sidebar updates
 


### PR DESCRIPTION
this PR fixes issue #9390 
Fixes incorrect singular wording in Deep Links Validate and fix notifications by using the pluralize helper from `package:devtools_app_shared/utils.dart`.
This updates both domain and path count titles, for example, “1 domain not verified” vs “10 domains not verified” and “2 paths not working”.

## Pre-launch Checklist

### General checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [ ] I signed the [CLA].
- [ ] I updated/added relevant documentation (doc comments with `///`).

### Issues checklist

- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I listed at least one issue which has the [`contributions-welcome`] or [`good-first-issue`] label. 
- [ ] I did not list at least one issue with the [`contributions-welcome`] or [`good-first-issue`] label. I understand this means my PR might take longer to be reviewed. 

### Tests checklist

- [ ] I added new tests to check the change I am making...
- [ ] OR there is a reason for not adding tests, which I explained in the PR description.

### AI-tooling checklist

- [ ] I did not use any AI tooling in creating this PR.
- [ ] OR I did use AI tooling, and...
    * [ ] I read the [AI contributions guidelines] and agree to follow them.
    * [ ] I reviewed all AI-generated code before opening this PR.
    * [ ] I understand and am able to discuss the code in this PR.
    * [ ] I have verifed the accuracy of any AI-generated text included in the PR description.
    * [ ] I commit to verifying the accuracy of any AI-generated code or text that I upload in response to review comments.

### Feature-change checklist 

- [ ] This PR does not change the DevTools UI or behavior and...
    * [ ] I added the `release-notes-not-required` label or left a comment requesting the label be added.
- [ ] OR this PR does change the DevTools UI or behavior and...
    * [ ] I added an entry to `packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md`.
    * [ ] I included before/after screenshots and/or a GIF demo of the new UI to my PR description.
    * [ ] I ran the DevTools app locally to manually verify my changes.

![build.yaml badge]

If you need help, consider asking for help on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/devtools/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[CLA]: https://cla.developers.google.com/
[`contributions-welcome`]: https://github.com/flutter/devtools/issues?q=state%3Aopen%20label%3Acontributions-welcome
[`good-first-issue`]: https://github.com/flutter/devtools/issues?q=state%3Aopen%20label%3Agood-first-issue
[AI contributions guidelines]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[build.yaml badge]: https://github.com/flutter/devtools/actions/workflows/build.yaml/badge.svg
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
