### PR TITLE
Prep devtools packages for publish

### DIFF
--- a/packages/devtools_app_shared/CHANGELOG.md
+++ b/packages/devtools_app_shared/CHANGELOG.md
@@ -3,7 +3,7 @@ Copyright 2025 The Flutter Authors
 Use of this source code is governed by a BSD-style license that can be
 found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
 -->
-## 0.5.1-wip
+## 0.5.1
 * Add DevTools-styled text field `DevToolsTextField`.
 * Updates `devtools_shared` constraint to `^13.0.0`.
 

--- a/packages/devtools_app_shared/pubspec.yaml
+++ b/packages/devtools_app_shared/pubspec.yaml
@@ -3,7 +3,7 @@
 # found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
 name: devtools_app_shared
 description: Package of Dart & Flutter structures shared between devtools_app and devtools extensions.
-version: 0.5.1-wip
+version: 0.5.1
 repository: https://github.com/flutter/devtools/tree/master/packages/devtools_app_shared
 
 environment:
@@ -15,7 +15,7 @@ resolution: workspace
 dependencies:
   collection: ^1.15.0
   dds_service_extensions: ^2.0.0
-  devtools_shared: ^13.0.0-wip
+  devtools_shared: ^13.0.0
   dtd: ^4.0.0
   flutter:
     sdk: flutter

--- a/packages/devtools_extensions/CHANGELOG.md
+++ b/packages/devtools_extensions/CHANGELOG.md
@@ -3,7 +3,7 @@ Copyright 2025 The Flutter Authors
 Use of this source code is governed by a BSD-style license that can be
 found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
 -->
-## 0.5.1-wip
+## 0.5.1
 * Updates `devtools_shared` constraint to `^13.0.0`.
 
 ## 0.5.0

--- a/packages/devtools_extensions/CHANGELOG.md
+++ b/packages/devtools_extensions/CHANGELOG.md
@@ -4,6 +4,7 @@ Use of this source code is governed by a BSD-style license that can be
 found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
 -->
 ## 0.5.1
+* Updates `devtools_app_shared` constraint to `^0.5.1`.
 * Updates `devtools_shared` constraint to `^13.0.0`.
 
 ## 0.5.0

--- a/packages/devtools_extensions/pubspec.yaml
+++ b/packages/devtools_extensions/pubspec.yaml
@@ -3,7 +3,7 @@
 # found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
 name: devtools_extensions
 description: A package for building and supporting extensions for Dart DevTools.
-version: 0.5.1-wip
+version: 0.5.1
 
 repository: https://github.com/flutter/devtools/tree/master/packages/devtools_extensions
 
@@ -18,8 +18,8 @@ executables:
 
 dependencies:
   args: ^2.4.2
-  devtools_shared: ^13.0.0-wip
-  devtools_app_shared: ^0.5.1-wip
+  devtools_shared: ^13.0.0
+  devtools_app_shared: ^0.5.1
   flutter:
     sdk: flutter
   io: ^1.0.4

--- a/packages/devtools_shared/CHANGELOG.md
+++ b/packages/devtools_shared/CHANGELOG.md
@@ -3,7 +3,7 @@ Copyright 2025 The Flutter Authors
 Use of this source code is governed by a BSD-style license that can be
 found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
 -->
-# 13.0.0-wip
+# 13.0.0
 * Deprecated `DevToolsStoreKeys.analyticsEnabled` since this is only used for legacy analytics.
 * **Breaking change:** Removed legacy analytics APIs and state cleanup (e.g. `apiGetFlutterGAEnabled`, `apiGetDevToolsEnabled`, `apiSetDevToolsEnabled`).
 * **Breaking change:** Removed public constant `devToolsEnabledPropertyName`.

--- a/packages/devtools_shared/pubspec.yaml
+++ b/packages/devtools_shared/pubspec.yaml
@@ -4,7 +4,7 @@
 name: devtools_shared
 description: Package of shared Dart structures between devtools_app, dds, and other tools.
 
-version: 13.0.0-wip
+version: 13.0.0
 
 repository: https://github.com/flutter/devtools/tree/master/packages/devtools_shared
 


### PR DESCRIPTION
Will wait for https://github.com/flutter/devtools/pull/9817 to land before publishing.

Work towards https://github.com/flutter/devtools/issues/9819.