### PR TITLE
Preserve selected feature tab in Performance page exports

### DIFF
--- a/packages/devtools_app/lib/src/screens/performance/performance_controller.dart
+++ b/packages/devtools_app/lib/src/screens/performance/performance_controller.dart
@@ -185,6 +185,7 @@ class PerformanceController extends DevToolsScreenController
   Future<void> _loadOfflineData(OfflinePerformanceData data) async {
     await clearData();
     offlinePerformanceData = data;
+    selectedFeatureTabIndex = data.selectedTab;
     await _applyToFeatureControllersAsync(
       (c) => c.setOfflineData(offlinePerformanceData!),
     );
@@ -285,6 +286,7 @@ class PerformanceController extends DevToolsScreenController
       selectedFrame: flutterFramesController.selectedFrame.value,
       rebuildCountModel: rebuildCountModel,
       displayRefreshRate: flutterFramesController.displayRefreshRate.value,
+      selectedTab: selectedFeatureTabIndex,
     ).toJson(),
   );
 

--- a/packages/devtools_app/lib/src/screens/performance/performance_model.dart
+++ b/packages/devtools_app/lib/src/screens/performance/performance_model.dart
@@ -18,6 +18,7 @@ class OfflinePerformanceData {
     this.frames = const <FlutterFrame>[],
     this.selectedFrame,
     this.rebuildCountModel,
+    this.selectedTab = 0,
     double? displayRefreshRate,
   }) : displayRefreshRate = displayRefreshRate ?? defaultRefreshRate;
 
@@ -36,6 +37,7 @@ class OfflinePerformanceData {
       selectedFrame: selectedFrame,
       rebuildCountModel: json.rebuildCountModel,
       displayRefreshRate: json.displayRefreshRate,
+      selectedTab: json.selectedTab,
     );
   }
 
