### PR TITLE
Remove more legacy analytics logic

### DIFF
--- a/packages/devtools_app/lib/src/shared/server/_analytics_api.dart
+++ b/packages/devtools_app/lib/src/shared/server/_analytics_api.dart
@@ -4,21 +4,6 @@
 
 part of 'server.dart';
 
-/// Request DevTools property value 'firstRun' (GA dialog) stored in the file
-/// '~/flutter-devtools/.devtools'.
-Future<bool> isFirstRun() async {
-  bool firstRun = false;
-  if (isDevToolsServerAvailable) {
-    final resp = await request(apiGetDevToolsFirstRun);
-    if (resp?.statusCode == 200) {
-      firstRun = json.decode(resp!.body);
-    } else {
-      logWarning(resp, apiGetDevToolsFirstRun);
-    }
-  }
-  return firstRun;
-}
-
 /// Requests the Flutter client id from the Flutter store file ~\.flutter.
 ///
 /// If an empty String is returned, this means that Flutter Tool has never been

--- a/packages/devtools_shared/CHANGELOG.md
+++ b/packages/devtools_shared/CHANGELOG.md
@@ -5,9 +5,11 @@ found in the LICENSE file or at https://developers.google.com/open-source/licens
 -->
 # 13.0.0-wip
 * Deprecated `DevToolsStoreKeys.analyticsEnabled` since this is only used for legacy analytics.
-* **Breaking change:** Removed legacy analytics APIs and state cleanup (e.g. `apiGetFlutterGAEnabled`, `apiGetDevToolsEnabled`, `apiSetDevToolsEnabled`).
+* **Breaking change:** Removed legacy analytics storage key `DevToolsStoreKeys.isFirstRun`.
+* **Breaking change:** Removed legacy analytics APIs and state cleanup
+(e.g. `apiGetFlutterGAEnabled`, `apiGetDevToolsEnabled`, `apiSetDevToolsEnabled`, `apiGetDevToolsFirstRun`, `apiResetDevTools`).
 * **Breaking change:** Removed public constant `devToolsEnabledPropertyName`.
-* **Breaking change:** Removed the `analyticsEnabled` getter and setter from `DevToolsUsage`.
+* **Breaking change:** Removed `isFirstRun`, `reset`, and `analyticsEnabled` from `DevToolsUsage`.
 
 # 12.1.0
 * Adds additional logging to `IntegrationTestRunner`.

--- a/packages/devtools_shared/CHANGELOG.md
+++ b/packages/devtools_shared/CHANGELOG.md
@@ -4,8 +4,8 @@ Use of this source code is governed by a BSD-style license that can be
 found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
 -->
 # 13.0.0-wip
-* Deprecated `DevToolsStoreKeys.analyticsEnabled` since this is only used for legacy analytics.
-* **Breaking change:** Removed legacy analytics storage key `DevToolsStoreKeys.isFirstRun`.
+* Deprecated `DevToolsStoreKeys.analyticsEnabled` and `DevToolsStoreKeys.isFirstRun`
+since these were only used for legacy analytics.
 * **Breaking change:** Removed legacy analytics APIs and state cleanup
 (e.g. `apiGetFlutterGAEnabled`, `apiGetDevToolsEnabled`, `apiSetDevToolsEnabled`, `apiGetDevToolsFirstRun`, `apiResetDevTools`).
 * **Breaking change:** Removed public constant `devToolsEnabledPropertyName`.

--- a/packages/devtools_shared/CHANGELOG.md
+++ b/packages/devtools_shared/CHANGELOG.md
@@ -4,8 +4,8 @@ Use of this source code is governed by a BSD-style license that can be
 found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
 -->
 # 13.0.0-wip
-* Deprecated `DevToolsStoreKeys.analyticsEnabled` and `DevToolsStoreKeys.isFirstRun`
-since these were only used for legacy analytics.
+* **Breaking change:** Removed `DevToolsStoreKeys.analyticsEnabled` and
+`DevToolsStoreKeys.isFirstRun` since these were only used for legacy analytics.
 * **Breaking change:** Removed legacy analytics APIs and state cleanup
 (e.g. `apiGetFlutterGAEnabled`, `apiGetDevToolsEnabled`, `apiSetDevToolsEnabled`, `apiGetDevToolsFirstRun`, `apiResetDevTools`).
 * **Breaking change:** Removed public constant `devToolsEnabledPropertyName`.

--- a/packages/devtools_shared/lib/src/devtools_api.dart
+++ b/packages/devtools_shared/lib/src/devtools_api.dart
@@ -17,10 +17,6 @@ const apiParameterVmServiceConnected = 'connected';
 /// Flutter GA properties APIs:
 const apiGetFlutterGAClientId = '${apiPrefix}getFlutterGAClientId';
 
