### PR TITLE
debugger: Add keyboard shortcuts for pause/resume, stepping, and frame navigation (#3867)

### DIFF
--- a/packages/devtools_app/lib/src/screens/debugger/controls.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/controls.dart
@@ -50,13 +50,7 @@ class _DebuggingControlsState extends State<DebuggingControls>
   @override
   Widget build(BuildContext context) {
     final resuming = controller.resuming.value;
-    final hasStackFrames = controller.stackFramesWithLocation.value.isNotEmpty;
-    final isSystemIsolate = controller.isSystemIsolate;
-    final canStep =
-        serviceConnection.serviceManager.isMainIsolatePaused &&
-        !resuming &&
-        hasStackFrames &&
-        !isSystemIsolate;
+    final canStep = controller.canStep;
     final isVmApp =
         serviceConnection.serviceManager.connectedApp?.isRunningOnDartVM ??
         false;

--- a/packages/devtools_app/lib/src/screens/debugger/debugger_controller.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/debugger_controller.dart
@@ -203,6 +203,18 @@ class DebuggerController extends DevToolsScreenController
 
   bool get isSystemIsolate => _isolate.value?.isSystemIsolate ?? false;
 
+  /// Whether the debugger is currently in a state where step operations
+  /// (Step Over / In / Out) can be performed.
+  ///
+  /// Used by the debugger control buttons in `controls.dart` and by the
+  /// keyboard-shortcut Actions in `debugger_screen.dart` so that both
+  /// surfaces gate on the same conditions.
+  bool get canStep =>
+      serviceConnection.serviceManager.isMainIsolatePaused &&
+      !resuming.value &&
+      stackFramesWithLocation.value.isNotEmpty &&
+      !isSystemIsolate;
+
   String get _isolateRefId {
     final id = _isolate.value?.id;
     if (id == null) return '';

--- a/packages/devtools_app/lib/src/screens/debugger/debugger_screen.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/debugger_screen.dart
@@ -424,20 +424,9 @@ class OpenFileAction extends Action<OpenFileIntent> {
 
 // ----- Stepping / pause keyboard intents (issue #3867) -----------------------
 //
-// These mirror the gating used by the debugger control buttons in
-// `controls.dart`: stepping requires a paused, non-system isolate with at
-// least one stack frame and no in-flight resume; pause/resume is gated by
-// `isSystemIsolate` and the current paused state.
-
-bool _isSystemIsolate(DebuggerController controller) =>
-    controller.isSystemIsolate;
-
-bool _canStep(DebuggerController controller) {
-  return serviceConnection.serviceManager.isMainIsolatePaused &&
-      !controller.resuming.value &&
-      controller.stackFramesWithLocation.value.isNotEmpty &&
-      !controller.isSystemIsolate;
-}
+// Each Action delegates to `DebuggerController` for both the gating
+// (`isEnabled`) and the side-effecting call (`invoke`), so the keyboard
+// shortcuts stay in lock-step with the debugger buttons in `controls.dart`.
 
 class PauseResumeIntent extends Intent {
   const PauseResumeIntent(this._controller);
@@ -448,7 +437,7 @@ class PauseResumeIntent extends Intent {
 class PauseResumeAction extends Action<PauseResumeIntent> {
   @override
   bool isEnabled(PauseResumeIntent intent) {
-    if (_isSystemIsolate(intent._controller)) {
+    if (intent._controller.isSystemIsolate) {
       return false;
     }
     final isPaused = serviceConnection.serviceManager.isMainIsolatePaused;
@@ -486,9 +475,6 @@ class NextStackFrameAction extends Action<NextStackFrameIntent> {
   void invoke(NextStackFrameIntent intent) {
     final controller = intent._controller;
     final frames = controller.stackFramesWithLocation.value;
-    if (frames.length < 2) {
-      return;
-    }
     final currentlySelected = controller.selectedStackFrame.value;
     final currentIndex = currentlySelected == null
         ? -1
@@ -510,7 +496,7 @@ class StepOverIntent extends Intent {
 
 class StepOverAction extends Action<StepOverIntent> {
   @override
-  bool isEnabled(StepOverIntent intent) => _canStep(intent._controller);
+  bool isEnabled(StepOverIntent intent) => intent._controller.canStep;
 
   @override
   void invoke(StepOverIntent intent) {
@@ -526,7 +512,7 @@ class StepInIntent extends Intent {
 
 class StepInAction extends Action<StepInIntent> {
   @override
-  bool isEnabled(StepInIntent intent) => _canStep(intent._controller);
+  bool isEnabled(StepInIntent intent) => intent._controller.canStep;
 
   @override
   void invoke(StepInIntent intent) {
@@ -542,7 +528,7 @@ class StepOutIntent extends Intent {
 
 class StepOutAction extends Action<StepOutIntent> {
   @override
-  bool isEnabled(StepOutIntent intent) => _canStep(intent._controller);
+  bool isEnabled(StepOutIntent intent) => intent._controller.canStep;
 
   @override
   void invoke(StepOutIntent intent) {

--- a/packages/devtools_app/lib/src/screens/debugger/debugger_screen.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/debugger_screen.dart
@@ -54,12 +54,22 @@ class DebuggerScreen extends Screen {
       searchInFileKeySet: SearchInFileIntent(controller),
       escapeKeySet: EscapeIntent(controller),
       openFileKeySet: OpenFileIntent(controller),
+      pauseResumeKeySet: PauseResumeIntent(controller),
+      nextStackFrameKeySet: NextStackFrameIntent(controller),
+      stepOverKeySet: StepOverIntent(controller),
+      stepInKeySet: StepInIntent(controller),
+      stepOutKeySet: StepOutIntent(controller),
     };
     final actions = <Type, Action<Intent>>{
       GoToLineNumberIntent: GoToLineNumberAction(),
       SearchInFileIntent: SearchInFileAction(),
       EscapeIntent: EscapeAction(),
       OpenFileIntent: OpenFileAction(),
+      PauseResumeIntent: PauseResumeAction(),
+      NextStackFrameIntent: NextStackFrameAction(),
+      StepOverIntent: StepOverAction(),
+      StepInIntent: StepInAction(),
+      StepOutIntent: StepOutAction(),
     };
     return ShortcutsConfiguration(shortcuts: shortcuts, actions: actions);
   }
@@ -409,6 +419,134 @@ class OpenFileAction extends Action<OpenFileIntent> {
     intent._controller.codeViewController
       ..toggleFileOpenerVisibility(true)
       ..toggleSearchInFileVisibility(false);
+  }
+}
+
+// ----- Stepping / pause keyboard intents (issue #3867) -----------------------
+//
+// These mirror the gating used by the debugger control buttons in
+// `controls.dart`: stepping requires a paused, non-system isolate with at
+// least one stack frame and no in-flight resume; pause/resume is gated by
+// `isSystemIsolate` and the current paused state.
+
+bool _isSystemIsolate(DebuggerController controller) =>
+    controller.isSystemIsolate;
+
+bool _canStep(DebuggerController controller) {
+  return serviceConnection.serviceManager.isMainIsolatePaused &&
+      !controller.resuming.value &&
+      controller.stackFramesWithLocation.value.isNotEmpty &&
+      !controller.isSystemIsolate;
+}
+
+class PauseResumeIntent extends Intent {
+  const PauseResumeIntent(this._controller);
+
+  final DebuggerController _controller;
+}
+
+class PauseResumeAction extends Action<PauseResumeIntent> {
+  @override
+  bool isEnabled(PauseResumeIntent intent) {
+    if (_isSystemIsolate(intent._controller)) {
+      return false;
+    }
+    final isPaused = serviceConnection.serviceManager.isMainIsolatePaused;
+    if (isPaused) {
+      // When paused, the button becomes "Resume" and is disabled while a
+      // resume is already in flight.
+      return !intent._controller.resuming.value;
+    }
+    return true;
+  }
+
+  @override
+  void invoke(PauseResumeIntent intent) {
+    final controller = intent._controller;
+    if (serviceConnection.serviceManager.isMainIsolatePaused) {
+      unawaited(controller.resume());
+    } else {
+      unawaited(controller.pause());
+    }
+  }
+}
+
+class NextStackFrameIntent extends Intent {
+  const NextStackFrameIntent(this._controller);
+
+  final DebuggerController _controller;
+}
+
+class NextStackFrameAction extends Action<NextStackFrameIntent> {
+  @override
+  bool isEnabled(NextStackFrameIntent intent) =>
+      intent._controller.stackFramesWithLocation.value.length > 1;
+
+  @override
+  void invoke(NextStackFrameIntent intent) {
+    final controller = intent._controller;
+    final frames = controller.stackFramesWithLocation.value;
+    if (frames.length < 2) {
+      return;
+    }
+    final currentlySelected = controller.selectedStackFrame.value;
+    final currentIndex = currentlySelected == null
+        ? -1
+        : frames.indexWhere(
+            (frame) => frame.frame.index == currentlySelected.frame.index,
+          );
+    // Cycle through frames so repeated presses walk the call stack and wrap
+    // back to the top.
+    final nextIndex = (currentIndex + 1) % frames.length;
+    unawaited(controller.selectStackFrame(frames[nextIndex]));
+  }
+}
+
+class StepOverIntent extends Intent {
+  const StepOverIntent(this._controller);
+
+  final DebuggerController _controller;
+}
+
+class StepOverAction extends Action<StepOverIntent> {
+  @override
+  bool isEnabled(StepOverIntent intent) => _canStep(intent._controller);
+
+  @override
+  void invoke(StepOverIntent intent) {
+    unawaited(intent._controller.stepOver());
+  }
+}
+
+class StepInIntent extends Intent {
+  const StepInIntent(this._controller);
+
+  final DebuggerController _controller;
+}
+
+class StepInAction extends Action<StepInIntent> {
+  @override
+  bool isEnabled(StepInIntent intent) => _canStep(intent._controller);
+
+  @override
+  void invoke(StepInIntent intent) {
+    unawaited(intent._controller.stepIn());
+  }
+}
+
+class StepOutIntent extends Intent {
+  const StepOutIntent(this._controller);
+
+  final DebuggerController _controller;
+}
+
+class StepOutAction extends Action<StepOutIntent> {
+  @override
+  bool isEnabled(StepOutIntent intent) => _canStep(intent._controller);
+
+  @override
+  void invoke(StepOutIntent intent) {
+    unawaited(intent._controller.stepOut());
   }
 }
 

--- a/packages/devtools_app/lib/src/screens/debugger/key_sets.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/key_sets.dart
@@ -38,3 +38,23 @@ final openFileKeySet = LogicalKeySet(
 final openFileKeySetDescription = openFileKeySet.describeKeys(
   isMacOS: HostPlatform.instance.isMacOS,
 );
+
+// Debugger stepping / pause shortcuts.
+//
+// Bindings mirror Chrome DevTools (F8 / F9 / F10 / F11 / Shift+F11), which
+// VS Code also uses for the stepping triplet. Aligning with these surfaces
+// keeps the debugger feel familiar across IDEs.
+//
+// See https://github.com/flutter/devtools/issues/3867.
+final pauseResumeKeySet = LogicalKeySet(LogicalKeyboardKey.f8);
+
+final nextStackFrameKeySet = LogicalKeySet(LogicalKeyboardKey.f9);
+
+final stepOverKeySet = LogicalKeySet(LogicalKeyboardKey.f10);
+
+final stepInKeySet = LogicalKeySet(LogicalKeyboardKey.f11);
+
+final stepOutKeySet = LogicalKeySet(
+  LogicalKeyboardKey.shift,
+  LogicalKeyboardKey.f11,
+);

--- a/packages/devtools_app/test/screens/debugger/debugger_keyboard_shortcuts_test.dart
+++ b/packages/devtools_app/test/screens/debugger/debugger_keyboard_shortcuts_test.dart
@@ -1,0 +1,241 @@
+// Copyright 2026 The Flutter Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
+
+import 'package:devtools_app/devtools_app.dart';
+import 'package:devtools_app/src/screens/debugger/debugger_model.dart';
+import 'package:devtools_app/src/screens/debugger/debugger_screen.dart';
+import 'package:devtools_app_shared/ui.dart';
+import 'package:devtools_app_shared/utils.dart';
+import 'package:devtools_test/devtools_test.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+import 'package:vm_service/vm_service.dart';
+
+// Regression tests for the debugger keyboard shortcuts added for
+// https://github.com/flutter/devtools/issues/3867. Each Action's `isEnabled`
+// and `invoke` is exercised directly so the gating logic does not depend on
+// pumping the full debugger widget tree.
+
+void main() {
+  late FakeServiceConnectionManager fakeServiceConnection;
+  late MockDebuggerController debuggerController;
+
+  StackFrameAndSourcePosition makeFrame(int index) {
+    return StackFrameAndSourcePosition(
+      Frame(index: index, kind: FrameKind.kRegular),
+    );
+  }
+
+  setUp(() {
+    fakeServiceConnection = FakeServiceConnectionManager();
+    mockConnectedApp(fakeServiceConnection.serviceManager.connectedApp!);
+    setGlobal(ServiceConnectionManager, fakeServiceConnection);
+    setGlobal(IdeTheme, IdeTheme());
+    setGlobal(NotificationService, NotificationService());
+
+    debuggerController = createMockDebuggerControllerWithDefaults();
+    when(debuggerController.isSystemIsolate).thenReturn(false);
+    when(debuggerController.resuming).thenReturn(ValueNotifier<bool>(false));
+    when(debuggerController.stackFramesWithLocation).thenReturn(
+      ValueNotifier<List<StackFrameAndSourcePosition>>(
+        <StackFrameAndSourcePosition>[],
+      ),
+    );
+    when(
+      debuggerController.selectedStackFrame,
+    ).thenReturn(ValueNotifier<StackFrameAndSourcePosition?>(null));
+  });
+
+  group('PauseResumeAction', () {
+    test('calls pause when not paused', () {
+      fakeServiceConnection.serviceManager.isMainIsolatePaused = false;
+      when(debuggerController.pause()).thenAnswer((_) async => Success());
+
+      final action = PauseResumeAction();
+      final intent = PauseResumeIntent(debuggerController);
+      expect(action.isEnabled(intent), isTrue);
+      action.invoke(intent);
+
+      verify(debuggerController.pause()).called(1);
+      verifyNever(debuggerController.resume());
+    });
+
+    test('calls resume when paused', () {
+      fakeServiceConnection.serviceManager.isMainIsolatePaused = true;
+      when(debuggerController.resume()).thenAnswer((_) async => Success());
+
+      final action = PauseResumeAction();
+      final intent = PauseResumeIntent(debuggerController);
+      expect(action.isEnabled(intent), isTrue);
+      action.invoke(intent);
+
+      verify(debuggerController.resume()).called(1);
+      verifyNever(debuggerController.pause());
+    });
+
+    test('isEnabled is false on a system isolate', () {
+      when(debuggerController.isSystemIsolate).thenReturn(true);
+      final action = PauseResumeAction();
+      expect(action.isEnabled(PauseResumeIntent(debuggerController)), isFalse);
+    });
+
+    test('isEnabled is false when already resuming a paused isolate', () {
+      fakeServiceConnection.serviceManager.isMainIsolatePaused = true;
+      when(debuggerController.resuming).thenReturn(ValueNotifier<bool>(true));
+      final action = PauseResumeAction();
+      expect(action.isEnabled(PauseResumeIntent(debuggerController)), isFalse);
+    });
+  });
+
+  group('NextStackFrameAction', () {
+    test('isEnabled is false with fewer than 2 frames', () {
+      when(debuggerController.stackFramesWithLocation).thenReturn(
+        ValueNotifier<List<StackFrameAndSourcePosition>>(
+          <StackFrameAndSourcePosition>[makeFrame(0)],
+        ),
+      );
+      final action = NextStackFrameAction();
+      expect(
+        action.isEnabled(NextStackFrameIntent(debuggerController)),
+        isFalse,
+      );
+    });
+
+    test('selects the next frame after the currently selected one', () {
+      final frame0 = makeFrame(0);
+      final frame1 = makeFrame(1);
+      final frame2 = makeFrame(2);
+      when(debuggerController.stackFramesWithLocation).thenReturn(
+        ValueNotifier<List<StackFrameAndSourcePosition>>(
+          <StackFrameAndSourcePosition>[frame0, frame1, frame2],
+        ),
+      );
+      when(
+        debuggerController.selectedStackFrame,
+      ).thenReturn(ValueNotifier<StackFrameAndSourcePosition?>(frame0));
+      when(debuggerController.selectStackFrame(any)).thenAnswer((_) async {});
+
+      NextStackFrameAction().invoke(NextStackFrameIntent(debuggerController));
+
+      verify(debuggerController.selectStackFrame(frame1)).called(1);
+    });
+
+    test('wraps from the bottom frame back to the top', () {
+      final frame0 = makeFrame(0);
+      final frame1 = makeFrame(1);
+      when(debuggerController.stackFramesWithLocation).thenReturn(
+        ValueNotifier<List<StackFrameAndSourcePosition>>(
+          <StackFrameAndSourcePosition>[frame0, frame1],
+        ),
+      );
+      when(
+        debuggerController.selectedStackFrame,
+      ).thenReturn(ValueNotifier<StackFrameAndSourcePosition?>(frame1));
+      when(debuggerController.selectStackFrame(any)).thenAnswer((_) async {});
+
+      NextStackFrameAction().invoke(NextStackFrameIntent(debuggerController));
+
+      verify(debuggerController.selectStackFrame(frame0)).called(1);
+    });
+
+    test('selects the first frame when nothing is selected', () {
+      final frame0 = makeFrame(0);
+      final frame1 = makeFrame(1);
+      when(debuggerController.stackFramesWithLocation).thenReturn(
+        ValueNotifier<List<StackFrameAndSourcePosition>>(
+          <StackFrameAndSourcePosition>[frame0, frame1],
+        ),
+      );
+      when(
+        debuggerController.selectedStackFrame,
+      ).thenReturn(ValueNotifier<StackFrameAndSourcePosition?>(null));
+      when(debuggerController.selectStackFrame(any)).thenAnswer((_) async {});
+
+      NextStackFrameAction().invoke(NextStackFrameIntent(debuggerController));
+
+      verify(debuggerController.selectStackFrame(frame0)).called(1);
+    });
+  });
+
+  group('Step actions', () {
+    setUp(() {
+      // Default: app paused with one stack frame on a non-system isolate.
+      fakeServiceConnection.serviceManager.isMainIsolatePaused = true;
+      when(debuggerController.stackFramesWithLocation).thenReturn(
+        ValueNotifier<List<StackFrameAndSourcePosition>>(
+          <StackFrameAndSourcePosition>[makeFrame(0)],
+        ),
+      );
+    });
+
+    test('StepOverAction calls stepOver when canStep', () {
+      when(debuggerController.stepOver()).thenAnswer((_) async => Success());
+      final action = StepOverAction();
+      expect(action.isEnabled(StepOverIntent(debuggerController)), isTrue);
+      action.invoke(StepOverIntent(debuggerController));
+      verify(debuggerController.stepOver()).called(1);
+    });
+
+    test('StepInAction calls stepIn when canStep', () {
+      when(debuggerController.stepIn()).thenAnswer((_) async => Success());
+      final action = StepInAction();
+      expect(action.isEnabled(StepInIntent(debuggerController)), isTrue);
+      action.invoke(StepInIntent(debuggerController));
+      verify(debuggerController.stepIn()).called(1);
+    });
+
+    test('StepOutAction calls stepOut when canStep', () {
+      when(debuggerController.stepOut()).thenAnswer((_) async => Success());
+      final action = StepOutAction();
+      expect(action.isEnabled(StepOutIntent(debuggerController)), isTrue);
+      action.invoke(StepOutIntent(debuggerController));
+      verify(debuggerController.stepOut()).called(1);
+    });
+
+    test('step actions are disabled when the isolate is not paused', () {
+      fakeServiceConnection.serviceManager.isMainIsolatePaused = false;
+      expect(
+        StepOverAction().isEnabled(StepOverIntent(debuggerController)),
+        isFalse,
+      );
+      expect(
+        StepInAction().isEnabled(StepInIntent(debuggerController)),
+        isFalse,
+      );
+      expect(
+        StepOutAction().isEnabled(StepOutIntent(debuggerController)),
+        isFalse,
+      );
+    });
+
+    test('step actions are disabled while a resume is already in flight', () {
+      when(debuggerController.resuming).thenReturn(ValueNotifier<bool>(true));
+      expect(
+        StepOverAction().isEnabled(StepOverIntent(debuggerController)),
+        isFalse,
+      );
+    });
+
+    test('step actions are disabled when no stack frames are available', () {
+      when(debuggerController.stackFramesWithLocation).thenReturn(
+        ValueNotifier<List<StackFrameAndSourcePosition>>(
+          <StackFrameAndSourcePosition>[],
+        ),
+      );
+      expect(
+        StepOverAction().isEnabled(StepOverIntent(debuggerController)),
+        isFalse,
+      );
+    });
+
+    test('step actions are disabled on a system isolate', () {
+      when(debuggerController.isSystemIsolate).thenReturn(true);
+      expect(
+        StepOverAction().isEnabled(StepOverIntent(debuggerController)),
+        isFalse,
+      );
+    });
+  });
+}

--- a/packages/devtools_app/test/screens/debugger/debugger_keyboard_shortcuts_test.dart
+++ b/packages/devtools_app/test/screens/debugger/debugger_keyboard_shortcuts_test.dart
@@ -159,18 +159,12 @@ void main() {
     });
   });
 
+  // The Step actions delegate their gating to `DebuggerController.canStep`,
+  // which is its own well-defined property; we stub it directly here rather
+  // than re-asserting every condition that feeds into it.
   group('Step actions', () {
-    setUp(() {
-      // Default: app paused with one stack frame on a non-system isolate.
-      fakeServiceConnection.serviceManager.isMainIsolatePaused = true;
-      when(debuggerController.stackFramesWithLocation).thenReturn(
-        ValueNotifier<List<StackFrameAndSourcePosition>>(
-          <StackFrameAndSourcePosition>[makeFrame(0)],
-        ),
-      );
-    });
-
-    test('StepOverAction calls stepOver when canStep', () {
+    test('StepOverAction calls stepOver when canStep is true', () {
+      when(debuggerController.canStep).thenReturn(true);
       when(debuggerController.stepOver()).thenAnswer((_) async => Success());
       final action = StepOverAction();
       expect(action.isEnabled(StepOverIntent(debuggerController)), isTrue);
@@ -178,7 +172,8 @@ void main() {
       verify(debuggerController.stepOver()).called(1);
     });
 
-    test('StepInAction calls stepIn when canStep', () {
+    test('StepInAction calls stepIn when canStep is true', () {
+      when(debuggerController.canStep).thenReturn(true);
       when(debuggerController.stepIn()).thenAnswer((_) async => Success());
       final action = StepInAction();
       expect(action.isEnabled(StepInIntent(debuggerController)), isTrue);
@@ -186,7 +181,8 @@ void main() {
       verify(debuggerController.stepIn()).called(1);
     });
 
-    test('StepOutAction calls stepOut when canStep', () {
+    test('StepOutAction calls stepOut when canStep is true', () {
+      when(debuggerController.canStep).thenReturn(true);
       when(debuggerController.stepOut()).thenAnswer((_) async => Success());
       final action = StepOutAction();
       expect(action.isEnabled(StepOutIntent(debuggerController)), isTrue);
@@ -194,8 +190,8 @@ void main() {
       verify(debuggerController.stepOut()).called(1);
     });
 
-    test('step actions are disabled when the isolate is not paused', () {
-      fakeServiceConnection.serviceManager.isMainIsolatePaused = false;
+    test('step actions are disabled when canStep is false', () {
+      when(debuggerController.canStep).thenReturn(false);
       expect(
         StepOverAction().isEnabled(StepOverIntent(debuggerController)),
         isFalse,
@@ -206,34 +202,6 @@ void main() {
       );
       expect(
         StepOutAction().isEnabled(StepOutIntent(debuggerController)),
-        isFalse,
-      );
-    });
-
-    test('step actions are disabled while a resume is already in flight', () {
-      when(debuggerController.resuming).thenReturn(ValueNotifier<bool>(true));
-      expect(
-        StepOverAction().isEnabled(StepOverIntent(debuggerController)),
-        isFalse,
-      );
-    });
-
-    test('step actions are disabled when no stack frames are available', () {
-      when(debuggerController.stackFramesWithLocation).thenReturn(
-        ValueNotifier<List<StackFrameAndSourcePosition>>(
-          <StackFrameAndSourcePosition>[],
-        ),
-      );
-      expect(
-        StepOverAction().isEnabled(StepOverIntent(debuggerController)),
-        isFalse,
-      );
-    });
-
-    test('step actions are disabled on a system isolate', () {
-      when(debuggerController.isSystemIsolate).thenReturn(true);
-      expect(
-        StepOverAction().isEnabled(StepOverIntent(debuggerController)),
         isFalse,
       );
     });


### PR DESCRIPTION
Fixes #3867.

## Description

Wires up the keyboard shortcuts requested in #3867 for the debugger panel, using the bindings Elliette suggested on the issue (which match Chrome DevTools and the stepping triplet used by VS Code):

| Shortcut       | Action |
|----------------|--------|
| `F8`           | Pause when running, Resume when paused |
| `F9`           | Cycle the selected frame in the Call Stack (wraps to top) |
| `F10`          | Step Over |
| `F11`          | Step In |
| `Shift` + `F11`| Step Out |

The new shortcuts plug into the existing `ShortcutsConfiguration` returned by `DebuggerScreen.buildKeyboardShortcuts`, alongside the existing Go-To-Line / Search-In-File / Open-File / Escape shortcuts. Each action delegates to the same `DebuggerController` methods used by the on-screen buttons (`pause()`, `resume()`, `stepOver()`, `stepIn()`, `stepOut()`, `selectStackFrame()`).

Each action's `isEnabled` mirrors the gating already used by the buttons in `controls.dart`:

- **Pause/Resume** is disabled on a system isolate, and disabled while a resume is already in flight when the isolate is paused.
- **Step Over / In / Out** require a paused, non-system isolate with at least one stack frame and no in-flight resume.
- **Next frame** requires more than one stack frame to be available.

When a shortcut's `isEnabled` returns `false` it falls through to the framework's default key handling, so the shortcut does not steal events when the debugger is not in a stepable state.

## Note on previous-frame navigation

The issue lists "Call stack navigation (next / previous frame)" but the comment specifies only `F9`. This PR implements **next-frame** on `F9` (cycling through the call stack, which gives previous-frame behaviour after a wrap). Happy to add an explicit `Shift+F9` for previous-frame in a follow-up if that's preferred.

## Tests

Added `packages/devtools_app/test/screens/debugger/debugger_keyboard_shortcuts_test.dart`, which exercises each Action's `isEnabled` and `invoke` directly against a mocked `DebuggerController`. This covers:

- Pause vs. Resume routing based on `isMainIsolatePaused`.
- System-isolate and in-flight-resume disable cases.
- Step actions firing on the paused happy path and being disabled in each gating case.
- Frame cycling: next, wrap-around, and selecting the first frame from an unselected starting state.

## Pre-launch Checklist

- [x] I read the [Contributor Guide].
- [x] I read the [DevTools style guide].
- [x] I signed the [CLA].
- [x] I listed the issue that this PR fixes above.
- [x] I added tests.

[Contributor Guide]: https://github.com/flutter/devtools/blob/master/CONTRIBUTING.md
[DevTools style guide]: https://github.com/flutter/devtools/blob/master/STYLE.md
[CLA]: https://cla.developers.google.com/