### PR TITLE
devtools_shared - allow tests to be run with "flutter test"

### DIFF
--- a/packages/devtools_shared/lib/src/test/cli_test_driver.dart
+++ b/packages/devtools_shared/lib/src/test/cli_test_driver.dart
@@ -13,6 +13,7 @@ import 'package:vm_service/utils.dart';
 import 'package:vm_service/vm_service.dart';
 import 'package:vm_service/vm_service_io.dart';
 
+import 'io_utils.dart';
 import 'test_utils.dart';
 
 class AppFixture {
@@ -102,7 +103,7 @@ class CliAppFixture extends AppFixture {
       '(Observatory|The Dart VM service is) listening on ',
     );
 
-    final process = await Process.start(Platform.resolvedExecutable, <String>[
+    final process = await Process.start(dartVMPath, <String>[
       '--observe=0',
       '--pause-isolates-on-start',
       appScriptPath,

--- a/packages/devtools_shared/lib/src/test/io_utils.dart
+++ b/packages/devtools_shared/lib/src/test/io_utils.dart
@@ -106,3 +106,24 @@ mixin IOMixin {
     return process.exitCode;
   }
 }
+
+/// The path to the Dart VM executable.
+///
+/// If running under `flutter_tester`, this will attempt to find the Dart SDK
+/// binary bundled with the Flutter SDK.
+String get dartVMPath {
+  final resolved = Platform.resolvedExecutable;
+  if (resolved.contains('flutter_tester')) {
+    final binaryName = Platform.isWindows ? 'dart.exe' : 'dart';
+
+    final platformDir = path.dirname(resolved); // 'darwin-x64' or similar
+    final engineDir = path.dirname(platformDir); // 'engine'
+    final artifactsDir = path.dirname(engineDir); // 'artifacts'
+    final cacheDir = path.dirname(artifactsDir); // 'cache'
+    final dartPath = path.join(cacheDir, 'dart-sdk', 'bin', binaryName);
+    if (File(dartPath).existsSync()) {
+      return dartPath;
+    }
+  }
+  return resolved;
+}

--- a/packages/devtools_shared/test/helpers/extension_test_manager.dart
+++ b/packages/devtools_shared/test/helpers/extension_test_manager.dart
@@ -4,6 +4,7 @@
 
 import 'dart:io';
 
+import 'package:devtools_shared/src/test/io_utils.dart';
 import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
 
@@ -104,7 +105,7 @@ class ExtensionTestManager {
 
       // Run `dart pub get` on this package to generate the
       // `.dart_tool/package_config.json` file.
-      final process = await Process.run(Platform.resolvedExecutable, [
+      final process = await Process.run(dartVMPath, [
         'pub',
         'get',
       ], workingDirectory: packageRoot.path);

--- a/packages/devtools_shared/test/helpers/helpers.dart
+++ b/packages/devtools_shared/test/helpers/helpers.dart
@@ -7,6 +7,7 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:devtools_shared/devtools_shared.dart';
+import 'package:devtools_shared/src/test/io_utils.dart';
 import 'package:path/path.dart' as path;
 
 typedef TestDtdConnectionInfo = ({DtdInfo? info, Process? process});
@@ -22,7 +23,7 @@ Future<TestDtdConnectionInfo> startDtd() async {
   TestDtdConnectionInfo onFailure() => (info: null, process: dtdProcess);
 
   try {
-    dtdProcess = await Process.start(Platform.resolvedExecutable, [
+    dtdProcess = await Process.start(dartVMPath, [
       'tooling-daemon',
       '--machine',
     ]);
@@ -72,7 +73,7 @@ class TestDartApp {
 
   Future<String> start() async {
     await _initTestApp();
-    process = await Process.start(Platform.resolvedExecutable, [
+    process = await Process.start(dartVMPath, [
       '--observe=0',
       'run',
       'bin/main.dart',


### PR DESCRIPTION
In `packages/devtools_shared/`, I couldn't run tests with `flutter test` (I assumed it was a flutter-dependent package).

Gemini came up with this to fix the situation. If this is straight-up not a supported workflow, we don't have to land this. But it seems like a good change to me. Just promoting correctness.