### PR TITLE
Update dart_skills_lint dependency to e449787 and centralize test configuration

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -213,11 +213,11 @@ packages:
     dependency: transitive
     description:
       path: "tool/dart_skills_lint"
-      ref: "2420128e11101002e2eac98eb90512103a388714"
-      resolved-ref: "2420128e11101002e2eac98eb90512103a388714"
+      ref: e4497873950727ee781fa411c1a2f624b1ec50c6
+      resolved-ref: e4497873950727ee781fa411c1a2f624b1ec50c6
       url: "https://github.com/flutter/skills"
     source: git
-    version: "0.2.0"
+    version: "0.3.0"
   dart_style:
     dependency: transitive
     description:

--- a/tool/pubspec.yaml
+++ b/tool/pubspec.yaml
@@ -28,6 +28,6 @@ dev_dependencies:
     git:
       url: https://github.com/flutter/skills
       path: tool/dart_skills_lint
-      ref: 2420128e11101002e2eac98eb90512103a388714
+      ref: e4497873950727ee781fa411c1a2f624b1ec50c6
   logging: ^1.1.1
   test: ^1.25.8

--- a/tool/test/validate_skills_test.dart
+++ b/tool/test/validate_skills_test.dart
@@ -7,6 +7,8 @@ import 'package:dart_skills_lint/dart_skills_lint.dart';
 import 'package:logging/logging.dart';
 import 'package:test/test.dart';
 
+const String _configFilePath = 'dart_skills_lint.yaml';
+
 void main() {
   test('Validate DevTools Skills', () async {
     final Level oldLevel = Logger.root.level;
@@ -17,16 +19,10 @@ void main() {
         });
 
     try {
-      // TODO(https://github.com/flutter/skills/issues/85): Update test
-      // to use dart_skills_lint.yaml for config when available.
-      final bool isValid = await validateSkills(
-        skillDirPaths: ['../.agents/skills'],
-        resolvedRules: {
-          'check-relative-paths': AnalysisSeverity.error,
-          'check-absolute-paths': AnalysisSeverity.error,
-          'check-trailing-whitespace': AnalysisSeverity.error,
-        },
+      final Configuration config = await ConfigParser.loadConfig(
+        path: _configFilePath,
       );
+      final bool isValid = await validateSkills(config: config);
       expect(
         isValid,
         isTrue,


### PR DESCRIPTION
Updates the pinned `dart_skills_lint` reference in `tool/pubspec.yaml` to commit hash `e4497873950727ee781fa411c1a2f624b1ec50c6` (version `0.3.0`). Refactors `tool/test/validate_skills_test.dart` to load configuration dynamically via `ConfigParser.loadConfig` and omit targeting overrides, enabling native path inheritance from `tool/dart_skills_lint.yaml`.
## Pre-launch Checklist
### General checklist
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I updated/added relevant documentation (doc comments with `///`).
### Issues checklist
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I listed at least one issue which has the [`contributions-welcome`] or [`good-first-issue`] label. 
- [x] I did not list at least one issue with the [`contributions-welcome`] or [`good-first-issue`] label. I understand this means my PR might take longer to be reviewed. 
### Tests checklist
- [ ] I added new tests to check the change I am making...
- [x] OR there is a reason for not adding tests, which I explained in the PR description.
### AI-tooling checklist
- [ ] I did not use any AI tooling in creating this PR.
- [x] OR I did use AI tooling, and...
    * [x] I read the [AI contributions guidelines] and agree to follow them.
    * [x] I reviewed all AI-generated code before opening this PR.
    * [x] I understand and am able to discuss the code in this PR.
    * [x] I have verifed the accuracy of any AI-generated text included in the PR description.
    * [x] I commit to verifying the accuracy of any AI-generated code or text that I upload in response to review comments.
### Feature-change checklist 
- [x] This PR does not change the DevTools UI or behavior and...
    * [x] I added the `release-notes-not-required` label or left a comment requesting the label be added.