### PR TITLE
Run `dcm check-unused-code` on each PR to find unused code.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -79,9 +79,13 @@ jobs:
           echo "$(dcm --version)"
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@e51d8e571e22473a2ddebf0ef8a2123f0ab2c02c
-      - name: Run DCM on root
+      - name: Run dcm analyze on root
         run: |
           dcm analyze packages/devtools_app packages/devtools_app_shared packages/devtools_extensions packages/devtools_shared packages/devtools_test
+      - name: Run dcm checks on packages
+        # TODO(https://github.com/flutter/devtools/issues/9906): run on all packages.
+        run: |
+          dcm check-unused-code packages/devtools_app
 
   test-packages:
     name: ${{ matrix.os }} ${{ matrix.package }} test

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -83,9 +83,9 @@ jobs:
         run: |
           dcm analyze packages/devtools_app packages/devtools_app_shared packages/devtools_extensions packages/devtools_shared packages/devtools_test
       - name: Run dcm checks on packages
-        # TODO(https://github.com/flutter/devtools/issues/9906): run on all packages.
+        # TODO(https://github.com/flutter/devtools/issues/9906): run on all DevTools packages.
         run: |
-          dcm check-unused-code packages/devtools_app
+          dcm check-unused-code packages/devtools_app --exclude-public-api
 
   test-packages:
     name: ${{ matrix.os }} ${{ matrix.package }} test

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -163,6 +163,7 @@ dart_code_metrics:
       # devtools_app/.
       # TODO(https://github.com/flutter/devtools/issues/9906) remove these
       # excludes as findings are resolved.
+      - integration_test/**
       - lib/src/extensions/**
       - lib/src/framework/**
       - lib/src/screens/**

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -166,6 +166,7 @@ dart_code_metrics:
       - lib/src/extensions/**
       - lib/src/framework/**
       - lib/src/screens/**
+      - lib/src/service/**
       - lib/src/shared/**
       - lib/src/standalone_ui/**
       - test/**

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -168,7 +168,7 @@ dart_code_metrics:
       - lib/src/screens/**
       - lib/src/shared/**
       - lib/src/standalone_ui/**
-      - test/
+      - test/**
   rules:
 #    - arguments-ordering Too strict
 #    - avoid-banned-imports # TODO(polina-c): add configuration

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -156,6 +156,19 @@ dart_code_metrics:
     maximum-nesting-level: 5
   metrics-exclude:
     - test/**
+  exclude:
+    unused-code:
+      # TODO(https://github.com/dart-lang/sdk/issues/63864): clean up these
+      # paths once this issue is fixed. These paths are currently relative to
+      # devtools_app/.
+      # TODO(https://github.com/flutter/devtools/issues/9906) remove these
+      # excludes as findings are resolved.
+      - lib/src/extensions/**
+      - lib/src/framework/**
+      - lib/src/screens/**
+      - lib/src/shared/**
+      - lib/src/standalone_ui/**
+      - test/
   rules:
 #    - arguments-ordering Too strict
 #    - avoid-banned-imports # TODO(polina-c): add configuration

--- a/packages/devtools_app/lib/src/app.dart
+++ b/packages/devtools_app/lib/src/app.dart
@@ -618,7 +618,9 @@ typedef UrlParametersBuilder =
 ///
 /// This avoids issues with widgets in the appbar being hidden by the banner
 /// in a web or desktop app.
+// ignore: unused-code, TODO(https://github.com/flutter/devtools/issues/9907): false positive.
 class _AlternateCheckedModeBanner extends StatelessWidget {
+  // ignore: unused-code, TODO(https://github.com/flutter/devtools/issues/9907): false positive.
   const _AlternateCheckedModeBanner({required this.builder});
   final WidgetBuilder builder;
 

--- a/packages/devtools_app/lib/src/app.dart
+++ b/packages/devtools_app/lib/src/app.dart
@@ -242,12 +242,11 @@ class DevToolsAppState extends State<DevToolsApp> with AutoDisposeMixin {
     // Provide the appropriate page route.
     if (pages.containsKey(page)) {
       Widget widget = pages[page]!(context, page, params, state);
-      assert(() {
+      if (kDebugMode) {
         widget = _AlternateCheckedModeBanner(
           builder: (context) => pages[page]!(context, page, params, state),
         );
-        return true;
-      }());
+      }
       return MaterialPage(child: widget);
     }
 


### PR DESCRIPTION
Runs `dcm check-unused-code` on each PR. This will help automate codebase health standards are checked on each PR.

I have intentionally excluded several directories and will work through those in separate PRs.

Work towards https://github.com/flutter/devtools/issues/9906. 