### PR TITLE
Bump Dart SDK minimums to Dart 3.11.0.

### DIFF
--- a/packages/devtools_app/pubspec.yaml
+++ b/packages/devtools_app/pubspec.yaml
@@ -12,7 +12,7 @@ version: 2.59.0
 repository: https://github.com/flutter/devtools/tree/master/packages/devtools_app
 
 environment:
-  sdk: ^3.10.0
+  sdk: ^3.11.0
   flutter: ">=3.32.0-1.0.pre.73"
 
 resolution: workspace

--- a/packages/devtools_app/pubspec.yaml
+++ b/packages/devtools_app/pubspec.yaml
@@ -13,7 +13,7 @@ repository: https://github.com/flutter/devtools/tree/master/packages/devtools_ap
 
 environment:
   sdk: ^3.11.0
-  flutter: ">=3.32.0-1.0.pre.73"
+  flutter: ^3.41.0
 
 resolution: workspace
 

--- a/packages/devtools_app/pubspec.yaml
+++ b/packages/devtools_app/pubspec.yaml
@@ -12,7 +12,7 @@ version: 2.59.0
 repository: https://github.com/flutter/devtools/tree/master/packages/devtools_app
 
 environment:
-  sdk: ">=3.8.0-265.0.dev <4.0.0"
+  sdk: ^3.10.0
   flutter: ">=3.32.0-1.0.pre.73"
 
 resolution: workspace

--- a/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
+++ b/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
@@ -15,7 +15,7 @@ To learn more about DevTools, check out the
 
 ## General updates
 
-TODO: Remove this section if there are not any updates.
+* The minimum Dart SDK version is bumped to 3.11.0.
 
 ## Inspector updates
 

--- a/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
+++ b/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
@@ -15,7 +15,7 @@ To learn more about DevTools, check out the
 
 ## General updates
 
-* The minimum Dart SDK version is bumped to 3.11.0.
+TODO: Remove this section if there are not any updates.
 
 ## Inspector updates
 

--- a/packages/devtools_app_shared/CHANGELOG.md
+++ b/packages/devtools_app_shared/CHANGELOG.md
@@ -6,6 +6,8 @@ found in the LICENSE file or at https://developers.google.com/open-source/licens
 ## 0.5.2-wip
 * Fix a `RangeError` thrown by `SplitPane` when the number of children
   changes between rebuilds.
+* The minimum Dart SDK version is bumped to 3.11.0.
+* The minimum Flutter SDK version is bumped to 3.41.0.
 
 ## 0.5.1
 * Add DevTools-styled text field `DevToolsTextField`.

--- a/packages/devtools_app_shared/pubspec.yaml
+++ b/packages/devtools_app_shared/pubspec.yaml
@@ -7,7 +7,7 @@ version: 0.5.2-wip
 repository: https://github.com/flutter/devtools/tree/master/packages/devtools_app_shared
 
 environment:
-  sdk: ^3.10.0
+  sdk: ^3.11.0
   flutter: ">=3.27.1"
 
 resolution: workspace

--- a/packages/devtools_app_shared/pubspec.yaml
+++ b/packages/devtools_app_shared/pubspec.yaml
@@ -7,7 +7,7 @@ version: 0.5.2-wip
 repository: https://github.com/flutter/devtools/tree/master/packages/devtools_app_shared
 
 environment:
-  sdk: ">=3.6.0 <4.0.0"
+  sdk: ^3.10.0
   flutter: ">=3.27.1"
 
 resolution: workspace

--- a/packages/devtools_app_shared/pubspec.yaml
+++ b/packages/devtools_app_shared/pubspec.yaml
@@ -8,7 +8,7 @@ repository: https://github.com/flutter/devtools/tree/master/packages/devtools_ap
 
 environment:
   sdk: ^3.11.0
-  flutter: ">=3.27.1"
+  flutter: ^3.41.0
 
 resolution: workspace
 

--- a/packages/devtools_extensions/CHANGELOG.md
+++ b/packages/devtools_extensions/CHANGELOG.md
@@ -3,6 +3,10 @@ Copyright 2025 The Flutter Authors
 Use of this source code is governed by a BSD-style license that can be
 found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
 -->
