### PR TITLE
Attempt to fix flaky tests caused by modifying the same test apps.

### DIFF
--- a/packages/devtools_app/test/screens/inspector/inspector_integration_test.dart
+++ b/packages/devtools_app/test/screens/inspector/inspector_integration_test.dart
@@ -31,39 +31,19 @@ import '../../test_infra/matchers/matchers.dart';
 // reduced to under 1 second without introducing flakes.
 const inspectorChangeSettleTime = Duration(seconds: 2);
 
-void _copyDirectorySync(Directory source, Directory destination) {
-  if (!destination.existsSync()) {
-    destination.createSync(recursive: true);
-  }
-  for (final entity in source.listSync()) {
-    final newPath = p.join(destination.path, p.basename(entity.path));
-    if (entity is Directory) {
-      _copyDirectorySync(entity, Directory(newPath));
-    } else if (entity is File) {
-      entity.copySync(newPath);
-    }
-  }
-}
 
 void main() {
   // We need to use real async in this test so we need to use this binding.
   initializeLiveTestWidgetsFlutterBindingWithAssets();
   const windowSize = Size(2600.0, 1200.0);
 
-  // We copy the fixture app to a temporary directory because the
-  // auto-refresh tests modify lib/main.dart in-place. If this used the shared
-  // 'inspector_app' fixture, it could cause flaky test failures in other tests
-  // (like inspector_service_test.dart) that run in parallel.
-  final tempAppDir =
-      'test/test_infra/fixtures/inspector_app_temp_${DateTime.now().millisecondsSinceEpoch}';
-  _copyDirectorySync(
-    Directory('test/test_infra/fixtures/inspector_app'),
-    Directory(tempAppDir),
-  );
-
+  // The auto-refresh tests modify lib/main.dart in-place.
+  // We use `useTempDirectory: true` (default in FlutterTestEnvironment) to
+  // copy the fixture app to a temporary directory. This prevents flaky test
+  // failures in other tests (like inspector_service_test.dart) that run in parallel.
   final env = FlutterTestEnvironment(
     const FlutterRunConfiguration(withDebugger: true),
-    testAppDirectory: tempAppDir,
+    testAppDirectory: 'test/test_infra/fixtures/inspector_app',
   );
 
   env.afterEverySetup = () async {
@@ -92,10 +72,6 @@ void main() {
 
   tearDownAll(() {
     env.finalTeardown();
-    final dir = Directory(tempAppDir);
-    if (dir.existsSync()) {
-      dir.deleteSync(recursive: true);
-    }
   });
 
   group('screenshot tests', () {

--- a/packages/devtools_app/test/screens/inspector/inspector_integration_test.dart
+++ b/packages/devtools_app/test/screens/inspector/inspector_integration_test.dart
@@ -31,15 +31,14 @@ import '../../test_infra/matchers/matchers.dart';
 // reduced to under 1 second without introducing flakes.
 const inspectorChangeSettleTime = Duration(seconds: 2);
 
-
 void main() {
   // We need to use real async in this test so we need to use this binding.
   initializeLiveTestWidgetsFlutterBindingWithAssets();
   const windowSize = Size(2600.0, 1200.0);
 
   // The auto-refresh tests modify lib/main.dart in-place.
-  // We use `useTempDirectory: true` to copy the fixture app to a temporary 
-  // directory. This prevents flaky test failures in other tests (like 
+  // We use `useTempDirectory: true` to copy the fixture app to a temporary
+  // directory. This prevents flaky test failures in other tests (like
   // inspector_service_test.dart) that run in parallel.
   final env = FlutterTestEnvironment(
     const FlutterRunConfiguration(withDebugger: true),

--- a/packages/devtools_app/test/screens/inspector/inspector_integration_test.dart
+++ b/packages/devtools_app/test/screens/inspector/inspector_integration_test.dart
@@ -38,12 +38,13 @@ void main() {
   const windowSize = Size(2600.0, 1200.0);
 
   // The auto-refresh tests modify lib/main.dart in-place.
-  // We use `useTempDirectory: true` (default in FlutterTestEnvironment) to
-  // copy the fixture app to a temporary directory. This prevents flaky test
-  // failures in other tests (like inspector_service_test.dart) that run in parallel.
+  // We use `useTempDirectory: true` to copy the fixture app to a temporary 
+  // directory. This prevents flaky test failures in other tests (like 
+  // inspector_service_test.dart) that run in parallel.
   final env = FlutterTestEnvironment(
     const FlutterRunConfiguration(withDebugger: true),
     testAppDirectory: 'test/test_infra/fixtures/inspector_app',
+    useTempDirectory: true,
   );
 
   env.afterEverySetup = () async {

--- a/packages/devtools_app/test/shared/diagnostics/inspector_service_test.dart
+++ b/packages/devtools_app/test/shared/diagnostics/inspector_service_test.dart
@@ -26,6 +26,7 @@ void main() {
   final env = FlutterTestEnvironment(
     const FlutterRunConfiguration(withDebugger: true),
     testAppDirectory: 'test/test_infra/fixtures/inspector_app',
+    useTempDirectory: true,
   );
 
   InspectorService? inspectorService;

--- a/packages/devtools_app/test/shared/eval_integration_test.dart
+++ b/packages/devtools_app/test/shared/eval_integration_test.dart
@@ -14,6 +14,7 @@ import '../test_infra/flutter_test_environment.dart';
 void main() {
   final env = FlutterTestEnvironment(
     const FlutterRunConfiguration(withDebugger: true),
+    useTempDirectory: true,
   );
 
   late Disposable isAlive;

--- a/packages/devtools_app/test/test_infra/flutter_test_environment.dart
+++ b/packages/devtools_app/test/test_infra/flutter_test_environment.dart
@@ -35,9 +35,9 @@ class FlutterTestEnvironment {
        _flutterExe = _parseFlutterExeFromEnv() {
     if (useTempDirectory) {
       final parentDir = p.dirname(testAppDirectory);
-      final tempDirectory = Directory(parentDir).createTempSync(
-        'flutter_test_temp_',
-      );
+      final tempDirectory = Directory(
+        parentDir,
+      ).createTempSync('flutter_test_temp_');
       _tempTestAppDirectory = tempDirectory.path;
       _copyToTempDirectory(testAppDirectory, tempDirectory);
     }

--- a/packages/devtools_app/test/test_infra/flutter_test_environment.dart
+++ b/packages/devtools_app/test/test_infra/flutter_test_environment.dart
@@ -28,7 +28,7 @@ class FlutterTestEnvironment {
   FlutterTestEnvironment(
     this._runConfig, {
     String testAppDirectory = 'test/test_infra/fixtures/flutter_app',
-    bool useTempDirectory = true,
+    bool useTempDirectory = false,
     FlutterDriverFactory? flutterDriverFactory,
   }) : _testAppDirectory = testAppDirectory,
        _flutterDriverFactory = flutterDriverFactory ?? defaultFlutterRunDriver,

--- a/packages/devtools_app/test/test_infra/flutter_test_environment.dart
+++ b/packages/devtools_app/test/test_infra/flutter_test_environment.dart
@@ -28,14 +28,15 @@ class FlutterTestEnvironment {
   FlutterTestEnvironment(
     this._runConfig, {
     String testAppDirectory = 'test/test_infra/fixtures/flutter_app',
-    bool useTempDirectory = false,
+    bool useTempDirectory = true,
     FlutterDriverFactory? flutterDriverFactory,
   }) : _testAppDirectory = testAppDirectory,
        _flutterDriverFactory = flutterDriverFactory ?? defaultFlutterRunDriver,
        _flutterExe = _parseFlutterExeFromEnv() {
     if (useTempDirectory) {
-      final tempDirectory = Directory.systemTemp.createTempSync(
-        'flutter_test_temp',
+      final parentDir = p.dirname(testAppDirectory);
+      final tempDirectory = Directory(parentDir).createTempSync(
+        'flutter_test_temp_',
       );
       _tempTestAppDirectory = tempDirectory.path;
       _copyToTempDirectory(testAppDirectory, tempDirectory);


### PR DESCRIPTION
eval_on_dart_library.dart and inspector_integration_test.dart have been flaky. The hypothesis is that this was caused by multiple integration tests sharing the same fixture workspace. 