### PR TITLE
Increase the timeout when waiting for Chrome to open

### DIFF
--- a/packages/devtools_shared/CHANGELOG.md
+++ b/packages/devtools_shared/CHANGELOG.md
@@ -27,6 +27,7 @@ found in the LICENSE file or at https://developers.google.com/open-source/licens
     argument.
 * Update `LocalFileSystem` and `IOPersistentProperties` to use `package:file`
   instead of `dart:io` to allow mocking the file system.
+* Increase ChromeDriver startup wait timeout to 30 seconds to support slower environments.
 
 # 13.0.2
 

--- a/packages/devtools_shared/lib/src/test/chrome_driver.dart
+++ b/packages/devtools_shared/lib/src/test/chrome_driver.dart
@@ -55,7 +55,7 @@ class ChromeDriver with IOMixin {
 
   Future<void> _waitForPortOpen(
     int port, {
-    Duration timeout = const Duration(seconds: 10),
+    Duration timeout = const Duration(seconds: 30),
   }) async {
     final stopwatch = Stopwatch()..start();
 


### PR DESCRIPTION
This should reduce flakiness in integration tests. Gemini identified ChromeDriver timing out after 10 seconds was identified as a cause for flakiness, after reviewing several logs fro GitHub CI.