-/// DevTools GA properties APIs:
-const apiResetDevTools = '${apiPrefix}resetDevTools';
-const apiGetDevToolsFirstRun = '${apiPrefix}getDevToolsFirstRun';
-
 abstract class PreferencesApi {
   /// Returns the preference value in the DevTools store file for the key
   /// specified by the [preferenceKeyProperty] query parameter.

--- a/packages/devtools_shared/lib/src/server/devtools_store.dart
+++ b/packages/devtools_shared/lib/src/server/devtools_store.dart
@@ -13,6 +13,13 @@ enum DevToolsStoreKeys {
   )
   analyticsEnabled,
 
+  /// The key holding the value for whether this is a user's first run of
+  /// DevTools.
+  @Deprecated(
+    'This key was used for legacy analytics and will be removed.',
+  )
+  isFirstRun,
+
   /// The key holding the value for the last DevTools version that the user
   /// viewed release notes for.
   lastReleaseNotesVersion,
@@ -58,7 +65,9 @@ class DevToolsUsage {
   void _removeLegacyKeys() {
     // TODO(https://github.com/flutter/devtools/issues/9775): remove this logic
     // once legacy keys have been removed for ~1 year.
-    properties.remove(DevToolsStoreKeys.analyticsEnabled.name);
+    properties
+      ..remove(DevToolsStoreKeys.analyticsEnabled.name)
+      ..remove(DevToolsStoreKeys.isFirstRun.name);
   }
 
   bool surveyNameExists(String surveyName) => properties[surveyName] != null;

--- a/packages/devtools_shared/lib/src/server/devtools_store.dart
+++ b/packages/devtools_shared/lib/src/server/devtools_store.dart
@@ -5,21 +5,6 @@
 import 'file_system.dart';
 
 enum DevToolsStoreKeys {
-  /// The key holding the value for whether Google Analytics (legacy) for
-  /// DevTools have been enabled.
-  @Deprecated(
-    'Use unified_analytics instead; this key is for legacy analytics and will '
-    'be removed.',
-  )
-  analyticsEnabled,
-
-  /// The key holding the value for whether this is a user's first run of
-  /// DevTools.
-  @Deprecated(
-    'This key was used for legacy analytics and will be removed.',
-  )
-  isFirstRun,
-
   /// The key holding the value for the last DevTools version that the user
   /// viewed release notes for.
   lastReleaseNotesVersion,
@@ -64,10 +49,12 @@ class DevToolsUsage {
 
   void _removeLegacyKeys() {
     // TODO(https://github.com/flutter/devtools/issues/9775): remove this logic
-    // once legacy keys have been removed for ~1 year.
+    // once legacy keys have been removed for ~1 year. We are intentionally
+    // using raw strings instead of values from [DevToolsStoreKeys] to avoid
+    // unnecessary breaking changes in the future.
     properties
-      ..remove(DevToolsStoreKeys.analyticsEnabled.name)
-      ..remove(DevToolsStoreKeys.isFirstRun.name);
+      ..remove('analyticsEnabled')
+      ..remove('isFirstRun');
   }
 
   bool surveyNameExists(String surveyName) => properties[surveyName] != null;

--- a/packages/devtools_shared/lib/src/server/devtools_store.dart
+++ b/packages/devtools_shared/lib/src/server/devtools_store.dart
@@ -13,10 +13,6 @@ enum DevToolsStoreKeys {
   )
   analyticsEnabled,
 
-  /// The key holding the value for whether this is a user's first run of
-  /// DevTools.
-  isFirstRun,
-
   /// The key holding the value for the last DevTools version that the user
   /// viewed release notes for.
   lastReleaseNotesVersion,
@@ -59,19 +55,10 @@ class DevToolsUsage {
 
   late IOPersistentProperties properties;
 
-  void reset() {
-    properties.remove(DevToolsStoreKeys.isFirstRun.name);
-  }
-
   void _removeLegacyKeys() {
     // TODO(https://github.com/flutter/devtools/issues/9775): remove this logic
     // once legacy keys have been removed for ~1 year.
     properties.remove(DevToolsStoreKeys.analyticsEnabled.name);
-  }
-
-  bool get isFirstRun {
-    return properties[DevToolsStoreKeys.isFirstRun.name] =
-        properties[DevToolsStoreKeys.isFirstRun.name] == null;
   }
 
   bool surveyNameExists(String surveyName) => properties[surveyName] != null;

--- a/packages/devtools_shared/lib/src/server/server_api.dart
+++ b/packages/devtools_shared/lib/src/server/server_api.dart
@@ -82,16 +82,6 @@ class ServerApi {
           api: api,
         );
 
-      // ----- DevTools Store. -----
-
-      case apiResetDevTools:
-        _devToolsStore.reset();
-        return _encodeResponse(true, api: api);
-      case apiGetDevToolsFirstRun:
-        // Has DevTools been run first time? To bring up analytics dialog.
-        final isFirstRun = _devToolsStore.isFirstRun;
-        return _encodeResponse(isFirstRun, api: api);
-
       // ----- Preferences api. -----
       case PreferencesApi.getPreferenceValue:
         return _PreferencesApiHandler.getPreferenceValue(


### PR DESCRIPTION
A follow on to https://github.com/flutter/devtools/pull/9777 to remove a few additional legacy analytics APIs. Work towards https://github.com/flutter/devtools/issues/9819