### PR TITLE
Use super parameters in more places, linted by the analyzer

### DIFF
--- a/packages/devtools_app/test/framework/scaffold/scaffold_debugger_test.dart
+++ b/packages/devtools_app/test/framework/scaffold/scaffold_debugger_test.dart
@@ -110,15 +110,9 @@ class _TestScreen extends Screen {
   const _TestScreen(
     this.name,
     this.key, {
-    bool showFloatingDebuggerControls = true,
-    Key? tabKey,
-  }) : super(
-         name,
-         title: name,
-         icon: Icons.computer,
-         tabKey: tabKey,
-         showFloatingDebuggerControls: showFloatingDebuggerControls,
-       );
+    super.showFloatingDebuggerControls = true,
+    super.tabKey,
+  }) : super(name, title: name, icon: Icons.computer);
 
   final String name;
   final Key key;

--- a/packages/devtools_app/test/framework/scaffold/scaffold_debugging_controls_test.dart
+++ b/packages/devtools_app/test/framework/scaffold/scaffold_debugging_controls_test.dart
@@ -92,15 +92,9 @@ class _TestScreen extends Screen {
   const _TestScreen(
     this.name,
     this.key, {
-    bool showFloatingDebuggerControls = true,
-    Key? tabKey,
-  }) : super(
-         name,
-         title: name,
-         icon: Icons.computer,
-         tabKey: tabKey,
-         showFloatingDebuggerControls: showFloatingDebuggerControls,
-       );
+    super.showFloatingDebuggerControls = true,
+    super.tabKey,
+  }) : super(name, title: name, icon: Icons.computer);
 
   final String name;
   final Key key;

--- a/packages/devtools_app/test/framework/scaffold/scaffold_debugging_controls_test.dart
+++ b/packages/devtools_app/test/framework/scaffold/scaffold_debugging_controls_test.dart
@@ -89,12 +89,8 @@ void main() {
 }
 
 class _TestScreen extends Screen {
-  const _TestScreen(
-    this.name,
-    this.key, {
-    super.showFloatingDebuggerControls = true,
-    super.tabKey,
-  }) : super(name, title: name, icon: Icons.computer);
+  const _TestScreen(this.name, this.key, {super.tabKey})
+    : super(name, title: name, icon: Icons.computer);
 
   final String name;
   final Key key;

--- a/packages/devtools_app/test/framework/scaffold/scaffold_no_app_test.dart
+++ b/packages/devtools_app/test/framework/scaffold/scaffold_no_app_test.dart
@@ -77,18 +77,8 @@ void main() {
 }
 
 class _TestScreen extends Screen {
-  const _TestScreen(
-    this.name,
-    this.key, {
-    bool showFloatingDebuggerControls = true,
-    Key? tabKey,
-  }) : super(
-         name,
-         title: name,
-         icon: Icons.computer,
-         tabKey: tabKey,
-         showFloatingDebuggerControls: showFloatingDebuggerControls,
-       );
+  const _TestScreen(this.name, this.key, {super.tabKey})
+    : super(name, title: name, icon: Icons.computer);
 
   final String name;
   final Key key;

--- a/packages/devtools_app/test/framework/scaffold/scaffold_profile_test.dart
+++ b/packages/devtools_app/test/framework/scaffold/scaffold_profile_test.dart
@@ -84,18 +84,8 @@ void main() {
 }
 
 class _TestScreen extends Screen {
-  const _TestScreen(
-    this.name,
-    this.key, {
-    bool showFloatingDebuggerControls = true,
-    Key? tabKey,
-  }) : super(
-         name,
-         title: name,
-         icon: Icons.computer,
-         tabKey: tabKey,
-         showFloatingDebuggerControls: showFloatingDebuggerControls,
-       );
+  const _TestScreen(this.name, this.key, {super.tabKey})
+    : super(name, title: name, icon: Icons.computer);
 
   final String name;
   final Key key;

--- a/packages/devtools_app/test/framework/scaffold/scaffold_test.dart
+++ b/packages/devtools_app/test/framework/scaffold/scaffold_test.dart
@@ -291,18 +291,8 @@ void main() {
 }
 
 class _TestScreen extends Screen {
-  const _TestScreen(
-    this.name,
-    this.key, {
-    bool showFloatingDebuggerControls = true,
-    Key? tabKey,
-  }) : super(
-         name,
-         title: name,
-         icon: Icons.computer,
-         tabKey: tabKey,
-         showFloatingDebuggerControls: showFloatingDebuggerControls,
-       );
+  const _TestScreen(this.name, this.key, {super.tabKey})
+    : super(name, title: name, icon: Icons.computer);
 
   final String name;
   final Key key;


### PR DESCRIPTION
This fixes a breakage in CI: https://github.com/flutter/devtools/actions/runs/25175731644/job/73807795671?pr=9814

A few parameters are also just removed, as they became seen as "unused," and no calls to the constructor passes a value for the parameter.