### PR TITLE
Fix HoverCard tooltip clipping in the Flutter Inspector

### DIFF
--- a/packages/devtools_app/lib/src/shared/ui/hover.dart
+++ b/packages/devtools_app/lib/src/shared/ui/hover.dart
@@ -232,7 +232,7 @@ class HoverCard {
     final maxX = math.max(_hoverMargin, overlaySize.width - _hoverMargin - width);
     final x = (event.position.dx - (width / 2.0)).clamp(_hoverMargin, maxX);
 
-    double y = event.position.dy + _hoverYOffset;
+    var y = event.position.dy + _hoverYOffset;
     if (y + _maxHoverCardHeight > overlaySize.height - _hoverMargin) {
       y = math.max(
         _hoverMargin,

--- a/packages/devtools_app/lib/src/shared/ui/hover.dart
+++ b/packages/devtools_app/lib/src/shared/ui/hover.dart
@@ -215,13 +215,33 @@ class HoverCard {
          context: context,
          contents: contents,
          width: width,
-         position: Offset(
-           math.max(0, event.position.dx - (width / 2.0)),
-           event.position.dy + _hoverYOffset,
-         ),
+         position: _calculateCursorPosition(context, event, width),
          title: title,
          hoverCardController: hoverCardController,
        );
+
+  static Offset _calculateCursorPosition(
+    BuildContext context,
+    PointerHoverEvent event,
+    double width,
+  ) {
+    final overlayBox =
+        Overlay.of(context).context.findRenderObject() as RenderBox;
+    final overlaySize = overlayBox.size;
+
+    final maxX = math.max(_hoverMargin, overlaySize.width - _hoverMargin - width);
+    final x = (event.position.dx - (width / 2.0)).clamp(_hoverMargin, maxX);
+
+    double y = event.position.dy + _hoverYOffset;
+    if (y + _maxHoverCardHeight > overlaySize.height - _hoverMargin) {
+      y = math.max(
+        _hoverMargin,
+        overlaySize.height - _maxHoverCardHeight - _hoverMargin,
+      );
+    }
+
+    return Offset(x, y);
+  }
 
   late OverlayEntry _overlayEntry;
 
@@ -542,8 +562,12 @@ class _HoverCardTooltipState extends State<HoverCardTooltip> {
         Overlay.of(context).context.findRenderObject() as RenderBox;
     final box = context.findRenderObject() as RenderBox;
 
-    final maxX = overlayBox.size.width - _hoverMargin - width;
-    final maxY = overlayBox.size.height - _hoverMargin;
+    final maxX = math.max(_hoverMargin, overlayBox.size.width - _hoverMargin - width);
+    double maxY = overlayBox.size.height - _hoverMargin;
+    if (maxY - _maxHoverCardHeight > _hoverMargin) {
+      maxY -= _maxHoverCardHeight;
+    }
+    maxY = math.max(_hoverMargin, maxY);
 
     final offset = box.localToGlobal(
       box.size.bottomCenter(Offset.zero).translate(-width / 2, _hoverYOffset),

--- a/packages/devtools_app/lib/src/shared/ui/hover.dart
+++ b/packages/devtools_app/lib/src/shared/ui/hover.dart
@@ -229,16 +229,17 @@ class HoverCard {
         Overlay.of(context).context.findRenderObject() as RenderBox;
     final overlaySize = overlayBox.size;
 
-    final maxX = math.max(_hoverMargin, overlaySize.width - _hoverMargin - width);
+    final maxX =
+        math.max(_hoverMargin, overlaySize.width - _hoverMargin - width);
     final x = (event.position.dx - (width / 2.0)).clamp(_hoverMargin, maxX);
 
-    var y = event.position.dy + _hoverYOffset;
-    if (y + _maxHoverCardHeight > overlaySize.height - _hoverMargin) {
-      y = math.max(
-        _hoverMargin,
-        overlaySize.height - _maxHoverCardHeight - _hoverMargin,
-      );
+    double maxY = overlaySize.height - _hoverMargin;
+    if (maxY - _maxHoverCardHeight > _hoverMargin) {
+      maxY -= _maxHoverCardHeight;
     }
+    maxY = math.max(_hoverMargin, maxY);
+
+    final y = (event.position.dy + _hoverYOffset).clamp(_hoverMargin, maxY);
 
     return Offset(x, y);
   }

--- a/packages/devtools_app/lib/src/shared/ui/hover.dart
+++ b/packages/devtools_app/lib/src/shared/ui/hover.dart
@@ -215,12 +215,12 @@ class HoverCard {
          context: context,
          contents: contents,
          width: width,
-         position: _calculateCursorPosition(context, event, width),
+         position: _calculateCardPositionFromPointerEvent(context, event, width),
          title: title,
          hoverCardController: hoverCardController,
        );
 
-  static Offset _calculateCursorPosition(
+  static Offset _calculateCardPositionFromPointerEvent(
     BuildContext context,
     PointerHoverEvent event,
     double width,
@@ -531,7 +531,7 @@ class _HoverCardTooltipState extends State<HoverCardTooltip> {
         title: hoverCardData.title,
         contents: hoverCardData.contents,
         width: hoverCardData.width,
-        position: _calculateTooltipPosition(hoverCardData.width),
+        position: _calculateCardPosition(hoverCardData.width),
         hoverCardController: _hoverCardController,
       ),
     );
@@ -558,7 +558,7 @@ class _HoverCardTooltipState extends State<HoverCardTooltip> {
     return completer;
   }
 
-  Offset _calculateTooltipPosition(double width) {
+  Offset _calculateCardPosition(double width) {
     final overlayBox =
         Overlay.of(context).context.findRenderObject() as RenderBox;
     final box = context.findRenderObject() as RenderBox;

--- a/packages/devtools_app/lib/src/shared/ui/hover.dart
+++ b/packages/devtools_app/lib/src/shared/ui/hover.dart
@@ -229,16 +229,16 @@ class HoverCard {
         Overlay.of(context).context.findRenderObject() as RenderBox;
     final overlaySize = overlayBox.size;
 
-    final maxX =
-        math.max(_hoverMargin, overlaySize.width - _hoverMargin - width);
+    final maxX = math.max(
+      _hoverMargin,
+      overlaySize.width - _hoverMargin - width,
+    );
     final x = (event.position.dx - (width / 2.0)).clamp(_hoverMargin, maxX);
 
-    double maxY = overlaySize.height - _hoverMargin;
-    if (maxY - _maxHoverCardHeight > _hoverMargin) {
-      maxY -= _maxHoverCardHeight;
-    }
-    maxY = math.max(_hoverMargin, maxY);
-
+    final maxY = math.max(
+      _hoverMargin,
+      overlaySize.height - _hoverMargin - _maxHoverCardHeight,
+    );
     final y = (event.position.dy + _hoverYOffset).clamp(_hoverMargin, maxY);
 
     return Offset(x, y);
@@ -563,12 +563,14 @@ class _HoverCardTooltipState extends State<HoverCardTooltip> {
         Overlay.of(context).context.findRenderObject() as RenderBox;
     final box = context.findRenderObject() as RenderBox;
 
-    final maxX = math.max(_hoverMargin, overlayBox.size.width - _hoverMargin - width);
-    double maxY = overlayBox.size.height - _hoverMargin;
-    if (maxY - _maxHoverCardHeight > _hoverMargin) {
-      maxY -= _maxHoverCardHeight;
-    }
-    maxY = math.max(_hoverMargin, maxY);
+    final maxX = math.max(
+      _hoverMargin,
+      overlayBox.size.width - _hoverMargin - width,
+    );
+    final maxY = math.max(
+      _hoverMargin,
+      overlayBox.size.height - _hoverMargin - _maxHoverCardHeight,
+    );
 
     final offset = box.localToGlobal(
       box.size.bottomCenter(Offset.zero).translate(-width / 2, _hoverYOffset),

--- a/packages/devtools_app/lib/src/shared/ui/hover.dart
+++ b/packages/devtools_app/lib/src/shared/ui/hover.dart
@@ -14,18 +14,18 @@ import 'package:provider/provider.dart';
 import 'common_widgets.dart';
 import 'utils.dart';
 
-const _maxHoverCardHeight = 250.0;
-const _hoverCardTitleHeight = 30.0;
+const _maxHoverCardContentHeight = 250.0;
+const _hoverCardTitleHeight = 24.0;
 const _hoverCardDividerHeight = 16.0;
-const _hoverCardPadding = 8.0;
 
 /// The total maximum height of the [HoverCard] including content, title,
-/// divider, and padding.
+/// divider, vertical padding, and borders.
 const _totalMaxHoverCardHeight =
-    _maxHoverCardHeight +
+    _maxHoverCardContentHeight +
     _hoverCardTitleHeight +
     _hoverCardDividerHeight +
-    _hoverCardPadding;
+    (denseSpacing * 2) +
+    (hoverCardBorderSize * 2);
 
 TextStyle get _hoverTitleTextStyle => fixBlurryText(
   const TextStyle(
@@ -153,9 +153,9 @@ class HoverCard {
     required Offset position,
     required HoverCardController hoverCardController,
     String? title,
-    double? maxCardHeight,
+    double? maxCardContentHeight,
   }) {
-    maxCardHeight ??= _maxHoverCardHeight;
+    maxCardContentHeight ??= _maxHoverCardContentHeight;
     final overlayState = Overlay.of(context);
     final theme = Theme.of(context);
     final colorScheme = theme.colorScheme;
@@ -190,6 +190,7 @@ class HoverCard {
                   if (title != null) ...[
                     SizedBox(
                       width: width,
+                      height: _hoverCardTitleHeight,
                       child: Text(
                         title,
                         overflow: TextOverflow.ellipsis,
@@ -197,11 +198,14 @@ class HoverCard {
                         textAlign: TextAlign.center,
                       ),
                     ),
-                    Divider(color: theme.focusColor),
+                    Divider(
+                      color: theme.focusColor,
+                      height: _hoverCardDividerHeight,
+                    ),
                   ],
                   SingleChildScrollView(
                     child: Container(
-                      constraints: BoxConstraints(maxHeight: maxCardHeight!),
+                      constraints: BoxConstraints(maxHeight: maxCardContentHeight!),
                       child: contents,
                     ),
                   ),

--- a/packages/devtools_app/lib/src/shared/ui/hover.dart
+++ b/packages/devtools_app/lib/src/shared/ui/hover.dart
@@ -15,6 +15,17 @@ import 'common_widgets.dart';
 import 'utils.dart';
 
 const _maxHoverCardHeight = 250.0;
+const _hoverCardTitleHeight = 30.0;
+const _hoverCardDividerHeight = 16.0;
+const _hoverCardPadding = 8.0;
+
+/// The total maximum height of the [HoverCard] including content, title,
+/// divider, and padding.
+const _totalMaxHoverCardHeight =
+    _maxHoverCardHeight +
+    _hoverCardTitleHeight +
+    _hoverCardDividerHeight +
+    _hoverCardPadding;
 
 TextStyle get _hoverTitleTextStyle => fixBlurryText(
   const TextStyle(
@@ -237,7 +248,7 @@ class HoverCard {
 
     final maxY = math.max(
       _hoverMargin,
-      overlaySize.height - _hoverMargin - _maxHoverCardHeight,
+      overlaySize.height - _hoverMargin - _totalMaxHoverCardHeight,
     );
     final y = (event.position.dy + _hoverYOffset).clamp(_hoverMargin, maxY);
 
@@ -569,7 +580,7 @@ class _HoverCardTooltipState extends State<HoverCardTooltip> {
     );
     final maxY = math.max(
       _hoverMargin,
-      overlayBox.size.height - _hoverMargin - _maxHoverCardHeight,
+      overlayBox.size.height - _hoverMargin - _totalMaxHoverCardHeight,
     );
 
     final offset = box.localToGlobal(

--- a/packages/devtools_app/lib/src/shared/ui/hover.dart
+++ b/packages/devtools_app/lib/src/shared/ui/hover.dart
@@ -208,7 +208,9 @@ class HoverCard {
                   ],
                   SingleChildScrollView(
                     child: Container(
-                      constraints: BoxConstraints(maxHeight: maxCardContentHeight!),
+                      constraints: BoxConstraints(
+                        maxHeight: maxCardContentHeight!,
+                      ),
                       child: contents,
                     ),
                   ),
@@ -588,10 +590,7 @@ class _HoverCardTooltipState extends State<HoverCardTooltip> {
     return completer;
   }
 
-  Offset _calculateCardPosition(
-    double width, {
-    String? title,
-  }) {
+  Offset _calculateCardPosition(double width, {String? title}) {
     final overlayBox =
         Overlay.of(context).context.findRenderObject() as RenderBox;
     final box = context.findRenderObject() as RenderBox;

--- a/packages/devtools_app/lib/src/shared/ui/hover.dart
+++ b/packages/devtools_app/lib/src/shared/ui/hover.dart
@@ -18,14 +18,17 @@ const _maxHoverCardContentHeight = 250.0;
 const _hoverCardTitleHeight = 24.0;
 const _hoverCardDividerHeight = 16.0;
 
-/// The total maximum height of the [HoverCard] including content, title,
-/// divider, vertical padding, and borders.
-const _totalMaxHoverCardHeight =
-    _maxHoverCardContentHeight +
-    _hoverCardTitleHeight +
-    _hoverCardDividerHeight +
-    (denseSpacing * 2) +
-    (hoverCardBorderSize * 2);
+/// Returns the total maximum height of the [HoverCard] including content,
+/// title (if present), divider, vertical padding, and borders.
+double _totalMaxHoverCardHeight({
+  required bool hasTitle,
+  double maxCardContentHeight = _maxHoverCardContentHeight,
+}) {
+  return maxCardContentHeight +
+      (hasTitle ? _hoverCardTitleHeight + _hoverCardDividerHeight : 0.0) +
+      (denseSpacing * 2) +
+      (hoverCardBorderSize * 2);
+}
 
 TextStyle get _hoverTitleTextStyle => fixBlurryText(
   const TextStyle(
@@ -230,7 +233,12 @@ class HoverCard {
          context: context,
          contents: contents,
          width: width,
-         position: _calculateCardPositionFromPointerEvent(context, event, width),
+         position: _calculateCardPositionFromPointerEvent(
+           context,
+           event,
+           width,
+           title: title,
+         ),
          title: title,
          hoverCardController: hoverCardController,
        );
@@ -238,23 +246,27 @@ class HoverCard {
   static Offset _calculateCardPositionFromPointerEvent(
     BuildContext context,
     PointerHoverEvent event,
-    double width,
-  ) {
+    double width, {
+    String? title,
+  }) {
     final overlayBox =
         Overlay.of(context).context.findRenderObject() as RenderBox;
     final overlaySize = overlayBox.size;
+    final localPosition = overlayBox.globalToLocal(event.position);
 
     final maxX = math.max(
       _hoverMargin,
       overlaySize.width - _hoverMargin - width,
     );
-    final x = (event.position.dx - (width / 2.0)).clamp(_hoverMargin, maxX);
+    final x = (localPosition.dx - (width / 2.0)).clamp(_hoverMargin, maxX);
 
     final maxY = math.max(
       _hoverMargin,
-      overlaySize.height - _hoverMargin - _totalMaxHoverCardHeight,
+      overlaySize.height -
+          _hoverMargin -
+          _totalMaxHoverCardHeight(hasTitle: title != null),
     );
-    final y = (event.position.dy + _hoverYOffset).clamp(_hoverMargin, maxY);
+    final y = (localPosition.dy + _hoverYOffset).clamp(_hoverMargin, maxY);
 
     return Offset(x, y);
   }
@@ -546,7 +558,10 @@ class _HoverCardTooltipState extends State<HoverCardTooltip> {
         title: hoverCardData.title,
         contents: hoverCardData.contents,
         width: hoverCardData.width,
-        position: _calculateCardPosition(hoverCardData.width),
+        position: _calculateCardPosition(
+          hoverCardData.width,
+          title: hoverCardData.title,
+        ),
         hoverCardController: _hoverCardController,
       ),
     );
@@ -573,7 +588,10 @@ class _HoverCardTooltipState extends State<HoverCardTooltip> {
     return completer;
   }
 
-  Offset _calculateCardPosition(double width) {
+  Offset _calculateCardPosition(
+    double width, {
+    String? title,
+  }) {
     final overlayBox =
         Overlay.of(context).context.findRenderObject() as RenderBox;
     final box = context.findRenderObject() as RenderBox;
@@ -584,7 +602,9 @@ class _HoverCardTooltipState extends State<HoverCardTooltip> {
     );
     final maxY = math.max(
       _hoverMargin,
-      overlayBox.size.height - _hoverMargin - _totalMaxHoverCardHeight,
+      overlayBox.size.height -
+          _hoverMargin -
+          _totalMaxHoverCardHeight(hasTitle: title != null),
     );
 
     final offset = box.localToGlobal(

--- a/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
+++ b/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
@@ -19,7 +19,7 @@ TODO: Remove this section if there are not any updates.
 
 ## Inspector updates
 
-TODO: Remove this section if there are not any updates.
+- Fixed an issue where hover tooltips in the widget tree were being clipped by the window boundaries. [#9823](https://github.com/flutter/devtools/pull/9823)
 
 ## Performance updates
 

--- a/packages/devtools_app/test/shared/ui/hover_positioning_test.dart
+++ b/packages/devtools_app/test/shared/ui/hover_positioning_test.dart
@@ -57,10 +57,9 @@ void main() {
       final hoverContentFinder = find.text('Hover Content');
       expect(hoverContentFinder, findsOneWidget);
 
-      final overlayContainer = find.ancestor(
-        of: hoverContentFinder,
-        matching: find.byType(Container),
-      ).last; // The outermost container of the HoverCard
+      final overlayContainer = find
+          .ancestor(of: hoverContentFinder, matching: find.byType(Container))
+          .last; // The outermost container of the HoverCard
 
       final renderBox = tester.renderObject(overlayContainer) as RenderBox;
       final position = renderBox.localToGlobal(Offset.zero);
@@ -80,10 +79,9 @@ void main() {
       final hoverContentFinder = find.text('Hover Content');
       expect(hoverContentFinder, findsOneWidget);
 
-      final overlayContainer = find.ancestor(
-        of: hoverContentFinder,
-        matching: find.byType(Container),
-      ).last;
+      final overlayContainer = find
+          .ancestor(of: hoverContentFinder, matching: find.byType(Container))
+          .last;
 
       final renderBox = tester.renderObject(overlayContainer) as RenderBox;
       final position = renderBox.localToGlobal(Offset.zero);
@@ -103,10 +101,9 @@ void main() {
       final hoverContentFinder = find.text('Hover Content');
       expect(hoverContentFinder, findsOneWidget);
 
-      final overlayContainer = find.ancestor(
-        of: hoverContentFinder,
-        matching: find.byType(Container),
-      ).last;
+      final overlayContainer = find
+          .ancestor(of: hoverContentFinder, matching: find.byType(Container))
+          .last;
 
       expect(overlayContainer, findsOneWidget);
     },

--- a/packages/devtools_app/test/shared/ui/hover_positioning_test.dart
+++ b/packages/devtools_app/test/shared/ui/hover_positioning_test.dart
@@ -3,47 +3,32 @@
 // found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
 
 import 'package:devtools_app/src/shared/ui/hover.dart';
+import 'package:devtools_test/helpers.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:provider/provider.dart';
 
 void main() {
-  late HoverCardController hoverCardController;
-
-  setUp(() {
-    hoverCardController = HoverCardController();
-  });
-
   Future<void> pumpHoverCardTooltip(
     WidgetTester tester, {
     required Alignment alignment,
-    Size windowSize = const Size(800, 600),
     String? title,
   }) async {
-    await tester.binding.setSurfaceSize(windowSize);
-    addTearDown(() => tester.binding.setSurfaceSize(null));
-
     await tester.pumpWidget(
-      MaterialApp(
-        home: Scaffold(
-          body: Provider<HoverCardController>.value(
-            value: hoverCardController,
-            child: Align(
-              alignment: alignment,
-              child: HoverCardTooltip.sync(
-                enabled: () => true,
-                generateHoverCardData: (event) => HoverCardData(
-                  title: title,
-                  contents: const SizedBox(
-                    width: 200,
-                    height: 250,
-                    child: Text('Hover Content'),
-                  ),
-                ),
-                child: const Text('Hover Me'),
+      wrapSimple(
+        Align(
+          alignment: alignment,
+          child: HoverCardTooltip.sync(
+            enabled: () => true,
+            generateHoverCardData: (event) => HoverCardData(
+              title: title,
+              contents: const SizedBox(
+                width: 200,
+                height: 250,
+                child: Text('Hover Content'),
               ),
             ),
+            child: const Text('Hover Me'),
           ),
         ),
       ),
@@ -58,64 +43,72 @@ void main() {
     await tester.pumpAndSettle();
   }
 
-  testWidgets('HoverCard at the bottom of the window should not overflow', (WidgetTester tester) async {
-    const windowSize = Size(800, 600);
-    // Use a title to increase the height beyond the base content height.
-    await pumpHoverCardTooltip(
-      tester,
-      alignment: Alignment.bottomCenter,
-      windowSize: windowSize,
-      title: 'A Very Important Title',
-    );
+  testWidgetsWithWindowSize(
+    'HoverCard at the bottom of the window should not overflow',
+    const Size(800, 600),
+    (WidgetTester tester) async {
+      // Use a title to increase the height beyond the base content height.
+      await pumpHoverCardTooltip(
+        tester,
+        alignment: Alignment.bottomCenter,
+        title: 'A Very Important Title',
+      );
 
-    final hoverContentFinder = find.text('Hover Content');
-    expect(hoverContentFinder, findsOneWidget);
+      final hoverContentFinder = find.text('Hover Content');
+      expect(hoverContentFinder, findsOneWidget);
 
-    final overlayContainer = find.ancestor(
-      of: hoverContentFinder,
-      matching: find.byType(Container),
-    ).last; // The outermost container of the HoverCard
+      final overlayContainer = find.ancestor(
+        of: hoverContentFinder,
+        matching: find.byType(Container),
+      ).last; // The outermost container of the HoverCard
 
-    final renderBox = tester.renderObject(overlayContainer) as RenderBox;
-    final position = renderBox.localToGlobal(Offset.zero);
-    final size = renderBox.size;
+      final renderBox = tester.renderObject(overlayContainer) as RenderBox;
+      final position = renderBox.localToGlobal(Offset.zero);
+      final size = renderBox.size;
 
-    // _hoverMargin = 16.0
-    expect(position.dy + size.height, lessThanOrEqualTo(windowSize.height - 16.0));
-  });
+      // _hoverMargin = 16.0
+      expect(position.dy + size.height, lessThanOrEqualTo(600.0 - 16.0));
+    },
+  );
 
-  testWidgets('HoverCard at the right of the window should not overflow', (WidgetTester tester) async {
-    const windowSize = Size(800, 600);
-    await pumpHoverCardTooltip(tester, alignment: Alignment.centerRight, windowSize: windowSize);
+  testWidgetsWithWindowSize(
+    'HoverCard at the right of the window should not overflow',
+    const Size(800, 600),
+    (WidgetTester tester) async {
+      await pumpHoverCardTooltip(tester, alignment: Alignment.centerRight);
 
-    final hoverContentFinder = find.text('Hover Content');
-    expect(hoverContentFinder, findsOneWidget);
+      final hoverContentFinder = find.text('Hover Content');
+      expect(hoverContentFinder, findsOneWidget);
 
-    final overlayContainer = find.ancestor(
-      of: hoverContentFinder,
-      matching: find.byType(Container),
-    ).last;
+      final overlayContainer = find.ancestor(
+        of: hoverContentFinder,
+        matching: find.byType(Container),
+      ).last;
 
-    final renderBox = tester.renderObject(overlayContainer) as RenderBox;
-    final position = renderBox.localToGlobal(Offset.zero);
-    final size = renderBox.size;
+      final renderBox = tester.renderObject(overlayContainer) as RenderBox;
+      final position = renderBox.localToGlobal(Offset.zero);
+      final size = renderBox.size;
 
-    // _hoverMargin = 16.0
-    expect(position.dx + size.width, lessThanOrEqualTo(windowSize.width - 16.0));
-  });
+      // _hoverMargin = 16.0
+      expect(position.dx + size.width, lessThanOrEqualTo(800.0 - 16.0));
+    },
+  );
 
-  testWidgets('HoverCard in very small window should not crash', (WidgetTester tester) async {
-    const windowSize = Size(100, 100); // Smaller than tooltip
-    await pumpHoverCardTooltip(tester, alignment: Alignment.center, windowSize: windowSize);
+  testWidgetsWithWindowSize(
+    'HoverCard in very small window should not crash',
+    const Size(100, 100), // Smaller than tooltip
+    (WidgetTester tester) async {
+      await pumpHoverCardTooltip(tester, alignment: Alignment.center);
 
-    final hoverContentFinder = find.text('Hover Content');
-    expect(hoverContentFinder, findsOneWidget);
+      final hoverContentFinder = find.text('Hover Content');
+      expect(hoverContentFinder, findsOneWidget);
 
-    final overlayContainer = find.ancestor(
-      of: hoverContentFinder,
-      matching: find.byType(Container),
-    ).last;
+      final overlayContainer = find.ancestor(
+        of: hoverContentFinder,
+        matching: find.byType(Container),
+      ).last;
 
-    expect(overlayContainer, findsOneWidget);
-  });
+      expect(overlayContainer, findsOneWidget);
+    },
+  );
 }

--- a/packages/devtools_app/test/shared/ui/hover_positioning_test.dart
+++ b/packages/devtools_app/test/shared/ui/hover_positioning_test.dart
@@ -1,9 +1,8 @@
-// Copyright 2024 The Flutter Authors
+// Copyright 2026 The Flutter Authors
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
 
 import 'package:devtools_app/src/shared/ui/hover.dart';
-import 'package:devtools_app_shared/ui.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';

--- a/packages/devtools_app/test/shared/ui/hover_positioning_test.dart
+++ b/packages/devtools_app/test/shared/ui/hover_positioning_test.dart
@@ -20,6 +20,7 @@ void main() {
     WidgetTester tester, {
     required Alignment alignment,
     Size windowSize = const Size(800, 600),
+    String? title,
   }) async {
     await tester.binding.setSurfaceSize(windowSize);
     addTearDown(() => tester.binding.setSurfaceSize(null));
@@ -34,9 +35,10 @@ void main() {
               child: HoverCardTooltip.sync(
                 enabled: () => true,
                 generateHoverCardData: (event) => HoverCardData(
+                  title: title,
                   contents: const SizedBox(
                     width: 200,
-                    height: 200,
+                    height: 250,
                     child: Text('Hover Content'),
                   ),
                 ),
@@ -59,23 +61,28 @@ void main() {
 
   testWidgets('HoverCard at the bottom of the window should not overflow', (WidgetTester tester) async {
     const windowSize = Size(800, 600);
-    await pumpHoverCardTooltip(tester, alignment: Alignment.bottomCenter, windowSize: windowSize);
+    // Use a title to increase the height beyond the base content height.
+    await pumpHoverCardTooltip(
+      tester,
+      alignment: Alignment.bottomCenter,
+      windowSize: windowSize,
+      title: 'A Very Important Title',
+    );
 
     final hoverContentFinder = find.text('Hover Content');
     expect(hoverContentFinder, findsOneWidget);
 
-    final overlayMouseRegion = find.ancestor(
+    final overlayContainer = find.ancestor(
       of: hoverContentFinder,
-      matching: find.byType(MouseRegion),
-    );
+      matching: find.byType(Container),
+    ).last; // The outermost container of the HoverCard
 
-    expect(overlayMouseRegion, findsOneWidget);
-
-    final renderBox = tester.renderObject(overlayMouseRegion) as RenderBox;
+    final renderBox = tester.renderObject(overlayContainer) as RenderBox;
     final position = renderBox.localToGlobal(Offset.zero);
     final size = renderBox.size;
 
-    expect(position.dy + size.height, lessThanOrEqualTo(windowSize.height));
+    // _hoverMargin = 16.0
+    expect(position.dy + size.height, lessThanOrEqualTo(windowSize.height - 16.0));
   });
 
   testWidgets('HoverCard at the right of the window should not overflow', (WidgetTester tester) async {
@@ -85,18 +92,17 @@ void main() {
     final hoverContentFinder = find.text('Hover Content');
     expect(hoverContentFinder, findsOneWidget);
 
-    final overlayMouseRegion = find.ancestor(
+    final overlayContainer = find.ancestor(
       of: hoverContentFinder,
-      matching: find.byType(MouseRegion),
-    );
+      matching: find.byType(Container),
+    ).last;
 
-    expect(overlayMouseRegion, findsOneWidget);
-
-    final renderBox = tester.renderObject(overlayMouseRegion) as RenderBox;
+    final renderBox = tester.renderObject(overlayContainer) as RenderBox;
     final position = renderBox.localToGlobal(Offset.zero);
     final size = renderBox.size;
 
-    expect(position.dx + size.width, lessThanOrEqualTo(windowSize.width));
+    // _hoverMargin = 16.0
+    expect(position.dx + size.width, lessThanOrEqualTo(windowSize.width - 16.0));
   });
 
   testWidgets('HoverCard in very small window should not crash', (WidgetTester tester) async {
@@ -106,11 +112,11 @@ void main() {
     final hoverContentFinder = find.text('Hover Content');
     expect(hoverContentFinder, findsOneWidget);
 
-    final overlayMouseRegion = find.ancestor(
+    final overlayContainer = find.ancestor(
       of: hoverContentFinder,
-      matching: find.byType(MouseRegion),
-    );
+      matching: find.byType(Container),
+    ).last;
 
-    expect(overlayMouseRegion, findsOneWidget);
+    expect(overlayContainer, findsOneWidget);
   });
 }

--- a/packages/devtools_app/test/shared/ui/hover_positioning_test.dart
+++ b/packages/devtools_app/test/shared/ui/hover_positioning_test.dart
@@ -124,7 +124,10 @@ void main() {
       expect(hoverContentFinderWithTitle, findsOneWidget);
 
       final containerWithTitle = find
-          .ancestor(of: hoverContentFinderWithTitle, matching: find.byType(Container))
+          .ancestor(
+            of: hoverContentFinderWithTitle,
+            matching: find.byType(Container),
+          )
           .last;
 
       final renderBoxWithTitle =
@@ -140,16 +143,16 @@ void main() {
     'HoverCard height clamping without title',
     const Size(800, 600),
     (WidgetTester tester) async {
-      await pumpHoverCardTooltip(
-        tester,
-        alignment: Alignment.bottomCenter,
-      );
+      await pumpHoverCardTooltip(tester, alignment: Alignment.bottomCenter);
 
       final hoverContentFinderNoTitle = find.text('Hover Content');
       expect(hoverContentFinderNoTitle, findsOneWidget);
 
       final containerNoTitle = find
-          .ancestor(of: hoverContentFinderNoTitle, matching: find.byType(Container))
+          .ancestor(
+            of: hoverContentFinderNoTitle,
+            matching: find.byType(Container),
+          )
           .last;
 
       final renderBoxNoTitle =

--- a/packages/devtools_app/test/shared/ui/hover_positioning_test.dart
+++ b/packages/devtools_app/test/shared/ui/hover_positioning_test.dart
@@ -1,0 +1,116 @@
+// Copyright 2024 The Flutter Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
+
+import 'package:devtools_app/src/shared/ui/hover.dart';
+import 'package:devtools_app_shared/ui.dart';
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+
+void main() {
+  late HoverCardController hoverCardController;
+
+  setUp(() {
+    hoverCardController = HoverCardController();
+  });
+
+  Future<void> pumpHoverCardTooltip(
+    WidgetTester tester, {
+    required Alignment alignment,
+    Size windowSize = const Size(800, 600),
+  }) async {
+    await tester.binding.setSurfaceSize(windowSize);
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Provider<HoverCardController>.value(
+            value: hoverCardController,
+            child: Align(
+              alignment: alignment,
+              child: HoverCardTooltip.sync(
+                enabled: () => true,
+                generateHoverCardData: (event) => HoverCardData(
+                  contents: const SizedBox(
+                    width: 200,
+                    height: 200,
+                    child: Text('Hover Content'),
+                  ),
+                ),
+                child: const Text('Hover Me'),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    // Trigger hover
+    final gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
+    await gesture.addPointer(location: Offset.zero);
+    final center = tester.getCenter(find.text('Hover Me'));
+    await gesture.moveTo(center);
+    await tester.pump(const Duration(milliseconds: 500));
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('HoverCard at the bottom of the window should not overflow', (WidgetTester tester) async {
+    const windowSize = Size(800, 600);
+    await pumpHoverCardTooltip(tester, alignment: Alignment.bottomCenter, windowSize: windowSize);
+
+    final hoverContentFinder = find.text('Hover Content');
+    expect(hoverContentFinder, findsOneWidget);
+
+    final overlayMouseRegion = find.ancestor(
+      of: hoverContentFinder,
+      matching: find.byType(MouseRegion),
+    );
+
+    expect(overlayMouseRegion, findsOneWidget);
+
+    final renderBox = tester.renderObject(overlayMouseRegion) as RenderBox;
+    final position = renderBox.localToGlobal(Offset.zero);
+    final size = renderBox.size;
+
+    expect(position.dy + size.height, lessThanOrEqualTo(windowSize.height));
+  });
+
+  testWidgets('HoverCard at the right of the window should not overflow', (WidgetTester tester) async {
+    const windowSize = Size(800, 600);
+    await pumpHoverCardTooltip(tester, alignment: Alignment.centerRight, windowSize: windowSize);
+
+    final hoverContentFinder = find.text('Hover Content');
+    expect(hoverContentFinder, findsOneWidget);
+
+    final overlayMouseRegion = find.ancestor(
+      of: hoverContentFinder,
+      matching: find.byType(MouseRegion),
+    );
+
+    expect(overlayMouseRegion, findsOneWidget);
+
+    final renderBox = tester.renderObject(overlayMouseRegion) as RenderBox;
+    final position = renderBox.localToGlobal(Offset.zero);
+    final size = renderBox.size;
+
+    expect(position.dx + size.width, lessThanOrEqualTo(windowSize.width));
+  });
+
+  testWidgets('HoverCard in very small window should not crash', (WidgetTester tester) async {
+    const windowSize = Size(100, 100); // Smaller than tooltip
+    await pumpHoverCardTooltip(tester, alignment: Alignment.center, windowSize: windowSize);
+
+    final hoverContentFinder = find.text('Hover Content');
+    expect(hoverContentFinder, findsOneWidget);
+
+    final overlayMouseRegion = find.ancestor(
+      of: hoverContentFinder,
+      matching: find.byType(MouseRegion),
+    );
+
+    expect(overlayMouseRegion, findsOneWidget);
+  });
+}

--- a/packages/devtools_app/test/shared/ui/hover_positioning_test.dart
+++ b/packages/devtools_app/test/shared/ui/hover_positioning_test.dart
@@ -7,6 +7,7 @@ import 'package:devtools_test/helpers.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
 
 void main() {
   Future<void> pumpHoverCardTooltip(
@@ -106,6 +107,122 @@ void main() {
           .last;
 
       expect(overlayContainer, findsOneWidget);
+    },
+  );
+
+  testWidgetsWithWindowSize(
+    'HoverCard height clamping with title',
+    const Size(800, 600),
+    (WidgetTester tester) async {
+      await pumpHoverCardTooltip(
+        tester,
+        alignment: Alignment.bottomCenter,
+        title: 'An Important Title',
+      );
+
+      final hoverContentFinderWithTitle = find.text('Hover Content');
+      expect(hoverContentFinderWithTitle, findsOneWidget);
+
+      final containerWithTitle = find
+          .ancestor(of: hoverContentFinderWithTitle, matching: find.byType(Container))
+          .last;
+
+      final renderBoxWithTitle =
+          tester.renderObject(containerWithTitle) as RenderBox;
+      final positionWithTitle = renderBoxWithTitle.localToGlobal(Offset.zero);
+
+      // Clamps strictly at y = 274.0 because of dynamic height containing title/divider.
+      expect(positionWithTitle.dy, equals(274.0));
+    },
+  );
+
+  testWidgetsWithWindowSize(
+    'HoverCard height clamping without title',
+    const Size(800, 600),
+    (WidgetTester tester) async {
+      await pumpHoverCardTooltip(
+        tester,
+        alignment: Alignment.bottomCenter,
+      );
+
+      final hoverContentFinderNoTitle = find.text('Hover Content');
+      expect(hoverContentFinderNoTitle, findsOneWidget);
+
+      final containerNoTitle = find
+          .ancestor(of: hoverContentFinderNoTitle, matching: find.byType(Container))
+          .last;
+
+      final renderBoxNoTitle =
+          tester.renderObject(containerNoTitle) as RenderBox;
+      final positionNoTitle = renderBoxNoTitle.localToGlobal(Offset.zero);
+
+      // Clamps lower down at y = 314.0 because max height is smaller without title gaps.
+      expect(positionNoTitle.dy, equals(314.0));
+    },
+  );
+
+  testWidgetsWithWindowSize(
+    'HoverCard translates global coordinates to local coordinates for offset overlays',
+    const Size(800, 600),
+    (WidgetTester tester) async {
+      final overlayKey = GlobalKey();
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Padding(
+              padding: const EdgeInsets.only(left: 50.0, top: 100.0),
+              child: Provider<HoverCardController>.value(
+                value: HoverCardController(),
+                child: Overlay(
+                  key: overlayKey,
+                  initialEntries: [
+                    OverlayEntry(
+                      builder: (context) => Align(
+                        alignment: Alignment.topLeft,
+                        child: HoverCardTooltip.sync(
+                          enabled: () => true,
+                          generateHoverCardData: (event) => HoverCardData(
+                            contents: const SizedBox(
+                              width: 200,
+                              height: 250,
+                              child: Text('Hover Content'),
+                            ),
+                          ),
+                          child: const Text('Hover Me Offset'),
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      // Trigger hover
+      final gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
+      await gesture.addPointer(location: Offset.zero);
+
+      final center = tester.getCenter(find.text('Hover Me Offset'));
+      await gesture.moveTo(center);
+      await tester.pump(const Duration(milliseconds: 500));
+      await tester.pumpAndSettle();
+
+      final hoverContentFinder = find.text('Hover Content');
+      expect(hoverContentFinder, findsOneWidget);
+
+      final overlayContainer = find
+          .ancestor(of: hoverContentFinder, matching: find.byType(Container))
+          .last;
+
+      final renderBox = tester.renderObject(overlayContainer) as RenderBox;
+      final position = renderBox.localToGlobal(Offset.zero);
+
+      // Dynamic margin is 16.0. Since overlay is offset by 50px globally at the left,
+      // dynamic local X is 16.0, mapped to global X = 50.0 + 16.0 = 66.0.
+      expect(position.dx, equals(66.0));
     },
   );
 }


### PR DESCRIPTION
Prevents hover tooltips from being clipped by the window edges by implementing proper clamping and positioning logic in HoverCard. 

Fixes #3920