### PR TITLE
Prepare for long filenames in Flutter repo

### DIFF
--- a/tool/lib/commands/update_flutter_sdk.dart
+++ b/tool/lib/commands/update_flutter_sdk.dart
@@ -86,10 +86,23 @@ class UpdateFlutterSdkCommand extends Command {
     }
 
     // Next, update (or clone) the tool/flutter-sdk copy.
+
+    // On Windows LCUI trybots, some of the flutter repo paths cause
+    // "Filename too long" errors. Filenames such as:
+    //     engine/src/flutter/testing/ios_scenario_app/ios/Scenarios/
+    //     ScenariosUITests/
+    //     golden_platform_view_clippath_with_transform_multiple_clips_impeller_iPhone SE (3rd generation)_26.2_simulator.png'.
+    final gitLongFilesCommand = CliCommand.git([
+      'config',
+      'core.longpaths',
+      'true',
+    ]);
+
     if (Directory(toolSdkPath).existsSync()) {
       log.stdout('Updating Flutter at $toolSdkPath');
       await processManager.runAll(
         commands: [
+          gitLongFilesCommand,
           CliCommand.git(['fetch']),
           CliCommand.git(['checkout', flutterVersion, '-f']),
           CliCommand.flutter(['--version']),
@@ -109,12 +122,7 @@ class UpdateFlutterSdkCommand extends Command {
       );
       await processManager.runAll(
         commands: [
-          // On Windows LCUI trybots, some of the flutter repo paths cause
-          // "Filename too long" errors. Filenames such as:
-          //     engine/src/flutter/testing/ios_scenario_app/ios/Scenarios/
-          //     ScenariosUITests/
-          //     golden_platform_view_clippath_with_transform_multiple_clips_impeller_iPhone SE (3rd generation)_26.2_simulator.png'.
-          CliCommand.git(['config', 'core.longpaths', 'true']),
+          gitLongFilesCommand,
           CliCommand.git(['checkout', flutterVersion, '-f']),
           CliCommand.flutter(['--version']),
         ],

--- a/tool/lib/commands/update_flutter_sdk.dart
+++ b/tool/lib/commands/update_flutter_sdk.dart
@@ -101,6 +101,7 @@ class UpdateFlutterSdkCommand extends Command {
       await processManager.runProcess(
         CliCommand.git([
           'clone',
+          '--no-checkout',
           'https://github.com/flutter/flutter',
           flutterSdkDirName,
         ]),
@@ -108,6 +109,12 @@ class UpdateFlutterSdkCommand extends Command {
       );
       await processManager.runAll(
         commands: [
+          // On Windows LCUI trybots, some of the flutter repo paths cause
+          // "Filename too long" errors. Filenames such as:
+          //     engine/src/flutter/testing/ios_scenario_app/ios/Scenarios/
+          //     ScenariosUITests/
+          //     golden_platform_view_clippath_with_transform_multiple_clips_impeller_iPhone SE (3rd generation)_26.2_simulator.png'.
+          CliCommand.git(['config', 'core.longpaths', 'true']),
           CliCommand.git(['checkout', flutterVersion, '-f']),
           CliCommand.flutter(['--version']),
         ],

--- a/tool/lib/utils.dart
+++ b/tool/lib/utils.dart
@@ -163,6 +163,7 @@ extension DevToolsProcessManagerExtension on ProcessManager {
     );
   }
 
+  /// Runs [commands] in serial, from [workingDirectory].
   Future<void> runAll({
     required List<CliCommand> commands,
     String? workingDirectory,


### PR DESCRIPTION
While moving this repo to the Dart SDK, I hit this error on the windows bots:

https://logs.chromium.org/logs/dart/buildbucket/cr-buildbucket/8676373343835221969/+/u/build_devtools/stdout?format=raw

```
Cloning Flutter into C:\b\s\w\ir\cache\builder\sdk\third_party\devtools_src\tool\flutter-sdk
C:\b\s\w\ir\cache\builder\sdk\third_party\devtools_src\tool > git clone https://github.com/flutter/flutter flutter-sdk
Cloning into 'flutter-sdk'...
...
error: unable to create file engine/src/flutter/testing/ios_scenario_app/ios/Scenarios/ScenariosUITests/golden_platform_view_clippath_with_transform_multiple_clips_impeller_iPhone SE (3rd generation)_26.2_simulator.png: Filename too long
Updating files:  57% (9162/16073)
error: unable to create file engine/src/flutter/testing/ios_scenario_app/ios/Scenarios/ScenariosUITests/golden_platform_view_cliprect_with_transform_multiple_clips_impeller_iPhone SE (3rd generation)_26.2_simulator.png: Filename too long
error: unable to create file engine/src/flutter/testing/ios_scenario_app/ios/Scenarios/ScenariosUITests/golden_platform_view_cliprrect_with_transform_multiple_clips_impeller_iPhone SE (3rd generation)_26.2_simulator.png: Filename too long
error: unable to create file engine/src/flutter/testing/ios_scenario_app/ios/Scenarios/ScenariosUITests/golden_platform_view_large_cliprrect_with_transform_multiple_clips_impeller_iPhone SE (3rd generation)_26.2_simulator.png: Filename too long
...
fatal: unable to checkout working tree
warning: Clone succeeded, but checkout failed.
```

In this PR, I _skip_ checking out 'master' on the 'git clone' command. Then run 'git config core.longpaths true' before checking out the appropriate commit.