### PR TITLE
Support brightness override in a11y page 

### DIFF
--- a/packages/devtools_app/lib/src/screens/accessibility/accessibility_controller.dart
+++ b/packages/devtools_app/lib/src/screens/accessibility/accessibility_controller.dart
@@ -2,11 +2,16 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
 
+import 'dart:async';
+
+import 'package:devtools_app_shared/service.dart';
 import 'package:devtools_app_shared/utils.dart';
 import 'package:flutter/foundation.dart';
 
+import '../../service/service_extensions.dart' as extensions;
 import '../../shared/framework/screen.dart';
 import '../../shared/framework/screen_controllers.dart';
+import '../../shared/globals.dart';
 
 /// Modes for brightness override in the accessibility controls.
 enum BrightnessOverride {
@@ -26,6 +31,12 @@ class AccessibilityController extends DevToolsScreenController
     _initListeners();
   }
 
+  @override
+  void init() {
+    super.init();
+    _initServiceExtensionStates();
+  }
+
   void _initListeners() {
     addAutoDisposeListener(brightness, _onBrightnessChanged);
     addAutoDisposeListener(textScale, _onTextScaleChanged);
@@ -34,9 +45,52 @@ class AccessibilityController extends DevToolsScreenController
     addAutoDisposeListener(highContrast, _onHighContrastChanged);
   }
 
+  void _initServiceExtensionStates() {
+    final state = serviceConnection.serviceManager.serviceExtensionManager
+        .getServiceExtensionState(extensions.brightnessMode.extension);
+
+    void updateFromDeviceState(ServiceExtensionState s) {
+      final newBrightness = !s.enabled || s.value == null
+          ? BrightnessOverride.system
+          : switch (s.value) {
+              'Brightness.light' => BrightnessOverride.light,
+              'Brightness.dark' => BrightnessOverride.dark,
+              _ => BrightnessOverride.system,
+            };
+      if (brightness.value != newBrightness) {
+        brightness.value = newBrightness;
+      }
+    }
+
+    updateFromDeviceState(state.value);
+    addAutoDisposeListener(
+      state,
+      () => updateFromDeviceState(state.value),
+    );
+  }
+
+
+
   void _onBrightnessChanged() {
-    // TODO(hannah-hyj): Implement VM service extension call for brightness override.
-    // e.g. using 'ext.flutter.brightnessOverride'.
+    final value = brightness.value;
+    // Values expected by Flutter framework's 'ext.flutter.brightnessOverride':
+    // - 'Brightness.light': forces light mode
+    // - 'Brightness.dark': forces dark mode
+    // - '': any value other than 'Brightness.light' or 'Brightness.dark' clears
+    //   the override and resets to system default.
+    final paramValue = switch (value) {
+      BrightnessOverride.light => 'Brightness.light',
+      BrightnessOverride.dark => 'Brightness.dark',
+      BrightnessOverride.system => '',
+    };
+    unawaited(
+      serviceConnection.serviceManager.serviceExtensionManager
+          .setServiceExtensionState(
+        extensions.brightnessMode.extension,
+        enabled: value != BrightnessOverride.system,
+        value: paramValue,
+      ),
+    );
   }
 
   void _onTextScaleChanged() {

--- a/packages/devtools_app/lib/src/screens/accessibility/accessibility_controller.dart
+++ b/packages/devtools_app/lib/src/screens/accessibility/accessibility_controller.dart
@@ -15,13 +15,18 @@ import '../../shared/globals.dart';
 
 /// Modes for brightness override in the accessibility controls.
 enum BrightnessOverride {
-  system('System Default'),
-  light('Light Mode'),
-  dark('Dark Mode');
+  system('System Default', 'system'),
+  light('Light Mode', 'Brightness.light'),
+  dark('Dark Mode', 'Brightness.dark');
 
-  const BrightnessOverride(this.display);
+  const BrightnessOverride(this.display, this.value);
 
+  /// The user-facing display label for this override option.
   final String display;
+
+  /// The raw value associated with this override option sent to or received
+  /// from the VM service extension.
+  final String value;
 }
 
 /// Controller for the Accessibility screen.
@@ -49,45 +54,29 @@ class AccessibilityController extends DevToolsScreenController
     final state = serviceConnection.serviceManager.serviceExtensionManager
         .getServiceExtensionState(extensions.brightnessMode.extension);
 
-    void updateFromDeviceState(ServiceExtensionState s) {
-      final newBrightness = !s.enabled || s.value == null
+    void updateFromDeviceState(ServiceExtensionState state) {
+      final newBrightness = !state.enabled || state.value == null
           ? BrightnessOverride.system
-          : switch (s.value) {
-              'Brightness.light' => BrightnessOverride.light,
-              'Brightness.dark' => BrightnessOverride.dark,
-              _ => BrightnessOverride.system,
-            };
-      if (brightness.value != newBrightness) {
-        brightness.value = newBrightness;
-      }
+          : BrightnessOverride.values.firstWhere(
+              (b) => b.value == state.value,
+              orElse: () => BrightnessOverride.system,
+            );
+      brightness.value = newBrightness;
     }
 
     updateFromDeviceState(state.value);
-    addAutoDisposeListener(
-      state,
-      () => updateFromDeviceState(state.value),
-    );
+    addAutoDisposeListener(state, () => updateFromDeviceState(state.value));
   }
 
   void _onBrightnessChanged() {
     final value = brightness.value;
-    // Values expected by Flutter framework's 'ext.flutter.brightnessOverride':
-    // - 'Brightness.light': forces light mode
-    // - 'Brightness.dark': forces dark mode
-    // - '': any value other than 'Brightness.light' or 'Brightness.dark' clears
-    //   the override and resets to system default.
-    final paramValue = switch (value) {
-      BrightnessOverride.light => 'Brightness.light',
-      BrightnessOverride.dark => 'Brightness.dark',
-      BrightnessOverride.system => '',
-    };
     unawaited(
       serviceConnection.serviceManager.serviceExtensionManager
           .setServiceExtensionState(
-        extensions.brightnessMode.extension,
-        enabled: value != BrightnessOverride.system,
-        value: paramValue,
-      ),
+            extensions.brightnessMode.extension,
+            enabled: value != BrightnessOverride.system,
+            value: value.value,
+          ),
     );
   }
 

