### PR TITLE
Prep devtools for next release

### DIFF
--- a/packages/devtools_app/lib/devtools.dart
+++ b/packages/devtools_app/lib/devtools.dart
@@ -10,4 +10,4 @@
 /// Note: a regexp in the `dt update-version' command logic matches the constant
 /// declaration `const version =`. If you change the declaration you must also
 /// modify the regex in the `dt update-version' command logic.
-const version = '2.58.0';
+const version = '2.59.0-dev.0';

--- a/packages/devtools_app/pubspec.yaml
+++ b/packages/devtools_app/pubspec.yaml
@@ -7,7 +7,7 @@ publish_to: none
 
 # Note: this version should only be updated by running the 'dt update-version'
 # command that updates the version here and in 'devtools.dart'.
-version: 2.58.0
+version: 2.59.0-dev.0
 
 repository: https://github.com/flutter/devtools/tree/master/packages/devtools_app
 

--- a/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
+++ b/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
@@ -6,9 +6,9 @@ found in the LICENSE file or at https://developers.google.com/open-source/licens
 This is a draft for future release notes that are going to land on
 [the Flutter website](https://docs.flutter.dev/tools/devtools/release-notes).
 
-# DevTools 2.58.0 release notes
+# DevTools 2.59.0 release notes
 
-The 2.58.0 release of the Dart and Flutter DevTools
+The 2.59.0 release of the Dart and Flutter DevTools
 includes the following changes among other general improvements.
 To learn more about DevTools, check out the
 [DevTools overview](/tools/devtools).
@@ -19,16 +19,11 @@ TODO: Remove this section if there are not any updates.
 
 ## Inspector updates
 
-- Deleted the option to use the legacy inspector.
-  [#9782](https://github.com/flutter/devtools/pull/9782)
-- Fixed an issue where navigating the Inspector widget tree with the keyboard arrow keys did not update the selected widget in the connected Flutter app. [#9810](https://github.com/flutter/devtools/pull/9810)
-- Fixed an issue where clicking a widget row after collapsing a subtree with the left arrow key unexpectedly re-expanded the subtree. [#9810](https://github.com/flutter/devtools/pull/9810)
-- Fixed an issue where collapsing the Inspector widget tree to a single row with the left arrow key caused a loading spinner to appear instead of showing the root node. [#9810](https://github.com/flutter/devtools/pull/9810)
+TODO: Remove this section if there are not any updates.
 
 ## Performance updates
 
-- Fixed an issue where 'More Debug Options' showed options as unselected in
-profile mode even when selected. [#9813](https://github.com/flutter/devtools/issues/9813)
+TODO: Remove this section if there are not any updates.
 
 ## CPU profiler updates
 
@@ -40,21 +35,15 @@ TODO: Remove this section if there are not any updates.
 
 ## Debugger updates
 
-- Fixed an issue where long string values in the console/variables view would overflow and overlap with other elements. [#7112](https://github.com/flutter/devtools/issues/7112)
+TODO: Remove this section if there are not any updates.
 
 ## Network profiler updates
 
-- Added response size column to the Network tab and displayed response size in the request inspector overview.  
-  [#9744](https://github.com/flutter/devtools/pull/9744)
+TODO: Remove this section if there are not any updates.
 
-- Improved HTTP request status classification in the Network tab to better distinguish cancelled, completed, and in-flight requests (for example, avoiding some cases where cancelled requests appeared as pending). [#9683](https://github.com/flutter/devtools/pull/9683)
-
-- Added a filter setting to hide HTTP-profiler socket data.  
-  [#9698](https://github.com/flutter/devtools/pull/9698)
-  
 ## Logging updates
 
-- Fixed an issue where log messages containing newline characters were incorrectly split into multiple separate entries in the Logging screen. [#9757](https://github.com/flutter/devtools/pull/9757)
+TODO: Remove this section if there are not any updates.
 
 ## App size tool updates
 
@@ -62,7 +51,7 @@ TODO: Remove this section if there are not any updates.
 
 ## Deep links tool updates
 
-- Pluralized "domain" and "path" in the validation summary notification titles when multiple errors are present. [#9790](https://github.com/flutter/devtools/pull/9790)
+TODO: Remove this section if there are not any updates.
 
 ## VS Code sidebar updates
 
@@ -79,4 +68,4 @@ TODO: Remove this section if there are not any updates.
 ## Full commit history
 
 To find a complete list of changes in this release, check out the
-[DevTools git log](https://github.com/flutter/devtools/tree/v2.58.0).
+[DevTools git log](https://github.com/flutter/devtools/tree/v2.59.0).

--- a/tool/lib/commands/release_notes_helper.dart
+++ b/tool/lib/commands/release_notes_helper.dart
@@ -91,6 +91,8 @@ class ReleaseNotesCommand extends Command {
     final websiteReleaseNotesDir = Directory(
       p.join(
         websiteRepoPath,
+        'sites',
+        'docs',
         'src',
         'content',
         'tools',


### PR DESCRIPTION
This PR also fixes an issue with the release notes tool due to file locations changing in the flutter/website repo.

Final step for the 2.58.0 release. Fixes https://github.com/flutter/devtools/issues/9819.