### PR TITLE
Update textmate grammar to latest version

### DIFF
--- a/packages/devtools_app/assets/dart_syntax.json
+++ b/packages/devtools_app/assets/dart_syntax.json
@@ -1,6 +1,6 @@
 {
 	"name": "Dart",
-	"version": "1.4.1",
+	"version": "1.5.0",
 	"fileTypes": [
 		"dart"
 	],
@@ -59,6 +59,12 @@
 		},
 		{
 			"include": "#constants-and-special-vars"
+		},
+		{
+			"include": "#class-identifier-with-optional-factory-method"
+		},
+		{
+			"include": "#function-identifier"
 		},
 		{
 			"include": "#operators"
@@ -227,14 +233,50 @@
 				{
 					"name": "constant.numeric.dart",
 					"match": "(?<!\\$)\\b((0(x|X)[0-9a-fA-F][0-9a-fA-F_]*)|(([0-9][0-9_]*\\.?[0-9_]*)|(\\.[0-9][0-9_]*))((e|E)(\\+|-)?[0-9][0-9_]*)?)\\b(?!\\$)"
-				},
-				{
-					"include": "#class-identifier"
-				},
-				{
-					"include": "#function-identifier"
 				}
-
+			]
+		},
+		"class-identifier-with-optional-factory-method": {
+			"patterns": [
+				{
+					"match": "(?<!\\$)\\b(bool|num|int|double|dynamic)\\b(?!\\$)\\s*(factory\\b)?",
+					"captures": {
+						"1": {
+							"name": "support.class.dart"
+						},
+						"2": {
+							"name": "entity.name.function.dart"
+						}
+					}
+				},
+				{
+					"match": "(?<!\\$)\\b(void)\\b(?!\\$)\\s*(factory\\b)?",
+					"captures": {
+						"1": {
+							"name": "storage.type.primitive.dart"
+						},
+						"2": {
+							"name": "entity.name.function.dart"
+						}
+					}
+				},
+				{
+					"begin": "(?<![a-zA-Z0-9_$])([_$]*[A-Z][a-zA-Z0-9_$]*)\\b\\s*(factory\\b)?",
+					"end": "(?!<)",
+					"beginCaptures": {
+						"1": {
+							"name": "support.class.dart"
+						},
+						"2": {
+							"name": "entity.name.function.dart"
+						}
+					},
+					"patterns": [
+						{
+							"include": "#type-args"
+						}
+					]
+				}
 			]
 		},
 		"class-identifier": {
@@ -279,6 +321,10 @@
 							]
 						}
 					}
+				},
+				{
+					"match": "(?<=\\.)new\\b",
+					"name": "entity.name.function.dart"
 				}
 			]
 		},
@@ -334,8 +380,8 @@
 					"match": "(?<!\\$)\\bassert\\b(?!\\$)"
 				},
 				{
-					"name": "keyword.control.new.dart",
-					"match": "(?<!\\$)\\b(new)\\b(?!\\$)"
+					"name": "keyword.new.dart",
+					"match": "(?<![\\$\\.])\\b(new)\\b(?!\\$)"
 				},
 				{
 					"name": "keyword.control.return.dart",
@@ -351,7 +397,7 @@
 				},
 				{
 					"name": "storage.type.primitive.dart",
-					"match": "(?<!\\$)\\b(?:void|var)\\b(?!\\$)"
+					"match": "(?<!\\$)\\b(?:var)\\b(?!\\$)"
 				}
 			]
 		},
@@ -407,6 +453,12 @@
 			"patterns": [
 				{
 					"include": "#constants-and-special-vars"
+				},
+				{
+					"include": "#class-identifier-with-optional-factory-method"
+				},
+				{
+					"include": "#function-identifier"
 				},
 				{
 					"include": "#strings"

--- a/packages/devtools_app/lib/src/screens/debugger/syntax_highlighter.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/syntax_highlighter.dart
@@ -247,9 +247,7 @@ class SyntaxHighlighter {
       'keyword.control.catch-exception.dart',
       'keyword.control.dart',
       'keyword.control.return.dart',
-      // While 'new' is not a control flow keyword, it uses the control flow
-      // color scheme so we include it here.
-      'keyword.control.new.dart',
+      'keyword.new.dart',
     ];
 
     const stringScopes = <String>[

--- a/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
+++ b/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
@@ -39,6 +39,8 @@ TODO: Remove this section if there are not any updates.
 
 * Prevent values from being garbage-collected, while being evaluated.
   [#9885](https://github.com/flutter/devtools/pull/9885)
+* Update to latest version of the Dart syntax highlighting grammar
+  [#9920](https://github.com/flutter/devtools/pull/9920).
 
 ## Network profiler updates
 

--- a/packages/devtools_app/test/test_infra/goldens/syntax_highlighting/keywords.dart.golden
+++ b/packages/devtools_app/test/test_infra/goldens/syntax_highlighting/keywords.dart.golden
@@ -410,7 +410,7 @@
 >  var a = new String.fromCharCode(1);
 #  ^^^ storage.type.primitive.dart
 #        ^ keyword.operator.assignment.dart
-#          ^^^ keyword.control.new.dart
+#          ^^^ keyword.new.dart
 #              ^^^^^^ support.class.dart
 #                    ^ punctuation.dot.dart
 #                     ^^^^^^^^^^^^ entity.name.function.dart


### PR DESCRIPTION
This updates the grammar to the latest version from https://github.com/dart-lang/dart-syntax-highlight and regenerates the goldens.

(I have another upcoming change, but to simplify reviewing, I didn't want to mix it in with previous updates here)