+## 0.5.2-wip
+* The minimum Dart SDK version is bumped to 3.11.0.
+* The minimum Flutter SDK version is bumped to 3.41.0.
+
 ## 0.5.1
 * Updates `devtools_app_shared` constraint to `^0.5.1`.
 * Updates `devtools_shared` constraint to `^13.0.0`.

--- a/packages/devtools_extensions/lib/src/api/model.dart
+++ b/packages/devtools_extensions/lib/src/api/model.dart
@@ -10,15 +10,12 @@ import 'api.dart';
 /// See [DevToolsExtensionEventType] for different types of events that are
 /// supported over this communication channel.
 class DevToolsExtensionEvent {
-  DevToolsExtensionEvent(
-    this.type, {
-    this.data,
-    this.source,
-  });
+  DevToolsExtensionEvent(this.type, {this.data, this.source});
 
   factory DevToolsExtensionEvent.parse(Map<String, Object?> json) {
-    final eventType =
-        DevToolsExtensionEventType.from(json[_typeKey]! as String);
+    final eventType = DevToolsExtensionEventType.from(
+      json[_typeKey]! as String,
+    );
     final data = (json[_dataKey] as Map?)?.cast<String, Object?>();
     final source = json[sourceKey] as String?;
     return DevToolsExtensionEvent(eventType, data: data, source: source);
@@ -44,10 +41,7 @@ class DevToolsExtensionEvent {
   final String? source;
 
   Map<String, Object?> toJson() {
-    return {
-      _typeKey: type.name,
-      if (data != null) _dataKey: data!,
-    };
+    return {_typeKey: type.name, _dataKey: ?data};
   }
 
   @override
@@ -65,10 +59,10 @@ typedef ExtensionEventHandler = void Function(DevToolsExtensionEvent event);
 /// notification the the DevTools notification framework.
 class ShowNotificationExtensionEvent extends DevToolsExtensionEvent {
   ShowNotificationExtensionEvent({required String message})
-      : super(
-          DevToolsExtensionEventType.showNotification,
-          data: {_messageKey: message},
-        );
+    : super(
+        DevToolsExtensionEventType.showNotification,
+        data: {_messageKey: message},
+      );
 
   factory ShowNotificationExtensionEvent.from(DevToolsExtensionEvent event) {
     assert(event.type == DevToolsExtensionEventType.showNotification);
@@ -93,18 +87,18 @@ class ShowBannerMessageExtensionEvent extends DevToolsExtensionEvent {
     required String extensionName,
     bool ignoreIfAlreadyDismissed = true,
     bool dismissOnConnectionChanges = true,
-  })  : assert(bannerMessageType == 'warning' || bannerMessageType == 'error'),
-        super(
-          DevToolsExtensionEventType.showBannerMessage,
-          data: {
-            _idKey: id,
-            _bannerMessageTypeKey: bannerMessageType,
-            _messageKey: message,
-            _extensionNameKey: extensionName,
-            _ignoreIfAlreadyDismissedKey: ignoreIfAlreadyDismissed,
-            _dismissOnConnectionChangesKey: dismissOnConnectionChanges,
-          },
-        );
+  }) : assert(bannerMessageType == 'warning' || bannerMessageType == 'error'),
+       super(
+         DevToolsExtensionEventType.showBannerMessage,
+         data: {
+           _idKey: id,
+           _bannerMessageTypeKey: bannerMessageType,
+           _messageKey: message,
+           _extensionNameKey: extensionName,
+           _ignoreIfAlreadyDismissedKey: ignoreIfAlreadyDismissed,
+           _dismissOnConnectionChangesKey: dismissOnConnectionChanges,
+         },
+       );
 
   factory ShowBannerMessageExtensionEvent.from(DevToolsExtensionEvent event) {
     assert(event.type == DevToolsExtensionEventType.showBannerMessage);
@@ -154,12 +148,9 @@ class CopyToClipboardExtensionEvent extends DevToolsExtensionEvent {
     required String content,
     String successMessage = defaultSuccessMessage,
   }) : super(
-          DevToolsExtensionEventType.copyToClipboard,
-          data: {
-            _contentKey: content,
-            _successMessageKey: successMessage,
-          },
-        );
+         DevToolsExtensionEventType.copyToClipboard,
+         data: {_contentKey: content, _successMessageKey: successMessage},
+       );
 
   factory CopyToClipboardExtensionEvent.from(DevToolsExtensionEvent event) {
     assert(event.type == DevToolsExtensionEventType.copyToClipboard);

--- a/packages/devtools_extensions/pubspec.yaml
+++ b/packages/devtools_extensions/pubspec.yaml
@@ -8,7 +8,7 @@ version: 0.5.1
 repository: https://github.com/flutter/devtools/tree/master/packages/devtools_extensions
 
 environment:
-  sdk: ">=3.6.0 <4.0.0"
+  sdk: ^3.10.0
   flutter: ">=3.27.1"
 
 resolution: workspace

--- a/packages/devtools_extensions/pubspec.yaml
+++ b/packages/devtools_extensions/pubspec.yaml
@@ -3,7 +3,7 @@
 # found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
 name: devtools_extensions
 description: A package for building and supporting extensions for Dart DevTools.
-version: 0.5.1
+version: 0.5.2-wip
 
 repository: https://github.com/flutter/devtools/tree/master/packages/devtools_extensions
 

--- a/packages/devtools_extensions/pubspec.yaml
+++ b/packages/devtools_extensions/pubspec.yaml
@@ -8,7 +8,7 @@ version: 0.5.1
 repository: https://github.com/flutter/devtools/tree/master/packages/devtools_extensions
 
 environment:
-  sdk: ^3.10.0
+  sdk: ^3.11.0
   flutter: ">=3.27.1"
 
 resolution: workspace

--- a/packages/devtools_extensions/pubspec.yaml
+++ b/packages/devtools_extensions/pubspec.yaml
@@ -9,7 +9,7 @@ repository: https://github.com/flutter/devtools/tree/master/packages/devtools_ex
 
 environment:
   sdk: ^3.11.0
-  flutter: ">=3.27.1"
+  flutter: ^3.41.0
 
 resolution: workspace
 

--- a/packages/devtools_shared/CHANGELOG.md
+++ b/packages/devtools_shared/CHANGELOG.md
@@ -3,6 +3,10 @@ Copyright 2025 The Flutter Authors
 Use of this source code is governed by a BSD-style license that can be
 found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
 -->
+# 13.0.2-wip
+* The minimum Dart SDK version is bumped to 3.11.0.
+* The minimum Flutter SDK version is bumped to 3.41.0.
+
 # 13.0.1
 * Handle null values for `FlutterStore.flutterClientId`.
 

--- a/packages/devtools_shared/lib/src/server/server_api.dart
+++ b/packages/devtools_shared/lib/src/server/server_api.dart
@@ -30,11 +30,11 @@ part 'handlers/_app_size.dart';
 part 'handlers/_deeplink.dart';
 part 'handlers/_devtools_extensions.dart';
 part 'handlers/_dtd.dart';
-part 'handlers/_vm_service.dart';
 part 'handlers/_preferences.dart';
 part 'handlers/_release_notes.dart';
 part 'handlers/_storage.dart';
 part 'handlers/_survey.dart';
+part 'handlers/_vm_service.dart';
 
 /// The DevTools server API.
 ///
@@ -268,10 +268,7 @@ class ServerApi {
     return shelf.Response(
       HttpStatus.internalServerError,
       body: error != null || logs != null
-          ? jsonEncode(<String, Object?>{
-              if (error != null) errorKey: error,
-              if (logs != null) logsKey: logs,
-            })
+          ? jsonEncode({errorKey: ?error, logsKey: ?logs})
           : null,
     );
   }

--- a/packages/devtools_shared/pubspec.yaml
+++ b/packages/devtools_shared/pubspec.yaml
@@ -9,7 +9,7 @@ version: 13.0.1
 repository: https://github.com/flutter/devtools/tree/master/packages/devtools_shared
 
 environment:
-  sdk: ">=3.6.0 <4.0.0"
+  sdk: ^3.10.0
 
 resolution: workspace
 

--- a/packages/devtools_shared/pubspec.yaml
+++ b/packages/devtools_shared/pubspec.yaml
@@ -4,7 +4,7 @@
 name: devtools_shared
 description: Package of shared Dart structures between devtools_app, dds, and other tools.
 
-version: 13.0.1
+version: 13.0.2-dev
 
 repository: https://github.com/flutter/devtools/tree/master/packages/devtools_shared
 

--- a/packages/devtools_shared/pubspec.yaml
+++ b/packages/devtools_shared/pubspec.yaml
@@ -9,7 +9,7 @@ version: 13.0.1
 repository: https://github.com/flutter/devtools/tree/master/packages/devtools_shared
 
 environment:
-  sdk: ^3.10.0
+  sdk: ^3.11.0
 
 resolution: workspace
 

--- a/packages/devtools_test/lib/src/mocks/fake_isolate_manager.dart
+++ b/packages/devtools_test/lib/src/mocks/fake_isolate_manager.dart
@@ -32,9 +32,7 @@ base class FakeIsolateManager extends Fake with TestIsolateManager {
 
   @override
   ValueNotifier<List<IsolateRef>> get isolates {
-    final value = _selectedIsolate.value;
-    _isolates ??= ValueNotifier([if (value != null) value]);
-    return _isolates!;
+    return _isolates ??= ValueNotifier([?_selectedIsolate.value]);
   }
 
   final _pausedState = ValueNotifier<bool>(false);

--- a/packages/devtools_test/pubspec.yaml
+++ b/packages/devtools_test/pubspec.yaml
@@ -8,7 +8,7 @@ publish_to: none
 repository: https://github.com/flutter/devtools/tree/master/packages/devtools_test
 
 environment:
-  sdk: ">=3.7.0-160.0.dev <4.0.0"
+  sdk: ^3.10.0
   flutter: ">=3.27.0-1.0.pre.563"
 
 resolution: workspace

--- a/packages/devtools_test/pubspec.yaml
+++ b/packages/devtools_test/pubspec.yaml
@@ -8,7 +8,7 @@ publish_to: none
 repository: https://github.com/flutter/devtools/tree/master/packages/devtools_test
 
 environment:
-  sdk: ^3.10.0
+  sdk: ^3.11.0
   flutter: ">=3.27.0-1.0.pre.563"
 
 resolution: workspace

--- a/packages/devtools_test/pubspec.yaml
+++ b/packages/devtools_test/pubspec.yaml
@@ -9,7 +9,7 @@ repository: https://github.com/flutter/devtools/tree/master/packages/devtools_te
 
 environment:
   sdk: ^3.11.0
-  flutter: ">=3.27.0-1.0.pre.563"
+  flutter: ^3.41.0
 
 resolution: workspace
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -286,10 +286,10 @@ packages:
     dependency: transitive
     description:
       name: file_selector_android
-      sha256: "89243030ea4b3463fb402b44d5eeacc4ccb1c46a88870cb2a5080d693200c1ed"
+      sha256: ff9f9a900e0b0cf546f05abe86c91a280d611005b977c2c46a446436d7a776e3
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.2+6"
+    version: "0.5.2+7"
   file_selector_ios:
     dependency: transitive
     description:
@@ -911,10 +911,10 @@ packages:
     dependency: transitive
     description:
       name: url_launcher_android
-      sha256: "17bc677f0b301615530dd1d67e0a9828cafa2d0b6b6eae4cd3679b7eac4a273c"
+      sha256: "8a46fcbcd5b865e87053fc5096101d12f56f3fe352c42aa621e7fec9290054b7"
       url: "https://pub.dev"
     source: hosted
-    version: "6.3.30"
+    version: "6.3.31"
   url_launcher_ios:
     dependency: transitive
     description:
@@ -1076,5 +1076,5 @@ packages:
     source: hosted
     version: "2.2.4"
 sdks:
-  dart: ">=3.11.0 <4.0.0"
-  flutter: ">=3.38.0"
+  dart: ">=3.12.0 <4.0.0"
+  flutter: ">=3.44.0 <4.0.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -326,10 +326,10 @@ packages:
     dependency: transitive
     description:
       name: file_selector_web
-      sha256: c4c0ea4224d97a60a7067eca0c8fd419e708ff830e0c83b11a48faf566cec3e7
+      sha256: "73181fbc5257776d8ecaa6a94ab3c8e920ad143b9132a6d984a9271dfc6928d3"
       url: "https://pub.dev"
     source: hosted
-    version: "0.9.4+2"
+    version: "0.9.5"
   file_selector_windows:
     dependency: transitive
     description:
@@ -446,10 +446,10 @@ packages:
     dependency: transitive
     description:
       name: image
-      sha256: f9881ff4998044947ec38d098bc7c8316ae1186fa786eddffdb867b9bc94dfce
+      sha256: "6300175e00616bbc832e2fc91bfa4d776af5402c81c7151bee6905bb08473c52"
       url: "https://pub.dev"
     source: hosted
-    version: "4.8.0"
+    version: "4.9.1"
   integration_test:
     dependency: transitive
     description: flutter
@@ -475,10 +475,10 @@ packages:
     dependency: transitive
     description:
       name: json_annotation
-      sha256: cb09e7dac6210041fad964ed7fbee004f14258b4eca4040f72d1234062ace4c8
+      sha256: "2a743920d81b7910627f68ee2c9ac1fc0bfee32b9fc3403587d7c6791ca12f80"
       url: "https://pub.dev"
     source: hosted
-    version: "4.11.0"
+    version: "4.12.0"
   json_rpc_2:
     dependency: transitive
     description:
@@ -911,10 +911,10 @@ packages:
     dependency: transitive
     description:
       name: url_launcher_android
-      sha256: "3bb000251e55d4a209aa0e2e563309dc9bb2befea2295fd0cec1f51760aac572"
+      sha256: "17bc677f0b301615530dd1d67e0a9828cafa2d0b6b6eae4cd3679b7eac4a273c"
       url: "https://pub.dev"
     source: hosted
-    version: "6.3.29"
+    version: "6.3.30"
   url_launcher_ios:
     dependency: transitive
     description:
@@ -1055,10 +1055,10 @@ packages:
     dependency: transitive
     description:
       name: xml
-      sha256: "971043b3a0d3da28727e40ed3e0b5d18b742fa5a68665cca88e74b7876d5e025"
+      sha256: "67f0aff7be013d107995e9b75bf4e7f2c3ef2dfdb2c8e68024bba0a7fd5756a4"
       url: "https://pub.dev"
     source: hosted
-    version: "6.6.1"
+    version: "7.0.1"
   yaml:
     dependency: transitive
     description:
@@ -1076,5 +1076,5 @@ packages:
     source: hosted
     version: "2.2.4"
 sdks:
-  dart: ">=3.13.0-0 <4.0.0"
+  dart: ">=3.11.0 <4.0.0"
   flutter: ">=3.38.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@
 # found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
 name: _devtools
 environment:
-  sdk: ^3.10.0
+  sdk: ^3.11.0
 workspace:
   - packages/devtools_app
   - packages/devtools_app_shared

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@
 # found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
 name: _devtools
 environment:
-  sdk: ^3.6.0
+  sdk: ^3.10.0
 workspace:
   - packages/devtools_app
   - packages/devtools_app_shared

--- a/tool/pubspec.yaml
+++ b/tool/pubspec.yaml
@@ -6,7 +6,7 @@ description: A repo management tool for DevTools.
 publish_to: none
 
 environment:
-  sdk: ^3.10.0
+  sdk: ^3.11.0
 
 resolution: workspace
 

--- a/tool/pubspec.yaml
+++ b/tool/pubspec.yaml
@@ -6,7 +6,7 @@ description: A repo management tool for DevTools.
 publish_to: none
 
 environment:
-  sdk: ">=3.7.0-160.0.dev <4.0.0"
+  sdk: ^3.10.0
 
 resolution: workspace
 


### PR DESCRIPTION
Bumping the minimum Dart SDK for each package exposes us to the use_null_aware_elements lint rule, allowing for little cleanups.