### PR TITLE
Use default service extension states in UI even when they are not available

### DIFF
--- a/packages/devtools_app/lib/src/service/service_extension_widgets.dart
+++ b/packages/devtools_app/lib/src/service/service_extension_widgets.dart
@@ -538,12 +538,9 @@ class _ServiceExtensionCheckboxState extends State<ServiceExtensionCheckbox>
   void _onMainIsolateChanged() => _initExtensionState();
 
   void _initExtensionState() {
-    if (serviceConnection.serviceManager.serviceExtensionManager
-        .isServiceExtensionAvailable(widget.serviceExtension.extension)) {
-      final state = serviceConnection.serviceManager.serviceExtensionManager
-          .getServiceExtensionState(widget.serviceExtension.extension);
-      _setValueFromState(state.value);
-    }
+    final state = serviceConnection.serviceManager.serviceExtensionManager
+        .getServiceExtensionState(widget.serviceExtension.extension);
+    _setValueFromState(state.value);
 
     unawaited(
       serviceConnection.serviceManager.serviceExtensionManager

--- a/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
+++ b/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
@@ -25,7 +25,7 @@ TODO: Remove this section if there are not any updates.
 ## Performance updates
 
 - Fixed an issue where 'More Debug Options' showed options as unselected in
-profile mode even when selected. [TODO](https://github.com/flutter/devtools/pull/TODO)
+profile mode even when selected. [#9813](https://github.com/flutter/devtools/issues/9813)
 
 ## CPU profiler updates
 

--- a/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
+++ b/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
@@ -24,7 +24,8 @@ TODO: Remove this section if there are not any updates.
 
 ## Performance updates
 
-TODO: Remove this section if there are not any updates.
+- Fixed an issue where 'More Debug Options' showed options as unselected in
+profile mode even when selected. [TODO](https://github.com/flutter/devtools/pull/TODO)
 
 ## CPU profiler updates
 

--- a/packages/devtools_app/test/service/service_extension_widgets_test.dart
+++ b/packages/devtools_app/test/service/service_extension_widgets_test.dart
@@ -222,6 +222,61 @@ void main() {
       expect(toggle.value, false, reason: 'The extension is disabled.');
     });
   });
+
+  group('ServiceExtensionCheckbox', () {
+    testWidgets('shows value state even when unavailable', (WidgetTester tester) async {
+      final ext = extensions.disableClipLayers;
+      final customFake = _UnavailableServiceExtensionManager();
+      customFake.makeUnavailable(ext.extension);
+      
+      // Override the serviceExtensionManager on mockServiceManager
+      when(mockServiceManager.serviceExtensionManager).thenReturn(customFake);
+      
+      // Set state to enabled: false (which means clips not disabled -> checked true)
+      await customFake.setServiceExtensionState(
+        ext.extension,
+        enabled: false,
+        value: false,
+      );
+      
+      final checkbox = ServiceExtensionCheckbox(serviceExtension: ext);
+      await tester.pumpWidget(
+        wrap(Scaffold(body: Center(child: checkbox))),
+      );
+      await tester.pumpAndSettle();
+      
+      final checkboxFinder = find.byType(Checkbox);
+      expect(checkboxFinder, findsOneWidget);
+      
+      final checkboxWidget = tester.widget<Checkbox>(checkboxFinder);
+      expect(checkboxWidget.value, isTrue);
+      expect(checkboxWidget.onChanged, isNull);
+    });
+  });
+}
+
+base class _UnavailableServiceExtensionManager extends FakeServiceExtensionManager {
+  final _unavailableExtensions = <String>{};
+
+  void makeUnavailable(String name) {
+    _unavailableExtensions.add(name);
+  }
+
+  @override
+  Future<bool> waitForServiceExtensionAvailable(String name) {
+    if (_unavailableExtensions.contains(name)) {
+      return Future.value(false);
+    }
+    return super.waitForServiceExtensionAvailable(name);
+  }
+
+  @override
+  bool isServiceExtensionAvailable(String name) {
+    if (_unavailableExtensions.contains(name)) {
+      return false;
+    }
+    return super.isServiceExtensionAvailable(name);
+  }
 }
 
 void registerServiceExtension(

--- a/packages/devtools_app/test/service/service_extension_widgets_test.dart
+++ b/packages/devtools_app/test/service/service_extension_widgets_test.dart
@@ -224,30 +224,30 @@ void main() {
   });
 
   group('ServiceExtensionCheckbox', () {
-    testWidgets('shows value state even when unavailable', (WidgetTester tester) async {
+    testWidgets('shows value state even when unavailable', (
+      WidgetTester tester,
+    ) async {
       final ext = extensions.disableClipLayers;
       final customFake = _UnavailableServiceExtensionManager();
       customFake.makeUnavailable(ext.extension);
-      
+
       // Override the serviceExtensionManager on mockServiceManager
       when(mockServiceManager.serviceExtensionManager).thenReturn(customFake);
-      
+
       // Set state to enabled: false (which means clips not disabled -> checked true)
       await customFake.setServiceExtensionState(
         ext.extension,
         enabled: false,
         value: false,
       );
-      
+
       final checkbox = ServiceExtensionCheckbox(serviceExtension: ext);
-      await tester.pumpWidget(
-        wrap(Scaffold(body: Center(child: checkbox))),
-      );
+      await tester.pumpWidget(wrap(Scaffold(body: Center(child: checkbox))));
       await tester.pumpAndSettle();
-      
+
       final checkboxFinder = find.byType(Checkbox);
       expect(checkboxFinder, findsOneWidget);
-      
+
       final checkboxWidget = tester.widget<Checkbox>(checkboxFinder);
       expect(checkboxWidget.value, isTrue);
       expect(checkboxWidget.onChanged, isNull);
@@ -255,7 +255,8 @@ void main() {
   });
 }
 
-base class _UnavailableServiceExtensionManager extends FakeServiceExtensionManager {
+base class _UnavailableServiceExtensionManager
+    extends FakeServiceExtensionManager {
   final _unavailableExtensions = <String>{};
 
   void makeUnavailable(String name) {


### PR DESCRIPTION
Fixes https://github.com/flutter/devtools/issues/4083