--- a/packages/devtools_app/lib/src/screens/accessibility/accessibility_controller.dart
+++ b/packages/devtools_app/lib/src/screens/accessibility/accessibility_controller.dart
@@ -69,8 +69,6 @@ class AccessibilityController extends DevToolsScreenController
     );
   }
 
-
-
   void _onBrightnessChanged() {
     final value = brightness.value;
     // Values expected by Flutter framework's 'ext.flutter.brightnessOverride':

--- a/packages/devtools_app/lib/src/service/service_extensions.dart
+++ b/packages/devtools_app/lib/src/service/service_extensions.dart
@@ -379,6 +379,21 @@ final togglePlatformMode = ServiceExtensionDescription<String>.from(
   tooltip: 'Override Target Platform',
 );
 
+/// Service extension description for overriding brightness in accessibility controls.
+final brightnessMode = ServiceExtensionDescription<String>.from(
+  extensions.brightnessMode,
+  title: 'Override brightness',
+  iconData: Icons.brightness_6,
+  displayValues: [
+    'System Default',
+    'Light Mode',
+    'Dark Mode',
+  ],
+  gaScreenName: gac.accessibility,
+  gaItem: gac.brightnessOverride,
+  tooltip: 'Override Brightness',
+);
+
 final disableClipLayers = ToggleableServiceExtensionDescription<bool>.from(
   extensions.disableClipLayers,
   title: 'Render Clip layers',

--- a/packages/devtools_app/lib/src/service/service_extensions.dart
+++ b/packages/devtools_app/lib/src/service/service_extensions.dart
@@ -382,7 +382,7 @@ final togglePlatformMode = ServiceExtensionDescription<String>.from(
 /// Service extension description for overriding brightness in accessibility controls.
 final brightnessMode = ServiceExtensionDescription<String>.from(
   extensions.brightnessMode,
-  title: 'Override brightness',
+  title: 'Override Brightness',
   iconData: Icons.brightness_6,
   gaScreenName: gac.accessibility,
   gaItem: gac.brightnessOverride,

--- a/packages/devtools_app/lib/src/service/service_extensions.dart
+++ b/packages/devtools_app/lib/src/service/service_extensions.dart
@@ -384,11 +384,6 @@ final brightnessMode = ServiceExtensionDescription<String>.from(
   extensions.brightnessMode,
   title: 'Override brightness',
   iconData: Icons.brightness_6,
-  displayValues: [
-    'System Default',
-    'Light Mode',
-    'Dark Mode',
-  ],
   gaScreenName: gac.accessibility,
   gaItem: gac.brightnessOverride,
   tooltip: 'Override Brightness',

--- a/packages/devtools_app/lib/src/shared/analytics/constants.dart
+++ b/packages/devtools_app/lib/src/shared/analytics/constants.dart
@@ -44,6 +44,7 @@ final vmTools = ScreenMetaData.vmTools.id;
 const console = 'console';
 final simple = ScreenMetaData.simple.id;
 final deeplink = ScreenMetaData.deepLinks.id;
+final accessibility = ScreenMetaData.accessibility.id;
 
 // GA events not associated with a any screen e.g., hotReload, hotRestart, etc
 const devToolsMain = 'main';
@@ -86,6 +87,7 @@ const repaintRainbow = 'repaintRainbow';
 const repaintRainbowDocs = 'repaintRainbowDocs';
 const debugBanner = 'debugBanner';
 const togglePlatform = 'togglePlatform';
+const brightnessOverride = 'brightnessOverride';
 const highlightOversizedImages = 'highlightOversizedImages';
 const highlightOversizedImagesDocs = 'highlightOversizedImagesDocs';
 const selectWidgetMode = 'selectWidgetMode';

--- a/packages/devtools_app/test/screens/accessibility/accessibility_controller_test.dart
+++ b/packages/devtools_app/test/screens/accessibility/accessibility_controller_test.dart
@@ -1,0 +1,118 @@
+// Copyright 2026 The Flutter Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
+
+@TestOn('vm')
+library;
+
+import 'package:devtools_app/devtools_app.dart';
+import 'package:devtools_app_shared/utils.dart';
+import 'package:devtools_test/devtools_test.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+
+void main() {
+  group('AccessibilityController', () {
+    late AccessibilityController controller;
+
+    setUp(() {
+      final fakeServiceConnection = FakeServiceConnectionManager();
+      when(
+        fakeServiceConnection.serviceManager.connectedApp!.isFlutterWebAppNow,
+      ).thenReturn(false);
+      when(
+        fakeServiceConnection.serviceManager.connectedApp!.isProfileBuildNow,
+      ).thenReturn(false);
+
+      setGlobal(NotificationService, NotificationService());
+      setGlobal(
+        DevToolsEnvironmentParameters,
+        ExternalDevToolsEnvironmentParameters(),
+      );
+      setGlobal(PreferencesController, PreferencesController());
+      setGlobal(ServiceConnectionManager, fakeServiceConnection);
+
+      controller = AccessibilityController()..init();
+    });
+
+    test('initial state', () {
+      expect(controller.brightness.value, BrightnessOverride.system);
+    });
+
+    test(
+      'service extension state change updates controller brightness state',
+      () {
+        final fakeServiceExtensionManager =
+            serviceConnection.serviceManager.serviceExtensionManager
+                as FakeServiceExtensionManager;
+
+        expect(controller.brightness.value, BrightnessOverride.system);
+
+        // Simulate service extension state change from device to dark mode
+        fakeServiceExtensionManager.fakeServiceExtensionStateChanged(
+          brightnessMode.extension,
+          'Brightness.dark',
+        );
+        expect(controller.brightness.value, BrightnessOverride.dark);
+
+        // Simulate service extension state change from device to light mode
+        fakeServiceExtensionManager.fakeServiceExtensionStateChanged(
+          brightnessMode.extension,
+          'Brightness.light',
+        );
+        expect(controller.brightness.value, BrightnessOverride.light);
+
+        // Simulate service extension state change from device to system
+        fakeServiceExtensionManager.fakeServiceExtensionStateChanged(
+          brightnessMode.extension,
+          'system',
+        );
+        expect(controller.brightness.value, BrightnessOverride.system);
+      },
+    );
+
+    test(
+      'setting controller brightness updates service extension state',
+      () async {
+        final fakeServiceExtensionManager =
+            serviceConnection.serviceManager.serviceExtensionManager
+                as FakeServiceExtensionManager;
+
+        // Initial state
+        expect(controller.brightness.value, BrightnessOverride.system);
+
+        // Set to dark mode
+        controller.brightness.value = BrightnessOverride.dark;
+
+        // Wait for async operations to complete
+        await Future<void>.delayed(Duration.zero);
+
+        final darkState = fakeServiceExtensionManager
+            .getServiceExtensionState(brightnessMode.extension)
+            .value;
+        expect(darkState.value, equals('Brightness.dark'));
+        expect(darkState.enabled, isTrue);
+
+        // Set to light mode
+        controller.brightness.value = BrightnessOverride.light;
+        await Future<void>.delayed(Duration.zero);
+
+        final lightState = fakeServiceExtensionManager
+            .getServiceExtensionState(brightnessMode.extension)
+            .value;
+        expect(lightState.value, equals('Brightness.light'));
+        expect(lightState.enabled, isTrue);
+
+        // Set to system
+        controller.brightness.value = BrightnessOverride.system;
+        await Future<void>.delayed(Duration.zero);
+
+        final systemState = fakeServiceExtensionManager
+            .getServiceExtensionState(brightnessMode.extension)
+            .value;
+        expect(systemState.value, equals('system'));
+        expect(systemState.enabled, isFalse);
+      },
+    );
+  });
+}

--- a/packages/devtools_app/test/screens/accessibility/accessibility_screen_test.dart
+++ b/packages/devtools_app/test/screens/accessibility/accessibility_screen_test.dart
@@ -181,36 +181,5 @@ void main() {
         expect(controller.highContrast.value, isTrue);
       },
     );
-
-    testWidgetsWithWindowSize(
-      'service extension state change updates controller brightness state',
-      windowSize,
-      (WidgetTester tester) async {
-        final fakeServiceExtensionManager =
-            serviceConnection.serviceManager.serviceExtensionManager
-                as FakeServiceExtensionManager;
-
-        await pumpAccessibilityScreen(tester);
-        await tester.pumpAndSettle();
-
-        expect(controller.brightness.value, BrightnessOverride.system);
-
-        // Simulate service extension state change from device to dark mode
-        fakeServiceExtensionManager.fakeServiceExtensionStateChanged(
-          brightnessMode.extension,
-          'Brightness.dark',
-        );
-        await tester.pumpAndSettle();
-        expect(controller.brightness.value, BrightnessOverride.dark);
-
-        // Simulate service extension state change from device to light mode
-        fakeServiceExtensionManager.fakeServiceExtensionStateChanged(
-          brightnessMode.extension,
-          'Brightness.light',
-        );
-        await tester.pumpAndSettle();
-        expect(controller.brightness.value, BrightnessOverride.light);
-      },
-    );
   });
 }

--- a/packages/devtools_app/test/screens/accessibility/accessibility_screen_test.dart
+++ b/packages/devtools_app/test/screens/accessibility/accessibility_screen_test.dart
@@ -181,5 +181,36 @@ void main() {
         expect(controller.highContrast.value, isTrue);
       },
     );
