### PR TITLE
Reject absolute paths in devToolsFileFromPath

### DIFF
--- a/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
+++ b/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
@@ -18,6 +18,10 @@ To learn more about DevTools, check out the
 * Fixed a bug where highlighted search matches in tables were unreadable in dark
   mode because the highlight color had become fully opaque. -
   [#9863](https://github.com/flutter/devtools/pull/9863)
+* Rejected absolute paths in DevTools server file reads so they stay within
+  the `~/.flutter-devtools/` directory and cannot resolve to arbitrary files
+  on disk. -
+  [#9844](https://github.com/flutter/devtools/pull/9844)
 
 ## Inspector updates
 

--- a/packages/devtools_shared/lib/src/server/file_system.dart
+++ b/packages/devtools_shared/lib/src/server/file_system.dart
@@ -45,14 +45,24 @@ extension LocalFileSystem on Never {
   ///
   /// Only files within ~/.flutter-devtools/ can be accessed.
   static File? devToolsFileFromPath(String pathFromDevToolsDir) {
-    if (pathFromDevToolsDir.contains('..')) {
+    if (pathFromDevToolsDir.contains('..') ||
+        path.isAbsolute(pathFromDevToolsDir)) {
       // The passed in path should not be able to walk up the directory tree
-      // outside of the ~/.flutter-devtools/ directory.
+      // outside of the ~/.flutter-devtools/ directory. It must also not be an
+      // absolute path: path.join() discards the base directory when its second
+      // argument is absolute, which would otherwise allow reading an arbitrary
+      // file on disk (e.g. an absolute path to a credentials .json file).
       return null;
     }
 
     ensureDevToolsDirectory();
-    final file = File(path.join(devToolsDir(), pathFromDevToolsDir));
+    final devToolsDirPath = devToolsDir();
+    final file = File(path.join(devToolsDirPath, pathFromDevToolsDir));
+    // Defense in depth: ensure the resolved path is actually contained within
+    // the DevTools directory.
+    if (!path.isWithin(devToolsDirPath, file.path)) {
+      return null;
+    }
     if (!file.existsSync()) {
       return null;
     }

--- a/packages/devtools_shared/test/server/file_system_test.dart
+++ b/packages/devtools_shared/test/server/file_system_test.dart
@@ -16,9 +16,7 @@ void main() {
       // directory and read an arbitrary file on disk.
       expect(LocalFileSystem.devToolsFileFromPath('/etc/passwd'), isNull);
       expect(
-        LocalFileSystem.devToolsFileFromPath(
-          '/home/user/.config/gcloud/application_default_credentials.json',
-        ),
+        LocalFileSystem.devToolsFileFromPath('/absolute/path/to/file.json'),
         isNull,
       );
     });

--- a/packages/devtools_shared/test/server/file_system_test.dart
+++ b/packages/devtools_shared/test/server/file_system_test.dart
@@ -1,0 +1,38 @@
+// Copyright 2026 The Flutter Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
+
+import 'package:devtools_shared/src/server/file_system.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('LocalFileSystem.devToolsFileFromPath path validation', () {
+    // These inputs must be rejected before any filesystem access so that reads
+    // stay confined to the ~/.flutter-devtools/ directory.
+
+    test('rejects absolute paths', () {
+      // path.join() discards the base directory when its second argument is
+      // absolute, so an absolute path would otherwise escape the DevTools
+      // directory and read an arbitrary file on disk.
+      expect(LocalFileSystem.devToolsFileFromPath('/etc/passwd'), isNull);
+      expect(
+        LocalFileSystem.devToolsFileFromPath(
+          '/home/user/.config/gcloud/application_default_credentials.json',
+        ),
+        isNull,
+      );
+    });
+
+    test('rejects paths containing ".."', () {
+      expect(LocalFileSystem.devToolsFileFromPath('..'), isNull);
+      expect(
+        LocalFileSystem.devToolsFileFromPath('../../../etc/passwd'),
+        isNull,
+      );
+      expect(
+        LocalFileSystem.devToolsFileFromPath('subdir/../../escape.json'),
+        isNull,
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Problem

`LocalFileSystem.devToolsFileFromPath()` is documented as "Only files within `~/.flutter-devtools/` can be accessed" and enforces that with `pathFromDevToolsDir.contains('..')`. However it does not reject absolute paths. `path.join(devToolsDir(), pathFromDevToolsDir)` discards the base directory when the second argument is absolute, so an absolute `pathFromDevToolsDir` (which contains no `..`) escapes the intended directory.

This is reachable via `getBaseAppSizeFile`/`getTestAppSizeFile` (`handlers/_app_size.dart`, `appSizeBase`/`appSizeTest` parameters) -> `devToolsFileAsJson` -> `devToolsFileFromPath`, allowing a caller to read an arbitrary `.json` file on the machine rather than only files under `~/.flutter-devtools/`.

## Fix

- Reject absolute paths (`path.isAbsolute`) in addition to the existing `..` check.
- Add a defense-in-depth `path.isWithin(devToolsDir, resolvedPath)` containment check on the resolved path.