@@ -44,6 +46,7 @@ class OfflinePerformanceData {
   static const displayRefreshRateKey = 'displayRefreshRate';
   static const flutterFramesKey = 'flutterFrames';
   static const selectedFrameIdKey = 'selectedFrameId';
+  static const selectedTabKey = 'selectedTab';
 
   final Uint8List? perfettoTraceBinary;
 
@@ -56,6 +59,12 @@ class OfflinePerformanceData {
 
   final FlutterFrame? selectedFrame;
 
+  /// The index of the feature tab that was selected when the data was exported.
+  ///
+  /// This is restored when loading offline data so the user lands on the same
+  /// tab they exported from.
+  final int selectedTab;
+
   bool get isEmpty => perfettoTraceBinary == null;
 
   Map<String, Object?> toJson() => {
@@ -64,6 +73,7 @@ class OfflinePerformanceData {
     selectedFrameIdKey: selectedFrame?.id,
     displayRefreshRateKey: displayRefreshRate,
     rebuildCountModelKey: rebuildCountModel?.toJson(),
+    selectedTabKey: selectedTab,
   };
 }
 
@@ -76,6 +86,9 @@ extension type _PerformanceDataJson(Map<String, Object?> json) {
 
   int? get selectedFrameId =>
       json[OfflinePerformanceData.selectedFrameIdKey] as int?;
+
+  int get selectedTab =>
+      json[OfflinePerformanceData.selectedTabKey] as int? ?? 0;
 
   List<FlutterFrame> get frames =>
       (json[OfflinePerformanceData.flutterFramesKey] as List? ?? [])

--- a/packages/devtools_app/lib/src/screens/performance/tabbed_performance_view.dart
+++ b/packages/devtools_app/lib/src/screens/performance/tabbed_performance_view.dart
@@ -80,17 +80,27 @@ class _TabbedPerformanceViewState extends State<TabbedPerformanceView>
         .map((t) => t.featureController)
         .toList();
 
-    // If there is not an active feature, activate the first.
+    // The set of visible tabs can differ between when offline data was exported
+    // and when it is loaded (e.g. the Frame Analysis and Rebuild Stats tabs are
+    // only shown for Flutter apps with the relevant data). Clamp the restored
+    // tab index to the tabs that are actually available to avoid an
+    // out-of-bounds selection.
+    final selectedTabIndex = controller.selectedFeatureTabIndex.clamp(
+      0,
+      tabs.length - 1,
+    );
+
+    // If there is not an active feature, activate the selected one.
     if (featureControllers.firstWhereOrNull(
           (controller) => controller?.isActiveFeature ?? false,
         ) ==
         null) {
-      _setActiveFeature(0, featureControllers[0]);
+      _setActiveFeature(selectedTabIndex, featureControllers[selectedTabIndex]);
     }
 
     return AnalyticsTabbedView(
       tabs: tabs,
-      initialSelectedIndex: controller.selectedFeatureTabIndex,
+      initialSelectedIndex: selectedTabIndex,
       gaScreen: gac.performance,
       onTabChanged: (int index) {
         _setActiveFeature(index, featureControllers[index]);

--- a/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
+++ b/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
@@ -23,7 +23,9 @@ TODO: Remove this section if there are not any updates.
 
 ## Performance updates
 
-TODO: Remove this section if there are not any updates.
+* Fixed a bug where the selected feature tab was not restored when loading
+  exported Performance data. -
+  [#9861](https://github.com/flutter/devtools/pull/9861)
 
 ## CPU profiler updates
 

--- a/packages/devtools_app/test/screens/performance/performance_model_test.dart
+++ b/packages/devtools_app/test/screens/performance/performance_model_test.dart
@@ -53,6 +53,15 @@ void main() {
       offlineData = OfflinePerformanceData.fromJson(rawPerformanceData);
       expect(offlineData.toJson(), rawPerformanceData);
     });
+
+    test('round trips a non-zero selectedTab', () {
+      final offlineData = OfflinePerformanceData(selectedTab: 2);
+      final json = offlineData.toJson();
+      expect(json[OfflinePerformanceData.selectedTabKey], equals(2));
+
+      final parsed = OfflinePerformanceData.fromJson(json);
+      expect(parsed.selectedTab, equals(2));
+    });
   });
 
   group('$FlutterTimelineEvent', () {

--- a/packages/devtools_app/test/screens/performance/performance_model_test.dart
+++ b/packages/devtools_app/test/screens/performance/performance_model_test.dart
@@ -16,6 +16,7 @@ void main() {
       expect(offlineData.selectedFrame, isNull);
       expect(offlineData.rebuildCountModel, isNull);
       expect(offlineData.displayRefreshRate, 60.0);
+      expect(offlineData.selectedTab, 0);
     });
 
     test('init from parse', () {
@@ -32,6 +33,7 @@ void main() {
       expect(offlineData.selectedFrame!.id, equals(2));
       expect(offlineData.displayRefreshRate, equals(60));
       expect(offlineData.rebuildCountModel, isNull);
+      expect(offlineData.selectedTab, equals(0));
     });
 
     test('to json', () {
@@ -44,6 +46,7 @@ void main() {
           OfflinePerformanceData.selectedFrameIdKey: null,
           OfflinePerformanceData.displayRefreshRateKey: 60,
           OfflinePerformanceData.rebuildCountModelKey: null,
+          OfflinePerformanceData.selectedTabKey: 0,
         }),
       );
 

--- a/packages/devtools_test/lib/src/test_data/_performance_data.dart
+++ b/packages/devtools_test/lib/src/test_data/_performance_data.dart
@@ -108244,7 +108244,8 @@ final Map<String, Object?> samplePerformanceData = json.decode('''
       }
     ],
     "displayRefreshRate": 60,
-    "rebuildCountModel": null
+    "rebuildCountModel": null,
+    "selectedTab": 0
   }
 }
 ''');


### PR DESCRIPTION
Closes #5150

## Description

The Performance page tracks the selected feature tab via `PerformanceController.selectedFeatureTabIndex`, but that index was never written to offline exports. As a result, loading exported performance data always reset the view to the first tab instead of the tab that was active when the data was exported.

This mirrors the behavior the Memory page already implements (`OfflineMemoryData.selectedTab`):

- `OfflinePerformanceData` now has a `selectedTab` field that is serialized in `toJson`/`fromJson` (defaults to `0` for backward compatibility with older export files that don't contain the key).
- `prepareOfflineScreenData` writes the current `selectedFeatureTabIndex` into the export.
- `_loadOfflineData` restores `selectedFeatureTabIndex` from the loaded data.

## Tests

- Updated `performance_model_test.dart` to assert `selectedTab` is created, parsed, and serialized.
- Updated the `samplePerformanceData` fixture so the existing `toJson` round-trip test stays in sync.

I don't have a Flutter/Dart toolchain set up locally, so I couldn't run `dart analyze` / the test suite myself — relying on CI to validate.