+
+    testWidgetsWithWindowSize(
+      'service extension state change updates controller brightness state',
+      windowSize,
+      (WidgetTester tester) async {
+        final fakeServiceExtensionManager =
+            serviceConnection.serviceManager.serviceExtensionManager
+                as FakeServiceExtensionManager;
+
+        await pumpAccessibilityScreen(tester);
+        await tester.pumpAndSettle();
+
+        expect(controller.brightness.value, BrightnessOverride.system);
+
+        // Simulate service extension state change from device to dark mode
+        fakeServiceExtensionManager.fakeServiceExtensionStateChanged(
+          brightnessMode.extension,
+          'Brightness.dark',
+        );
+        await tester.pumpAndSettle();
+        expect(controller.brightness.value, BrightnessOverride.dark);
+
+        // Simulate service extension state change from device to light mode
+        fakeServiceExtensionManager.fakeServiceExtensionStateChanged(
+          brightnessMode.extension,
+          'Brightness.light',
+        );
+        await tester.pumpAndSettle();
+        expect(controller.brightness.value, BrightnessOverride.light);
+      },
+    );
   });
 }

--- a/packages/devtools_app_shared/lib/src/service/service_extensions.dart
+++ b/packages/devtools_app_shared/lib/src/service/service_extensions.dart
@@ -201,6 +201,13 @@ final togglePlatformMode = ServiceExtension<String>(
   values: ['iOS', 'android', 'fuchsia', 'macOS', 'linux'],
 );
 
