### PR TITLE
Prepare for new properties on int

### DIFF
--- a/packages/devtools_app/test/screens/debugger/debugger_evaluation_test.dart
+++ b/packages/devtools_app/test/screens/debugger/debugger_evaluation_test.dart
@@ -261,6 +261,9 @@ void main() {
 
     test(
       'returns no operators for int',
+      // Temporarily skip this test while Flutter gets a Dart SDK with new
+      // properties on 'int'.
+      skip: true,
       () async {
         await runMethodAndWaitForPause(
           'AnotherClass().pauseWithScopedVariablesMethod()',


### PR DESCRIPTION
There is a failure seen on the HHH bot, caused by new int members in the Dart SDK. I think this change has not yet made it to Flutter, as the devtools tests, as customer tests, haven't been flagged yet. The failure: https://logs.chromium.org/logs/dart/buildbucket/cr-buildbucket/8681902379780991265/+/u/Run_customer_testing_tests/stdout?format=raw

Rather than dance around a sync forward or disabling the devtools tests wholesale as customer tests, in this change I just disable the one test. After the Dart roll into Flutter, we can bump our flutter candidate SHA and enable the test and correct it.
