### PR TITLE
debugger: if controller has been disposed, leave showScriptLocation early

### DIFF
--- a/packages/devtools_app/lib/src/screens/debugger/codeview_controller.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/codeview_controller.dart
@@ -237,6 +237,8 @@ class CodeViewController extends DisposableController
     final isolateRef =
         serviceConnection.serviceManager.isolateManager.selectedIsolate.value!;
     final processedReport = await _getSourceReport(isolateRef, current.script);
+    // The controller may have been disposed while awaiting the source report.
+    if (disposed) return;
 
     parsedScript.value = ParsedScript(
       script: current.script,
@@ -267,6 +269,8 @@ class CodeViewController extends DisposableController
     if (scriptRef.id != parsedScript.value?.script.id) {
       // Try to parse the script if it isn't the currently parsed script:
       final script = await _parseScript(scriptRef);
+      // The controller may have been disposed while awaiting the script parsing.
+      if (disposed) return false;
       if (script == null) {
         // Return early and indicate failure if parsing fails.
         reportError(

--- a/packages/devtools_app/lib/src/screens/debugger/codeview_controller.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/codeview_controller.dart
@@ -218,6 +218,9 @@ class CodeViewController extends DisposableController
     );
 
     if (succeeded) {
+      // The controller may have been disposed while awaiting the asynchronous
+      // location display setup.
+      if (disposed) return;
       // Update the scripts history (and make sure we don't react to the
       // subsequent event).
       scriptsHistory.current.removeListener(_scriptHistoryListener);


### PR DESCRIPTION
This was discovered by Gemini when I asked it to look through integration tests for causes of flakiness.