### PR TITLE
fix: keep network search field enabled after clearing calls

### DIFF
--- a/packages/devtools_app/lib/src/screens/network/network_screen.dart
+++ b/packages/devtools_app/lib/src/screens/network/network_screen.dart
@@ -194,8 +194,6 @@ class _NetworkProfilerControlsState extends State<_NetworkProfilerControls>
         _recording = controller.recordingNotifier.value;
       });
     });
-
-    addAutoDisposeListener(controller.filteredData);
   }
 
   @override

--- a/packages/devtools_app/lib/src/screens/network/network_screen.dart
+++ b/packages/devtools_app/lib/src/screens/network/network_screen.dart
@@ -205,7 +205,6 @@ class _NetworkProfilerControlsState extends State<_NetworkProfilerControls>
     }
 
     final screenWidth = ScreenSize(context).width;
-    final hasRequests = controller.filteredData.value.isNotEmpty;
     return Column(
       children: [
         Row(
@@ -233,7 +232,6 @@ class _NetworkProfilerControlsState extends State<_NetworkProfilerControls>
             Expanded(
               child: SearchField<NetworkController>(
                 searchController: controller,
-                searchFieldEnabled: hasRequests,
                 searchFieldWidth: screenWidth <= MediaSize.xs
                     ? defaultSearchFieldWidth
                     : wideSearchFieldWidth,

--- a/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
+++ b/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
@@ -39,7 +39,9 @@ TODO: Remove this section if there are not any updates.
 
 ## Network profiler updates
 
-TODO: Remove this section if there are not any updates.
+* Fixed the Network tab search field becoming disabled after clearing all
+  requests, so the search query can now be edited at any time. -
+  [#9855](https://github.com/flutter/devtools/pull/9855)
 
 ## Logging updates
 

--- a/packages/devtools_app/test/screens/network/network_profiler_test.dart
+++ b/packages/devtools_app/test/screens/network/network_profiler_test.dart
@@ -52,8 +52,6 @@ void main() {
   setUpAll(() {
     setGlobal(OfflineDataController, OfflineDataController());
     socketProfile = loadSocketProfile();
-    httpProfile = loadHttpProfile();
-    setGlobal(IdeTheme, IdeTheme());
     setGlobal(
       DevToolsEnvironmentParameters,
       ExternalDevToolsEnvironmentParameters(),
@@ -65,6 +63,12 @@ void main() {
 
   group('Network Profiler', () {
     setUp(() {
+      // Reload the fixtures for every test. Clearing requests mutates these
+      // shared profiles in place (FakeVmServiceWrapper clears the same lists
+      // aliased by _startingRequests/_startingSockets), so a test that taps
+      // Clear would otherwise leave them empty for the next test.
+      socketProfile = loadSocketProfile();
+      httpProfile = loadHttpProfile();
       fakeServiceConnection = FakeServiceConnectionManager(
         service: FakeServiceManager.createFakeService(
           socketProfile: socketProfile,

--- a/packages/devtools_app/test/screens/network/network_profiler_test.dart
+++ b/packages/devtools_app/test/screens/network/network_profiler_test.dart
@@ -52,6 +52,7 @@ void main() {
   setUpAll(() {
     setGlobal(OfflineDataController, OfflineDataController());
     socketProfile = loadSocketProfile();
+    httpProfile = loadHttpProfile();
     setGlobal(IdeTheme, IdeTheme());
     setGlobal(
       DevToolsEnvironmentParameters,

--- a/packages/devtools_app/test/screens/network/network_profiler_test.dart
+++ b/packages/devtools_app/test/screens/network/network_profiler_test.dart
@@ -338,6 +338,48 @@ void main() {
       // Wait to ensure all the timers have been cancelled.
       await tester.pumpAndSettle(const Duration(seconds: 2));
     });
+
+    testWidgetsWithWindowSize(
+      'search field stays enabled after clearing',
+      windowSize,
+      (WidgetTester tester) async {
+        // Load the network profiler screen.
+        controller = NetworkController();
+        await pumpNetworkScreen(tester);
+
+        // Populate the screen with requests.
+        await loadRequestsAndCheck(tester);
+
+        Finder searchFieldTextField() => find.descendant(
+          of: find.byType(SearchField<NetworkController>),
+          matching: find.byType(TextField),
+        );
+
+        // The search field is enabled while requests are present.
+        expect(
+          tester.widget<TextField>(searchFieldTextField()).enabled,
+          isTrue,
+        );
+
+        // Pause the profiler so polling does not repopulate the requests after
+        // they are cleared below.
+        await tester.tap(find.byType(StartStopRecordingButton));
+        await tester.pumpAndSettle();
+
+        // Clear the results.
+        await tester.tap(find.byType(ClearButton));
+        await tester.pumpAndSettle(const Duration(seconds: 2));
+        expect(controller.requests.value, isEmpty);
+
+        // The search field must stay enabled even with no requests present, so
+        // the query can still be edited before the next batch of requests
+        // arrives.
+        expect(
+          tester.widget<TextField>(searchFieldTextField()).enabled,
+          isTrue,
+        );
+      },
+    );
   });
 
   group('NetworkRequestOverviewView', () {

--- a/packages/devtools_app/test/screens/network/network_profiler_test.dart
+++ b/packages/devtools_app/test/screens/network/network_profiler_test.dart
@@ -52,6 +52,7 @@ void main() {
   setUpAll(() {
     setGlobal(OfflineDataController, OfflineDataController());
     socketProfile = loadSocketProfile();
+    setGlobal(IdeTheme, IdeTheme());
     setGlobal(
       DevToolsEnvironmentParameters,
       ExternalDevToolsEnvironmentParameters(),


### PR DESCRIPTION
Fixes #9853.

The Network tab search field was tied to whether any requests were currently present. `_NetworkProfilerControlsState.build` computed `hasRequests` from `controller.filteredData` and passed it to `SearchField` as `searchFieldEnabled`, so the moment all calls were cleared the field went disabled and the query could no longer be edited.

This drops the `hasRequests` gate. `SearchField.searchFieldEnabled` already defaults to `true`, so removing the argument keeps the field enabled at all times. That matches how search fields behave elsewhere in DevTools and lets users prepare or adjust a query before the next batch of requests arrives, without needing live traffic first.

### Tests

Added `search field stays enabled after clearing` to `network_profiler_test.dart`, inside the existing `Network Profiler` group. It loads the screen with requests, confirms the search field `TextField` is enabled, pauses recording, taps the Clear button so `controller.requests` is emptied, then asserts the `TextField` is still enabled. Before this change the field was gated on `hasRequests`, so it would be disabled in that state and the assertion would fail.

`dart analyze` and `dart format` are clean on both changed files. Running the widget test against my locally installed Flutter SDK currently fails to compile because of an unrelated, pre-existing framework error (`isSizedToContent` getter missing on `WindowingOwnerLinux` in `flutter/lib/src/widgets/_window_linux.dart`), which reproduces without this change. CI compiles against the pinned SDK.

## Pre-launch Checklist

### General checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I updated/added relevant documentation (doc comments with `///`).

### Issues checklist

- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I listed at least one issue which has the [`contributions-welcome`] or [`good-first-issue`] label. 
- [x] I did not list at least one issue with the [`contributions-welcome`] or [`good-first-issue`] label. I understand this means my PR might take longer to be reviewed. 

### Tests checklist

- [x] I added new tests to check the change I am making...
- [ ] OR there is a reason for not adding tests, which I explained in the PR description.

### AI-tooling checklist

- [ ] I did not use any AI tooling in creating this PR.
- [x] OR I did use AI tooling, and...
    * [x] I read the [AI contributions guidelines] and agree to follow them.
    * [x] I reviewed all AI-generated code before opening this PR.
    * [x] I understand and am able to discuss the code in this PR.
    * [x] I have verifed the accuracy of any AI-generated text included in the PR description.
    * [x] I commit to verifying the accuracy of any AI-generated code or text that I upload in response to review comments.

### Feature-change checklist 

- [ ] This PR does not change the DevTools UI or behavior and...
    * [ ] I added the `release-notes-not-required` label or left a comment requesting the label be added.
- [x] OR this PR does change the DevTools UI or behavior and...
    * [x] I added an entry to `packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md`.
    * [ ] I included before/after screenshots and/or a GIF demo of the new UI to my PR description.
    * [ ] I ran the DevTools app locally to manually verify my changes.

![build.yaml badge]

If you need help, consider asking for help on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/devtools/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[CLA]: https://cla.developers.google.com/
[`contributions-welcome`]: https://github.com/flutter/devtools/issues?q=state%3Aopen%20label%3Acontributions-welcome
[`good-first-issue`]: https://github.com/flutter/devtools/issues?q=state%3Aopen%20label%3Agood-first-issue
[AI contributions guidelines]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[build.yaml badge]: https://github.com/flutter/devtools/actions/workflows/build.yaml/badge.svg
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
