### PR TITLE
Fix bad contrast for highlighted search results in tables

### DIFF
--- a/packages/devtools_app/lib/src/shared/table/_table_row.dart
+++ b/packages/devtools_app/lib/src/shared/table/_table_row.dart
@@ -324,8 +324,8 @@ class _TableRowState<T> extends State<TableRow<T>>
     final searchAwareBackgroundColor = isSearchMatch
         ? Color.alphaBlend(
             isActiveSearchMatch
-                ? activeSearchMatchColorOpaque
-                : searchMatchColorOpaque,
+                ? activeSearchMatchColorTranslucent
+                : searchMatchColorTranslucent,
             backgroundColor,
           )
         : backgroundColor;

--- a/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
+++ b/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
@@ -15,7 +15,9 @@ To learn more about DevTools, check out the
 
 ## General updates
 
-TODO: Remove this section if there are not any updates.
+* Fixed a bug where highlighted search matches in tables were unreadable in dark
+  mode because the highlight color had become fully opaque. -
+  [#9863](https://github.com/flutter/devtools/pull/9863)
 
 ## Inspector updates
 

--- a/packages/devtools_app_shared/lib/src/ui/theme/theme.dart
+++ b/packages/devtools_app_shared/lib/src/ui/theme/theme.dart
@@ -224,9 +224,11 @@ const darkColorScheme = ColorScheme(
 );
 
 const searchMatchColor = Colors.yellow;
-final searchMatchColorOpaque = Colors.yellow.withValues(alpha: 0.5);
+final searchMatchColorTranslucent = Colors.yellow.withValues(alpha: 0.5);
 const activeSearchMatchColor = Colors.orangeAccent;
-final activeSearchMatchColorOpaque = Colors.orangeAccent.withValues(alpha: 0.5);
+final activeSearchMatchColorTranslucent = Colors.orangeAccent.withValues(
+  alpha: 0.5,
+);
 
 /// Gets an alternating color to use for indexed UI elements.
 Color alternatingColorForIndex(int index, ColorScheme colorScheme) {

--- a/packages/devtools_app_shared/lib/src/ui/theme/theme.dart
+++ b/packages/devtools_app_shared/lib/src/ui/theme/theme.dart
@@ -224,10 +224,9 @@ const darkColorScheme = ColorScheme(
 );
 
 const searchMatchColor = Colors.yellow;
-final searchMatchColorOpaque = Colors.yellow.withValues(alpha: 255 / 2);
+final searchMatchColorOpaque = Colors.yellow.withValues(alpha: 0.5);
 const activeSearchMatchColor = Colors.orangeAccent;
-final activeSearchMatchColorOpaque =
-    Colors.orangeAccent.withValues(alpha: 255 / 2);
+final activeSearchMatchColorOpaque = Colors.orangeAccent.withValues(alpha: 0.5);
 
 /// Gets an alternating color to use for indexed UI elements.
 Color alternatingColorForIndex(int index, ColorScheme colorScheme) {

--- a/packages/devtools_app_shared/test/ui/theme_test.dart
+++ b/packages/devtools_app_shared/test/ui/theme_test.dart
@@ -99,4 +99,15 @@ void main() {
       );
     });
   });
+
+  group('search match colors', () {
+    // Regression test for https://github.com/flutter/devtools/issues/9010: the
+    // "opaque" search match colors are blended over the row background, so they
+    // must stay translucent. Otherwise the (theme-colored) row text is drawn on
+    // a fully opaque highlight and becomes unreadable.
+    test('are translucent so row text stays legible', () {
+      expect(searchMatchColorOpaque.a, closeTo(0.5, 0.001));
+      expect(activeSearchMatchColorOpaque.a, closeTo(0.5, 0.001));
+    });
+  });
 }

--- a/packages/devtools_app_shared/test/ui/theme_test.dart
+++ b/packages/devtools_app_shared/test/ui/theme_test.dart
@@ -106,8 +106,8 @@ void main() {
     // must stay translucent. Otherwise the (theme-colored) row text is drawn on
     // a fully opaque highlight and becomes unreadable.
     test('are translucent so row text stays legible', () {
-      expect(searchMatchColorOpaque.a, closeTo(0.5, 0.001));
-      expect(activeSearchMatchColorOpaque.a, closeTo(0.5, 0.001));
+      expect(searchMatchColorTranslucent.a, closeTo(0.5, 0.001));
+      expect(activeSearchMatchColorTranslucent.a, closeTo(0.5, 0.001));
     });
   });
 }


### PR DESCRIPTION
Fixes #9010

## Problem

When a table row matches a search (e.g. searching in the CPU profiler), the whole row was highlighted with a fully opaque yellow/orange background while the row text kept its theme color (`onSurface`). In dark mode that's light text on solid yellow — unreadable.

## Root cause

`_table_row.dart` blends `searchMatchColorOpaque` / `activeSearchMatchColorOpaque` over the row background. These were intended to be **translucent** (`Colors.yellow.withOpacity(0.5)`), but during the `withOpacity` → `withValues` migration in #8784 they became:

```dart
Colors.yellow.withValues(alpha: 255 / 2);
```

`withValues` takes `alpha` in the range `0.0`–`1.0`, so `255 / 2` (= 127.5) clamps to `1.0` — fully opaque. The row tint stopped being translucent, so the underlying text was no longer legible. (This issue was filed 2025-03, ~2 months after #8784 landed the regression.)

## Fix

Restore the intended translucency:

```dart
Colors.yellow.withValues(alpha: 0.5);
Colors.orangeAccent.withValues(alpha: 0.5);
```

The highlight is again a subtle 50% tint over the row background, so the theme-colored text stays readable in both light and dark themes. Added a regression test asserting these colors remain translucent.

## Note

I couldn't run `flutter test` locally (no Dart/Flutter toolchain in my environment) — relying on CI to validate.