### PR TITLE
Fix SplitPane RangeError when child count changes between rebuilds

### DIFF
--- a/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
+++ b/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
@@ -15,7 +15,10 @@ To learn more about DevTools, check out the
 
 ## General updates
 
-TODO: Remove this section if there are not any updates.
+* Fixed a `RangeError` thrown by `SplitPane` when the parent rebuilt the
+  widget with a different number of children, for example when toggling a
+  panel in or out of the layout. -
+  [#9822](https://github.com/flutter/devtools/pull/9822)
 
 ## Inspector updates
 

--- a/packages/devtools_app_shared/CHANGELOG.md
+++ b/packages/devtools_app_shared/CHANGELOG.md
@@ -3,6 +3,10 @@ Copyright 2025 The Flutter Authors
 Use of this source code is governed by a BSD-style license that can be
 found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
 -->
+## 0.5.2
+* Fix a `RangeError` thrown by `SplitPane` when the number of children
+  changes between rebuilds.
+
 ## 0.5.1
 * Add DevTools-styled text field `DevToolsTextField`.
 * Updates `devtools_shared` constraint to `^13.0.0`.

--- a/packages/devtools_app_shared/CHANGELOG.md
+++ b/packages/devtools_app_shared/CHANGELOG.md
@@ -3,7 +3,7 @@ Copyright 2025 The Flutter Authors
 Use of this source code is governed by a BSD-style license that can be
 found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
 -->
-## 0.5.2
+## 0.5.2-wip
 * Fix a `RangeError` thrown by `SplitPane` when the number of children
   changes between rebuilds.
 

--- a/packages/devtools_app_shared/lib/src/ui/split_pane.dart
+++ b/packages/devtools_app_shared/lib/src/ui/split_pane.dart
@@ -88,7 +88,7 @@ final class SplitPane extends StatefulWidget {
 }
 
 final class _SplitPaneState extends State<SplitPane> {
-  late final List<double> fractions;
+  late List<double> fractions;
 
   bool get isHorizontal => widget.axis == Axis.horizontal;
 
@@ -96,6 +96,18 @@ final class _SplitPaneState extends State<SplitPane> {
   void initState() {
     super.initState();
     fractions = List.of(widget.initialFractions);
+  }
+
+  @override
+  void didUpdateWidget(SplitPane oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    // When the number of children changes, the previously stored [fractions]
+    // list will be out of sync with [widget.minSizes] and [widget.children],
+    // which causes a RangeError during layout. Reset to the new
+    // [initialFractions] when the child count changes.
+    if (oldWidget.children.length != widget.children.length) {
+      fractions = List.of(widget.initialFractions);
+    }
   }
 
   @override

--- a/packages/devtools_app_shared/pubspec.yaml
+++ b/packages/devtools_app_shared/pubspec.yaml
@@ -3,7 +3,7 @@
 # found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
 name: devtools_app_shared
 description: Package of Dart & Flutter structures shared between devtools_app and devtools extensions.
-version: 0.5.1
+version: 0.5.2
 repository: https://github.com/flutter/devtools/tree/master/packages/devtools_app_shared
 
 environment:

--- a/packages/devtools_app_shared/pubspec.yaml
+++ b/packages/devtools_app_shared/pubspec.yaml
@@ -3,7 +3,7 @@
 # found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
 name: devtools_app_shared
 description: Package of Dart & Flutter structures shared between devtools_app and devtools extensions.
-version: 0.5.2
+version: 0.5.2-wip
 repository: https://github.com/flutter/devtools/tree/master/packages/devtools_app_shared
 
 environment:

--- a/packages/devtools_app_shared/test/ui/split_pane_test.dart
+++ b/packages/devtools_app_shared/test/ui/split_pane_test.dart
@@ -1154,6 +1154,67 @@ void main() {
       );
     });
 
+    group('rebuilds with a different number of children', () {
+      testWidgets(
+        'does not throw a RangeError when child count shrinks',
+        (WidgetTester tester) async {
+          final threeChildSplit = buildSplitPane(
+            Axis.horizontal,
+            children: const [_w1, _w2, _w3],
+            initialFractions: const [0.2, 0.4, 0.4],
+            minSizes: const [50.0, 50.0, 50.0],
+          );
+          await tester.pumpWidget(wrap(threeChildSplit));
+          expect(find.byKey(_k1), findsOneWidget);
+          expect(find.byKey(_k2), findsOneWidget);
+          expect(find.byKey(_k3), findsOneWidget);
+
+          final twoChildSplit = buildSplitPane(
+            Axis.horizontal,
+            children: const [_w1, _w2],
+            initialFractions: const [0.5, 0.5],
+            minSizes: const [50.0, 50.0],
+          );
+          await tester.pumpWidget(wrap(twoChildSplit));
+          await tester.pumpAndSettle();
+
+          expect(tester.takeException(), isNull);
+          expect(find.byKey(_k1), findsOneWidget);
+          expect(find.byKey(_k2), findsOneWidget);
+          expect(find.byKey(_k3), findsNothing);
+        },
+      );
+
+      testWidgets(
+        'does not throw a RangeError when child count grows',
+        (WidgetTester tester) async {
+          final twoChildSplit = buildSplitPane(
+            Axis.horizontal,
+            children: const [_w1, _w2],
+            initialFractions: const [0.5, 0.5],
+            minSizes: const [50.0, 50.0],
+          );
+          await tester.pumpWidget(wrap(twoChildSplit));
+          expect(find.byKey(_k1), findsOneWidget);
+          expect(find.byKey(_k2), findsOneWidget);
+
+          final threeChildSplit = buildSplitPane(
+            Axis.horizontal,
+            children: const [_w1, _w2, _w3],
+            initialFractions: const [0.2, 0.4, 0.4],
+            minSizes: const [50.0, 50.0, 50.0],
+          );
+          await tester.pumpWidget(wrap(threeChildSplit));
+          await tester.pumpAndSettle();
+
+          expect(tester.takeException(), isNull);
+          expect(find.byKey(_k1), findsOneWidget);
+          expect(find.byKey(_k2), findsOneWidget);
+          expect(find.byKey(_k3), findsOneWidget);
+        },
+      );
+    });
+
     group('axisFor', () {
       testWidgetsWithWindowSize(
         'return Axis.horizontal',


### PR DESCRIPTION
Fixes #9648.

`SplitPane` cached its `fractions` list in `initState` only. When the parent rebuilt the widget with a different number of children (for example, toggling a panel in or out with a collection-`if`), `fractions.length` stayed at the old value while `widget.minSizes` and `widget.children` shrank. The next layout pass called `minSizeForIndex` with an index past the end of `widget.minSizes` and threw `RangeError (index): Index out of range: index should be less than 2: 2` from `split_pane.dart:126`.

This adds `didUpdateWidget` to `_SplitPaneState`. When the child count changes, `fractions` is reset to `List.of(widget.initialFractions)` so it stays in sync with the new `children` and `minSizes`. The existing constructor assertion (`children.length == initialFractions.length`) already guarantees the new list has the right length, so no extra defensive logic is needed. `fractions` lost its `final` modifier to allow the reassignment.

`devtools_app_shared` is bumped to `0.5.2` and a CHANGELOG entry is added.

### Tests

Added two regression tests in `split_pane_test.dart` under a new `rebuilds with a different number of children` group:

- pumps a 3-child `SplitPane`, then pumps a 2-child `SplitPane` with the same key path, and asserts no exception is thrown
- the inverse: 2-child then 3-child

Both tests reproduce the original `RangeError` on master and pass with the fix.

Note: running the local `flutter test` against the bundled Flutter SDK currently fails to compile because of an unrelated pre-existing error in `flutter/lib/src/widgets/_window_linux.dart` (`isSizedToContent` getter is missing on `WindowingOwnerLinux`). That failure reproduces on master without this change and is independent of `SplitPane`. CI should compile against a matching SDK.

## Pre-launch Checklist

### General checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I updated/added relevant documentation (doc comments with `///`).

### Issues checklist

- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I listed at least one issue which has the [`contributions-welcome`] or [`good-first-issue`] label. 
- [x] I did not list at least one issue with the [`contributions-welcome`] or [`good-first-issue`] label. I understand this means my PR might take longer to be reviewed. 

### Tests checklist

- [x] I added new tests to check the change I am making...
- [ ] OR there is a reason for not adding tests, which I explained in the PR description.

### AI-tooling checklist

- [ ] I did not use any AI tooling in creating this PR.
- [x] OR I did use AI tooling, and...
    * [x] I read the [AI contributions guidelines] and agree to follow them.
    * [x] I reviewed all AI-generated code before opening this PR.
    * [x] I understand and am able to discuss the code in this PR.
    * [x] I have verifed the accuracy of any AI-generated text included in the PR description.
    * [x] I commit to verifying the accuracy of any AI-generated code or text that I upload in response to review comments.

### Feature-change checklist 

- [ ] This PR does not change the DevTools UI or behavior and...
    * [ ] I added the `release-notes-not-required` label or left a comment requesting the label be added.
- [x] OR this PR does change the DevTools UI or behavior and...
    * [x] I added an entry to `packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md`.
    * [ ] I included before/after screenshots and/or a GIF demo of the new UI to my PR description.
    * [x] I ran the DevTools app locally to manually verify my changes.

![build.yaml badge]

If you need help, consider asking for help on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/devtools/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[CLA]: https://cla.developers.google.com/
[`contributions-welcome`]: https://github.com/flutter/devtools/issues?q=state%3Aopen%20label%3Acontributions-welcome
[`good-first-issue`]: https://github.com/flutter/devtools/issues?q=state%3Aopen%20label%3Agood-first-issue
[AI contributions guidelines]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[build.yaml badge]: https://github.com/flutter/devtools/actions/workflows/build.yaml/badge.svg
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md