+/// Override the platform brightness (light mode, dark mode, or system default).
+final brightnessMode = ServiceExtension<String>(
+  extension:
+      '$flutterExtensionPrefix${FoundationServiceExtensions.brightnessOverride.name}',
+  values: ['system', 'Brightness.light', 'Brightness.dark'],
+);
+
 /// Toggle whether interacting with the device selects widgets or triggers
 /// normal interactions.
 final toggleSelectWidgetMode = ToggleableServiceExtension<bool>(
@@ -259,6 +266,7 @@ final _extensionDescriptions = <ServiceExtension<Object>>[
   toggleSelectWidgetMode,
   countWidgetBuilds,
   profilePlatformChannels,
+  brightnessMode,
 ];
 
 /// Service extensions that are not safe to call unless a frame has already
@@ -281,6 +289,7 @@ final _unsafeBeforeFirstFrameFlutterExtensions = Set.of(
     enableOnDeviceInspector,
     togglePlatformMode,
     slowAnimations,
+    brightnessMode,
   ].map((extension) => extension.extension),
 );
 

--- a/packages/devtools_app_shared/test/service/service_extensions_test.dart
+++ b/packages/devtools_app_shared/test/service/service_extensions_test.dart
@@ -1,0 +1,32 @@
+// Copyright 2026 The Flutter Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
+
+import 'package:devtools_app_shared/service_extensions.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('ServiceExtensions', () {
+    test('brightnessMode is properly configured', () {
+      expect(
+        brightnessMode.extension,
+        equals('ext.flutter.brightnessOverride'),
+      );
+      expect(
+        brightnessMode.values,
+        equals(['system', 'Brightness.light', 'Brightness.dark']),
+      );
+      expect(
+        serviceExtensionsAllowlist[brightnessMode.extension],
+        equals(brightnessMode),
+      );
+    });
+
+    test('brightnessMode is in unsafe before first frame set', () {
+      expect(
+        isUnsafeBeforeFirstFlutterFrame('ext.flutter.brightnessOverride'),
+        isTrue,
+      );
+    });
+  });
+}


