### PR TITLE
Run `dcm check-dependencies` over DevTools packages

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -86,6 +86,7 @@ jobs:
       - name: Run dcm checks on packages
         run: |
           dcm check-unused-code packages/devtools_app packages/devtools_app_shared packages/devtools_extensions packages/devtools_shared packages/devtools_test --exclude-public-api
+          dcm check-dependencies packages/devtools_app packages/devtools_app_shared packages/devtools_extensions packages/devtools_shared packages/devtools_test
 
   test-packages:
     name: ${{ matrix.os }} ${{ matrix.package }} test

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -166,9 +166,8 @@ dcm:
     cyclomatic-complexity: 20
     number-of-parameters: 4
     maximum-nesting-level: 5
-  metrics-exclude:
-    - packages/devtools_app/test/test_infra/test_data/**
   exclude:
+    dependencies:
     unused-code:
       # This fixture has unused code for testing the debugger.
       - packages/devtools_app/test/test_infra/fixtures/flutter_app/**

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -168,6 +168,9 @@ dcm:
     maximum-nesting-level: 5
   exclude:
     dependencies:
+      - "**/packages/devtools_extensions/example/**"
+    metrics:
+      - packages/devtools_app/test/test_infra/test_data/**
     unused-code:
       # This fixture has unused code for testing the debugger.
       - packages/devtools_app/test/test_infra/fixtures/flutter_app/**

--- a/packages/devtools_app/pubspec.yaml
+++ b/packages/devtools_app/pubspec.yaml
@@ -21,7 +21,6 @@ dependencies:
   async: ^2.0.0
   collection: ^1.15.0
   dap: ^1.1.0
-  dart_service_protocol_shared: ^0.0.3
   dds_service_extensions: ^2.0.2
   devtools_app_shared:
   devtools_extensions:
@@ -43,12 +42,14 @@ dependencies:
   meta: ^1.9.1
   mime: ^2.0.0
   path: ^1.8.0
+  # ignore: dependencies, used to load the Perfetto UI compiled assets.
   perfetto_ui_compiled:
     path: ../../third_party/packages/perfetto_ui_compiled
   pointer_interceptor: ^0.10.1+1
   provider: ^6.0.2
   source_map_stack_trace: ^2.1.2
   source_maps: ^0.10.12
+  # ignore: dependencies, used in a conditional import.
   sse: ^4.1.2
   stack_trace: ^1.12.0
   string_scanner: ^1.4.0
@@ -57,17 +58,17 @@ dependencies:
   vm_service_protos: ^2.0.0
   vm_snapshot_analysis: ^0.7.6
   web: ^1.0.0
-  web_socket_channel: ^3.0.0
 
 dev_dependencies:
   args: ^2.4.2
   benchmark_harness: ^2.3.1
-  build_runner: ^2.5.4
+  dart_service_protocol_shared: ^0.0.3
   devtools_test:
     path: ../devtools_test
   fake_async: ^1.3.1
   flutter_driver:
     sdk: flutter
+  flutter_lints: ^6.0.0
   flutter_test:
     sdk: flutter
   integration_test:
@@ -78,7 +79,7 @@ dev_dependencies:
   test: ^1.21.0
   web_benchmarks: ^4.1.1
   webdriver: ^3.1.0
-  webkit_inspection_protocol: ">=0.5.0 <2.0.0"
+  web_socket_channel: ^3.0.0
 
 flutter:
   uses-material-design: true

--- a/packages/devtools_app/test/test_infra/fixtures/flutter_app/pubspec.yaml
+++ b/packages/devtools_app/test/test_infra/fixtures/flutter_app/pubspec.yaml
@@ -15,6 +15,7 @@ dependencies:
     sdk: flutter
 
 dev_dependencies:
+  flutter_lints: ^6.0.0
   flutter_test:
     sdk: flutter
 

--- a/packages/devtools_app/test/test_infra/fixtures/flutter_error_app/pubspec.yaml
+++ b/packages/devtools_app/test/test_infra/fixtures/flutter_error_app/pubspec.yaml
@@ -21,6 +21,7 @@ dependencies:
     sdk: flutter
 
 dev_dependencies:
+  flutter_lints: ^6.0.0
   flutter_test:
     sdk: flutter
 

--- a/packages/devtools_app/test/test_infra/fixtures/inspector_app/pubspec.yaml
+++ b/packages/devtools_app/test/test_infra/fixtures/inspector_app/pubspec.yaml
@@ -17,6 +17,7 @@ dependencies:
     path: ../custom_widgets
 
 dev_dependencies:
+  flutter_lints: ^6.0.0
   flutter_test:
     sdk: flutter
 

--- a/packages/devtools_app/test/test_infra/fixtures/memory_app/pubspec.yaml
+++ b/packages/devtools_app/test/test_infra/fixtures/memory_app/pubspec.yaml
@@ -15,6 +15,7 @@ dependencies:
     sdk: flutter
 
 dev_dependencies:
+  flutter_lints: ^6.0.0
   flutter_test:
     sdk: flutter
 

--- a/packages/devtools_app_shared/pubspec.yaml
+++ b/packages/devtools_app_shared/pubspec.yaml
@@ -28,6 +28,7 @@ dependencies:
   web: ^1.0.0
 
 dev_dependencies:
+  flutter_lints: ^6.0.0
   flutter_test:
     sdk: flutter
   test: ^1.21.0

--- a/packages/devtools_extensions/example/app_that_uses_foo/pubspec.yaml
+++ b/packages/devtools_extensions/example/app_that_uses_foo/pubspec.yaml
@@ -23,6 +23,7 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   flutter_lints: ^4.0.0
+  # ignore: dependencies, intentional for example code.
   standalone_extension:
     path: ../packages_with_extensions/standalone_extension
   test: ^1.21.0

--- a/packages/devtools_extensions/example/packages_with_extensions/dart_foo/packages/dart_foo_devtools_extension/pubspec.yaml
+++ b/packages/devtools_extensions/example/packages_with_extensions/dart_foo/packages/dart_foo_devtools_extension/pubspec.yaml
@@ -12,6 +12,7 @@ environment:
   flutter: '>=3.0.0'
 
 dependencies:
+  # ignore: dependencies, intentional for example code.
   devtools_app_shared:
     path: ../../../../../../devtools_app_shared
   devtools_extensions:

--- a/packages/devtools_extensions/example/packages_with_extensions/standalone_extension/pubspec.yaml
+++ b/packages/devtools_extensions/example/packages_with_extensions/standalone_extension/pubspec.yaml
@@ -12,6 +12,7 @@ environment:
   flutter: '>=3.0.0'
 
 dependencies:
+  # ignore: dependencies, intentional for example code.
   devtools_app_shared:
     path: ../../../../devtools_app_shared
   devtools_extensions:

--- a/packages/devtools_extensions/pubspec.yaml
+++ b/packages/devtools_extensions/pubspec.yaml
@@ -32,9 +32,8 @@ dependencies:
 dev_dependencies:
   flutter_driver:
     sdk: flutter
+  flutter_lints: ^6.0.0
   flutter_test:
-    sdk: flutter
-  flutter_web_plugins:
     sdk: flutter
   integration_test:
     sdk: flutter

--- a/packages/devtools_shared/pubspec.yaml
+++ b/packages/devtools_shared/pubspec.yaml
@@ -30,4 +30,5 @@ dependencies:
   yaml_edit: ^2.1.1
 
 dev_dependencies:
+  flutter_lints: ^6.0.0
   test: ^1.21.2

--- a/packages/devtools_test/pubspec.yaml
+++ b/packages/devtools_test/pubspec.yaml
@@ -14,13 +14,13 @@ environment:
 resolution: workspace
 
 dependencies:
-  async: ^2.0.0
   collection: ^1.15.0
   dap: ^1.1.0
   devtools_app:
   devtools_app_shared:
   devtools_shared:
   dtd: ^4.0.0
+  fixnum: ^1.1.1
   flutter:
     sdk: flutter
   flutter_test:
@@ -32,7 +32,7 @@ dependencies:
   path: ^1.8.0
   provider: ^6.0.2
   vm_service: '>=13.0.0 <16.0.0'
-  webkit_inspection_protocol: '>=0.5.0 <2.0.0'
+  vm_service_protos: ^2.0.1
 
 dev_dependencies:
-  build_runner: ^2.3.3
+  flutter_lints: ^6.0.0


### PR DESCRIPTION
This adds the `dcm check-dependencies` check to our CI and resolves (or ignores) findings where appropriate.

Fixes https://github.com/flutter/devtools/issues/9940