### PR TITLE
Migrate devtools tool skill validation to new dart_skills_lint API

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -213,11 +213,11 @@ packages:
     dependency: transitive
     description:
       path: "tool/dart_skills_lint"
-      ref: e4497873950727ee781fa411c1a2f624b1ec50c6
-      resolved-ref: e4497873950727ee781fa411c1a2f624b1ec50c6
+      ref: "05e5a45fa412ddbdd1d694eee0c71f4bbaea2617"
+      resolved-ref: "05e5a45fa412ddbdd1d694eee0c71f4bbaea2617"
       url: "https://github.com/flutter/skills"
     source: git
-    version: "0.3.0"
+    version: "0.4.0"
   dart_style:
     dependency: transitive
     description:
@@ -555,10 +555,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: c82594181e3312f3d0695fc95aaaf7758d75b8d4ae2bbecf223b9fd5109a059d
+      sha256: "307249ce4ff29d58a18e97f6345f539382eb9c9c29ecda628900f31de0443dd9"
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.3"
+    version: "1.19.0"
   mime:
     dependency: transitive
     description:

--- a/tool/pubspec.yaml
+++ b/tool/pubspec.yaml
@@ -28,6 +28,6 @@ dev_dependencies:
     git:
       url: https://github.com/flutter/skills
       path: tool/dart_skills_lint
-      ref: e4497873950727ee781fa411c1a2f624b1ec50c6
+      ref: 05e5a45fa412ddbdd1d694eee0c71f4bbaea2617
   logging: ^1.1.1
   test: ^1.25.8


### PR DESCRIPTION
Bumps the pinned `dart_skills_lint` dependency ref to the latest main commit. 

This latest commit allows setting parameters on rules which is important for some flavors of evals as the non tracked artifacts will cause the linter to throw false positives. 