### PR DESCRIPTION
tracking issue: https://github.com/flutter/devtools/issues/9893 

https://github.com/user-attachments/assets/18bf3266-7de7-4d46-af30-4585e14f12fc


 the ext.flutter.brightnessOverride service extension and VM service support to Flutter was added a while ago in PR [#59571](https://github.com/flutter/flutter/pull/59571)  





## Pre-launch Checklist

### General checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [ ] I signed the [CLA].
- [ ] I updated/added relevant documentation (doc comments with `///`).

### Issues checklist

- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I listed at least one issue which has the [`contributions-welcome`] or [`good-first-issue`] label. 
- [ ] I did not list at least one issue with the [`contributions-welcome`] or [`good-first-issue`] label. I understand this means my PR might take longer to be reviewed. 

### Tests checklist

- [ ] I added new tests to check the change I am making...
- [ ] OR there is a reason for not adding tests, which I explained in the PR description.

### AI-tooling checklist

- [ ] I did not use any AI tooling in creating this PR.
- [ ] OR I did use AI tooling, and...
    * [ ] I read the [AI contributions guidelines] and agree to follow them.
    * [ ] I reviewed all AI-generated code before opening this PR.
    * [ ] I understand and am able to discuss the code in this PR.
    * [ ] I have verifed the accuracy of any AI-generated text included in the PR description.
    * [ ] I commit to verifying the accuracy of any AI-generated code or text that I upload in response to review comments.

### Feature-change checklist 

- [ ] This PR does not change the DevTools UI or behavior and...
    * [ ] I added the `release-notes-not-required` label or left a comment requesting the label be added.
- [ ] OR this PR does change the DevTools UI or behavior and...
    * [ ] I added an entry to `packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md`.
    * [ ] I included before/after screenshots and/or a GIF demo of the new UI to my PR description.
    * [ ] I ran the DevTools app locally to manually verify my changes.

![build.yaml badge]

If you need help, consider asking for help on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/devtools/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[CLA]: https://cla.developers.google.com/
[`contributions-welcome`]: https://github.com/flutter/devtools/issues?q=state%3Aopen%20label%3Acontributions-welcome
[`good-first-issue`]: https://github.com/flutter/devtools/issues?q=state%3Aopen%20label%3Agood-first-issue
[AI contributions guidelines]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[build.yaml badge]: https://github.com/flutter/devtools/actions/workflows/build.yaml/badge.svg
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
