### PR TITLE
Enable additional DCM lints (PR 1 of many)

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -187,6 +187,7 @@ dcm:
     - avoid-collapsible-if
     - avoid-collection-methods-with-unrelated-types
     - avoid-constant-assert-conditions
+    - avoid-duplicate-named-imports
     - avoid-importing-entrypoint-exports:
         only-in-src: true
     - avoid-duplicate-exports

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -179,6 +179,7 @@ dcm:
 #    - avoid-banned-imports # TODO(polina-c): add configuration
     - avoid-importing-entrypoint-exports:
         only-in-src: true
+    - avoid-accessing-collections-by-constant-index
     - avoid-async-call-in-sync-function # This does catch findings that unawaited_futures misses.
     - avoid-cascade-after-if-null
     - avoid-collapsible-if

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -186,6 +186,7 @@ dcm:
     - avoid-cascade-after-if-null
     - avoid-collapsible-if
     - avoid-collection-methods-with-unrelated-types
+    - avoid-constant-assert-conditions
     - avoid-importing-entrypoint-exports:
         only-in-src: true
     - avoid-duplicate-exports

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -175,15 +175,19 @@ dcm:
       # Ignore unused code in package examples.
       - packages/devtools_app_shared/example/**
   rules:
-#    - arguments-ordering Too strict
-#    - avoid-banned-imports # TODO(polina-c): add configuration
-    - avoid-importing-entrypoint-exports:
-        only-in-src: true
     - avoid-accessing-collections-by-constant-index
     - avoid-async-call-in-sync-function # This does catch findings that unawaited_futures misses.
+    - avoid-banned-imports:
+            entries:
+              - paths: ['packages/devtools_shared/lib/.*\.dart']
+                deny: ['package:flutter/.*']
+                message: 'Do not import Flutter libraries in devtools_shared.'
+                severity: error
     - avoid-cascade-after-if-null
     - avoid-collapsible-if
     - avoid-collection-methods-with-unrelated-types
+    - avoid-importing-entrypoint-exports:
+        only-in-src: true
     - avoid-duplicate-exports
     - avoid-dynamic
 #    - avoid-global-state   TODO(jacobr): bunch of false positives around boolean flags.

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -181,6 +181,7 @@ dcm:
         only-in-src: true
     - avoid-async-call-in-sync-function # This does catch findings that unawaited_futures misses.
     - avoid-cascade-after-if-null
+    - avoid-collapsible-if
     - avoid-collection-methods-with-unrelated-types
     - avoid-duplicate-exports
     - avoid-dynamic

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -179,6 +179,7 @@ dcm:
 #    - avoid-banned-imports # TODO(polina-c): add configuration
     - avoid-importing-entrypoint-exports:
         only-in-src: true
+    - avoid-async-call-in-sync-function # This does catch findings that unawaited_futures misses.
     - avoid-cascade-after-if-null
     - avoid-collection-methods-with-unrelated-types
     - avoid-duplicate-exports

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -188,6 +188,7 @@ dcm:
     - avoid-collection-methods-with-unrelated-types
     - avoid-constant-assert-conditions
     - avoid-duplicate-named-imports
+    - avoid-empty-test-groups
     - avoid-importing-entrypoint-exports:
         only-in-src: true
     - avoid-duplicate-exports

--- a/packages/devtools_app/lib/src/screens/debugger/codeview.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/codeview.dart
@@ -1380,8 +1380,10 @@ final defaultScriptPopupMenuOptions = [
 final copyPackagePathOption = ScriptPopupMenuOption(
   label: 'Copy package path',
   icon: Icons.content_copy,
-  onSelected: (_, controller) => Clipboard.setData(
-    ClipboardData(text: controller.scriptLocation.value?.scriptRef.uri ?? ''),
+  onSelected: (_, controller) => unawaited(
+    Clipboard.setData(
+      ClipboardData(text: controller.scriptLocation.value?.scriptRef.uri ?? ''),
+    ),
   ),
 );
 

--- a/packages/devtools_app/lib/src/screens/debugger/debugger_controller.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/debugger_controller.dart
@@ -402,6 +402,7 @@ class DebuggerController extends DevToolsScreenController
   /// cache, in order to reduce flashing in the editor view.
   void _populateScriptAndShowLocation(ScriptRef scriptRef) {
     safeUnawaited(
+      // ignore: avoid-async-call-in-sync-function, safeUnawaited handles this.
       scriptManager.getScript(scriptRef).then((script) async {
         await codeViewController.showScriptLocation(ScriptLocation(scriptRef));
       }),

--- a/packages/devtools_app/lib/src/screens/debugger/program_explorer_model.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/program_explorer_model.dart
@@ -190,17 +190,16 @@ class VMServiceObjectNode extends TreeNode<VMServiceObjectNode> {
         ?.isolateNow
         ?.rootLib
         ?.uri;
-    if (rootLibUri != null) {
-      if (rootLibUri.startsWith('package:') ||
-          rootLibUri.startsWith('google3:')) {
-        final parts = rootLibUri.split('/')..removeLast();
-        final path = parts.join('/');
-        for (int i = 0; i < root.children.length; ++i) {
-          if (root.children[i].name.startsWith(path)) {
-            final rootLibNode = root.removeChildAtIndex(i);
-            root.addChild(rootLibNode, index: 0);
-            break;
-          }
+    if (rootLibUri != null &&
+        (rootLibUri.startsWith('package:') ||
+            rootLibUri.startsWith('google3:'))) {
+      final parts = rootLibUri.split('/')..removeLast();
+      final path = parts.join('/');
+      for (int i = 0; i < root.children.length; ++i) {
+        if (root.children[i].name.startsWith(path)) {
+          final rootLibNode = root.removeChildAtIndex(i);
+          root.addChild(rootLibNode, index: 0);
+          break;
         }
       }
     }

--- a/packages/devtools_app/lib/src/screens/dtd/dtd_tools_screen.dart
+++ b/packages/devtools_app/lib/src/screens/dtd/dtd_tools_screen.dart
@@ -193,7 +193,7 @@ class _DtdNotConnectedViewState extends State<DtdNotConnectedView> {
             Expanded(
               child: DevToolsClearableTextField(
                 controller: textEditingController,
-                onSubmitted: (_) => _connect(),
+                onSubmitted: (_) => unawaited(_connect()),
               ),
             ),
             const SizedBox(width: defaultSpacing),

--- a/packages/devtools_app/lib/src/screens/inspector/inspector_controller.dart
+++ b/packages/devtools_app/lib/src/screens/inspector/inspector_controller.dart
@@ -551,10 +551,9 @@ class InspectorController extends DisposableController
   }) {
     if (currentDistance > inRange.end) return null;
 
-    if (inRange.contains(currentDistance)) {
-      if (of.description == matching.description) {
-        return of;
-      }
+    if (inRange.contains(currentDistance) &&
+        of.description == matching.description) {
+      return of;
     }
 
     final children = of.childrenNow;
@@ -968,10 +967,8 @@ class InspectorController extends DisposableController
     required RemoteDiagnosticsNode? selection,
     bool notifyFlutterInspector = false,
   }) {
-    if (selection != null) {
-      if (selection.isCreatedByLocalProject) {
-        _navigateTo(selection);
-      }
+    if (selection != null && selection.isCreatedByLocalProject) {
+      _navigateTo(selection);
     }
 
     if (notifyFlutterInspector && selection != null) {

--- a/packages/devtools_app/lib/src/screens/memory/panes/chart/controller/chart_pane_controller.dart
+++ b/packages/devtools_app/lib/src/screens/memory/panes/chart/controller/chart_pane_controller.dart
@@ -87,18 +87,17 @@ class MemoryChartPaneController extends DisposableController
 
   void _maybeUpdateChart() {
     if (!isChartVisible.value) return;
-    if (!offlineDataController.showingOfflineData.value) {
-      if (_chartConnection == null) {
-        _chartConnection ??= _chartConnection = ChartVmConnection(
-          data.timeline,
-          isAndroidChartVisible: isAndroidChartVisible,
-        );
-        if (serviceConnection.serviceManager.connectedState.value.connected) {
-          _chartConnection!.init();
-          resume();
-        } else {
-          data.isDeviceAndroid ??= false;
-        }
+    if (!offlineDataController.showingOfflineData.value &&
+        _chartConnection == null) {
+      _chartConnection ??= _chartConnection = ChartVmConnection(
+        data.timeline,
+        isAndroidChartVisible: isAndroidChartVisible,
+      );
+      if (serviceConnection.serviceManager.connectedState.value.connected) {
+        _chartConnection!.init();
+        resume();
+      } else {
+        data.isDeviceAndroid ??= false;
       }
     }
     _maybeCalculateAndroidChartVisibility();

--- a/packages/devtools_app/lib/src/screens/memory/panes/chart/controller/charts/android_chart_controller.dart
+++ b/packages/devtools_app/lib/src/screens/memory/panes/chart/controller/charts/android_chart_controller.dart
@@ -8,8 +8,6 @@ import 'package:flutter/material.dart';
 
 import '../../../../../../shared/charts/chart_controller.dart';
 import '../../../../../../shared/charts/chart_trace.dart' as chart_trace;
-import '../../../../../../shared/charts/chart_trace.dart'
-    show ChartType, ChartSymbol;
 import '../../../../shared/primitives/memory_timeline.dart';
 import '../../data/charts.dart';
 
@@ -122,10 +120,10 @@ class AndroidChartController extends ChartController {
 
     // Stack trace
     final stackIndex = createTrace(
-      ChartType.line,
+      chart_trace.ChartType.line,
       chart_trace.PaintCharacteristics(
         color: _Color.stackColor,
-        symbol: ChartSymbol.disc,
+        symbol: chart_trace.ChartSymbol.disc,
         diameter: 1.5,
       ),
       stacked: true,
@@ -138,10 +136,10 @@ class AndroidChartController extends ChartController {
 
     // Java heap trace.
     final javaHeapIndex = createTrace(
-      ChartType.line,
+      chart_trace.ChartType.line,
       chart_trace.PaintCharacteristics(
         color: _Color.javaColor,
-        symbol: ChartSymbol.disc,
+        symbol: chart_trace.ChartSymbol.disc,
         diameter: 1.5,
       ),
       stacked: true,
@@ -155,10 +153,10 @@ class AndroidChartController extends ChartController {
 
     // Code trace
     final codeIndex = createTrace(
-      ChartType.line,
+      chart_trace.ChartType.line,
       chart_trace.PaintCharacteristics(
         color: _Color.codeColor,
-        symbol: ChartSymbol.disc,
+        symbol: chart_trace.ChartSymbol.disc,
         diameter: 1.5,
       ),
       stacked: true,
@@ -171,10 +169,10 @@ class AndroidChartController extends ChartController {
 
     // Graphics Trace
     final graphicIndex = createTrace(
-      ChartType.line,
+      chart_trace.ChartType.line,
       chart_trace.PaintCharacteristics(
         color: _Color.graphicColor,
-        symbol: ChartSymbol.disc,
+        symbol: chart_trace.ChartSymbol.disc,
         diameter: 1.5,
       ),
       stacked: true,
@@ -188,10 +186,10 @@ class AndroidChartController extends ChartController {
 
     // Native heap trace.
     final nativeHeapIndex = createTrace(
-      ChartType.line,
+      chart_trace.ChartType.line,
       chart_trace.PaintCharacteristics(
         color: _Color.nativeHeapColor,
-        symbol: ChartSymbol.disc,
+        symbol: chart_trace.ChartSymbol.disc,
         diameter: 1.5,
       ),
       stacked: true,
@@ -205,10 +203,10 @@ class AndroidChartController extends ChartController {
 
     // Other trace
     final otherIndex = createTrace(
-      ChartType.line,
+      chart_trace.ChartType.line,
       chart_trace.PaintCharacteristics(
         color: _Color.otherColor,
-        symbol: ChartSymbol.disc,
+        symbol: chart_trace.ChartSymbol.disc,
         diameter: 1.5,
       ),
       stacked: true,
@@ -221,10 +219,10 @@ class AndroidChartController extends ChartController {
 
     // System trace
     final systemIndex = createTrace(
-      ChartType.line,
+      chart_trace.ChartType.line,
       chart_trace.PaintCharacteristics(
         color: _Color.systemColor,
-        symbol: ChartSymbol.disc,
+        symbol: chart_trace.ChartSymbol.disc,
         diameter: 1.5,
       ),
       stacked: true,
@@ -241,7 +239,7 @@ class AndroidChartController extends ChartController {
       chart_trace.ChartType.line,
       chart_trace.PaintCharacteristics(
         color: _Color.totalColor,
-        symbol: ChartSymbol.dashedLine,
+        symbol: chart_trace.ChartSymbol.dashedLine,
         strokeWidth: 2,
       ),
       name: AndroidTraceName.total.toString(),

--- a/packages/devtools_app/lib/src/screens/memory/panes/chart/controller/charts/event_chart_controller.dart
+++ b/packages/devtools_app/lib/src/screens/memory/panes/chart/controller/charts/event_chart_controller.dart
@@ -8,8 +8,6 @@ import 'package:flutter/material.dart';
 
 import '../../../../../../shared/charts/chart_controller.dart';
 import '../../../../../../shared/charts/chart_trace.dart' as chart_trace;
-import '../../../../../../shared/charts/chart_trace.dart'
-    show ChartType, PaintCharacteristics, ChartSymbol;
 import '../../../../shared/primitives/memory_timeline.dart';
 
 class _Sizes {
@@ -132,11 +130,11 @@ class EventChartController extends ChartController {
     }
 
     final extensionEventsIndex = createTrace(
-      ChartType.symbol,
-      PaintCharacteristics(
+      chart_trace.ChartType.symbol,
+      chart_trace.PaintCharacteristics(
         color: Colors.purpleAccent[100]!,
         colorAggregate: Colors.purpleAccent[400],
-        symbol: ChartSymbol.filledTriangle,
+        symbol: chart_trace.ChartSymbol.filledTriangle,
         height: 20,
         width: 20,
         fixedMinY: _Sizes.visibleVm,
@@ -151,8 +149,8 @@ class EventChartController extends ChartController {
     );
 
     final snapshotIndex = createTrace(
-      ChartType.symbol,
-      PaintCharacteristics(
+      chart_trace.ChartType.symbol,
+      chart_trace.PaintCharacteristics(
         color: Colors.green,
         strokeWidth: 3,
         diameter: 6,
@@ -169,8 +167,8 @@ class EventChartController extends ChartController {
 
     // Auto-snapshot
     final autoSnapshotIndex = createTrace(
-      ChartType.symbol,
-      PaintCharacteristics(
+      chart_trace.ChartType.symbol,
+      chart_trace.PaintCharacteristics(
         color: Colors.red,
         strokeWidth: 3,
         diameter: 6,
@@ -187,8 +185,8 @@ class EventChartController extends ChartController {
 
     // Manual GC
     final manualGCIndex = createTrace(
-      ChartType.symbol,
-      PaintCharacteristics(
+      chart_trace.ChartType.symbol,
+      chart_trace.PaintCharacteristics(
         color: Colors.blue,
         strokeWidth: 3,
         diameter: 6,
@@ -207,8 +205,8 @@ class EventChartController extends ChartController {
 
     // Monitor
     final monitorIndex = createTrace(
-      ChartType.symbol,
-      PaintCharacteristics(
+      chart_trace.ChartType.symbol,
+      chart_trace.PaintCharacteristics(
         color: mainMonitorColor,
         strokeWidth: 3,
         diameter: 6,
@@ -224,8 +222,8 @@ class EventChartController extends ChartController {
     );
 
     final monitorResetIndex = createTrace(
-      ChartType.symbol,
-      PaintCharacteristics.concentric(
+      chart_trace.ChartType.symbol,
+      chart_trace.PaintCharacteristics.concentric(
         color: Colors.grey[600]!,
         strokeWidth: 4,
         diameter: 6,
@@ -244,10 +242,10 @@ class EventChartController extends ChartController {
 
     // VM GC
     final gcIndex = createTrace(
-      ChartType.symbol,
-      PaintCharacteristics(
+      chart_trace.ChartType.symbol,
+      chart_trace.PaintCharacteristics(
         color: Colors.blue,
-        symbol: ChartSymbol.disc,
+        symbol: chart_trace.ChartSymbol.disc,
         diameter: 4,
         fixedMinY: _Sizes.visibleVm,
         fixedMaxY: _Sizes.extensions,

--- a/packages/devtools_app/lib/src/screens/memory/panes/chart/controller/charts/vm_chart_controller.dart
+++ b/packages/devtools_app/lib/src/screens/memory/panes/chart/controller/charts/vm_chart_controller.dart
@@ -8,8 +8,6 @@ import 'package:flutter/material.dart';
 
 import '../../../../../../shared/charts/chart_controller.dart';
 import '../../../../../../shared/charts/chart_trace.dart' as chart_trace;
-import '../../../../../../shared/charts/chart_trace.dart'
-    show ChartType, ChartSymbol;
 import '../../../../shared/primitives/memory_timeline.dart';
 import '../../data/charts.dart';
 
@@ -133,7 +131,7 @@ class VMChartController extends ChartController {
     }
 
     final externalIndex = createTrace(
-      ChartType.line,
+      chart_trace.ChartType.line,
       chart_trace.PaintCharacteristics(
         color: _Colors.externals,
         symbol: chart_trace.ChartSymbol.disc,
@@ -149,7 +147,7 @@ class VMChartController extends ChartController {
 
     // Used Heap
     final usedIndex = createTrace(
-      ChartType.line,
+      chart_trace.ChartType.line,
       chart_trace.PaintCharacteristics(
         color: _Colors.used,
         symbol: chart_trace.ChartSymbol.disc,
@@ -163,11 +161,11 @@ class VMChartController extends ChartController {
 
     // Heap Capacity
     final capacityIndex = createTrace(
-      ChartType.line,
+      chart_trace.ChartType.line,
       chart_trace.PaintCharacteristics(
         color: _Colors.capacity,
         diameter: 0.0,
-        symbol: ChartSymbol.dashedLine,
+        symbol: chart_trace.ChartSymbol.dashedLine,
       ),
       name: VmTraceName.capacity.toString(),
     );
@@ -178,10 +176,10 @@ class VMChartController extends ChartController {
 
     // RSS
     final rSSIndex = createTrace(
-      ChartType.line,
+      chart_trace.ChartType.line,
       chart_trace.PaintCharacteristics(
         color: _Colors.rss,
-        symbol: ChartSymbol.dashedLine,
+        symbol: chart_trace.ChartSymbol.dashedLine,
         strokeWidth: 2,
       ),
       name: VmTraceName.rSS.toString(),

--- a/packages/devtools_app/lib/src/screens/memory/panes/diff/data/classes_diff.dart
+++ b/packages/devtools_app/lib/src/screens/memory/panes/diff/data/classes_diff.dart
@@ -45,7 +45,7 @@ class ObjectSetDiff {
       }
 
       if (kDebugMode) {
-        throw Exception(
+        throw StateError(
           'Unexpected state for code $code: before=$before, after=$after',
         );
       }

--- a/packages/devtools_app/lib/src/screens/memory/panes/diff/data/classes_diff.dart
+++ b/packages/devtools_app/lib/src/screens/memory/panes/diff/data/classes_diff.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
 
+import 'package:flutter/foundation.dart';
+
 import '../../../../../shared/memory/class_name.dart';
 import '../../../../../shared/memory/classes.dart';
 import '../../../../../shared/memory/heap_data.dart';
@@ -42,7 +44,11 @@ class ObjectSetDiff {
         continue;
       }
 
-      assert(false);
+      if (kDebugMode) {
+        throw Exception(
+          'Unexpected state for code $code: before=$before, after=$after',
+        );
+      }
     }
 
     assert(

--- a/packages/devtools_app/lib/src/screens/performance/panes/controls/enhance_tracing/enhance_tracing.dart
+++ b/packages/devtools_app/lib/src/screens/performance/panes/controls/enhance_tracing/enhance_tracing.dart
@@ -144,6 +144,7 @@ class _TraceWidgetBuildsSettingState extends State<TraceWidgetBuildsSetting>
 
       safeUnawaited(
         serviceConnection.serviceManager.serviceExtensionManager
+            // ignore: avoid-async-call-in-sync-function, safeUnawaited handles this.
             .waitForServiceExtensionAvailable(extension.extension)
             .then((isServiceAvailable) {
               if (isServiceAvailable) {

--- a/packages/devtools_app/lib/src/screens/performance/panes/flutter_frames/flutter_frames_controller.dart
+++ b/packages/devtools_app/lib/src/screens/performance/panes/flutter_frames/flutter_frames_controller.dart
@@ -136,12 +136,11 @@ class FlutterFramesController extends PerformanceFeatureController {
   }
 
   void _maybeBadgeTabForJankyFrame(FlutterFrame frame) {
-    if (_badgeTabForJankyFrames.value) {
-      if (frame.isJanky(_displayRefreshRate.value)) {
-        serviceConnection.errorBadgeManager.incrementBadgeCount(
-          PerformanceScreen.id,
-        );
-      }
+    if (_badgeTabForJankyFrames.value &&
+        frame.isJanky(_displayRefreshRate.value)) {
+      serviceConnection.errorBadgeManager.incrementBadgeCount(
+        PerformanceScreen.id,
+      );
     }
   }
 

--- a/packages/devtools_app/lib/src/screens/vm_developer/object_inspector/vm_simple_list_display.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/object_inspector/vm_simple_list_display.dart
@@ -66,11 +66,13 @@ class _VmSimpleListDisplayState extends State<VmSimpleListDisplay> {
           .value!
           .id!;
       final service = serviceConnection.serviceManager.service!;
-      _initialized = service
-          .getObject(isolateId, elementsInstance.id!)
-          .then(
-            (e) => entries.addAll((e as Instance).elements!.cast<Response?>()),
-          );
+      // ignore: avoid-async-call-in-sync-function, intentional assignment of a future.
+      _initialized = service.getObject(isolateId, elementsInstance.id!);
+      unawaited(
+        _initialized.then(
+          (e) => entries.addAll((e as Instance).elements!.cast<Response?>()),
+        ),
+      );
       return;
     }
     final elementsList = widget.vmObject.elementsAsList;

--- a/packages/devtools_app/lib/src/service/service_extension_widgets.dart
+++ b/packages/devtools_app/lib/src/service/service_extension_widgets.dart
@@ -252,7 +252,7 @@ class _HotReloadScaffoldAction extends ScaffoldAction {
     : super(
         icon: hotReloadIcon,
         tooltip: HotReloadButton._hotReloadTooltip,
-        onPressed: (_) => _callHotReload(),
+        onPressed: (_) => unawaited(_callHotReload()),
       );
 }
 

--- a/packages/devtools_app/lib/src/service/vm_flags.dart
+++ b/packages/devtools_app/lib/src/service/vm_flags.dart
@@ -43,17 +43,16 @@ class VmFlagManager with DisposerMixin {
 
   @visibleForTesting
   void handleVmEvent(Event event) async {
-    if (event.kind == EventKind.kVMFlagUpdate) {
-      if (_flagNotifiers.containsKey(event.flag)) {
-        final currentFlag = _flagNotifiers[event.flag]!.value;
-        _flagNotifiers[event.flag]!.value = Flag.parse({
-          'name': currentFlag.name,
-          'comment': currentFlag.comment,
-          'modified': true,
-          'valueAsString': event.newValue,
-        })!;
-        _flags.value = await service.getFlagList();
-      }
+    if (event.kind == EventKind.kVMFlagUpdate &&
+        _flagNotifiers.containsKey(event.flag)) {
+      final currentFlag = _flagNotifiers[event.flag]!.value;
+      _flagNotifiers[event.flag]!.value = Flag.parse({
+        'name': currentFlag.name,
+        'comment': currentFlag.comment,
+        'modified': true,
+        'valueAsString': event.newValue,
+      })!;
+      _flags.value = await service.getFlagList();
     }
   }
 

--- a/packages/devtools_app/lib/src/shared/charts/chart_controller.dart
+++ b/packages/devtools_app/lib/src/shared/charts/chart_controller.dart
@@ -4,6 +4,7 @@
 
 import 'package:collection/collection.dart';
 import 'package:devtools_app_shared/utils.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 import '../primitives/utils.dart';
@@ -315,7 +316,9 @@ class ChartController extends DisposableController
           labelInterval = labelsTwoMinutes;
           break;
         default:
-          assert(false, 'Unexpected Duration $rangeInMinutes');
+          if (kDebugMode) {
+            throw Exception('Unexpected Duration $rangeInMinutes');
+          }
       }
     }
 

--- a/packages/devtools_app/lib/src/shared/charts/chart_controller.dart
+++ b/packages/devtools_app/lib/src/shared/charts/chart_controller.dart
@@ -317,7 +317,7 @@ class ChartController extends DisposableController
           break;
         default:
           if (kDebugMode) {
-            throw Exception('Unexpected Duration $rangeInMinutes');
+            throw ArgumentError('Unexpected Duration $rangeInMinutes');
           }
       }
     }

--- a/packages/devtools_app/lib/src/shared/charts/flame_chart.dart
+++ b/packages/devtools_app/lib/src/shared/charts/flame_chart.dart
@@ -443,13 +443,11 @@ abstract class FlameChartState<
       );
       return KeyEventResult.handled;
     } else if (eventKey == PhysicalKeyboardKey.keyA) {
-      // `unawaited` does not work for FutureOr
-      // ignore: discarded_futures
+      // ignore: discarded_futures, avoid-async-call-in-sync-function, `unawaited` does not work for FutureOr
       scrollToX(horizontalControllerGroup.offset - keyboardScrollUnit);
       return KeyEventResult.handled;
     } else if (eventKey == PhysicalKeyboardKey.keyD) {
-      // `unawaited` does not work for FutureOr
-      // ignore: discarded_futures
+      // ignore: discarded_futures, avoid-async-call-in-sync-function, `unawaited` does not work for FutureOr
       scrollToX(horizontalControllerGroup.offset + keyboardScrollUnit);
       return KeyEventResult.handled;
     }
@@ -480,8 +478,7 @@ abstract class FlameChartState<
       // to call this that guarantees the scroll controller offsets will be
       // updated for the new zoom level and layout size
       // https://github.com/flutter/devtools/issues/2012.
-      // `unawaited` does not work for FutureOr
-      // ignore: discarded_futures
+      // ignore: discarded_futures, avoid-async-call-in-sync-function, `unawaited` does not work for FutureOr
       scrollToX(newScrollOffset, jump: true);
     });
   }

--- a/packages/devtools_app/lib/src/shared/config_specific/import_export/import_export.dart
+++ b/packages/devtools_app/lib/src/shared/config_specific/import_export/import_export.dart
@@ -77,16 +77,15 @@ class ImportController {
       return;
     }
 
-    if (activeScreenId == ScreenMetaData.performance.id) {
-      if (devToolsOfflineData.json.containsKey('traceEvents')) {
-        notificationService.push(
-          'It looks like you are trying to load data that was saved from an '
-          'old version of DevTools. This data uses a legacy format that is no '
-          'longer supported. To load this file in DevTools, you will need to '
-          'downgrade your Flutter version to < 3.22.',
-        );
-        return;
-      }
+    if (activeScreenId == ScreenMetaData.performance.id &&
+        devToolsOfflineData.json.containsKey('traceEvents')) {
+      notificationService.push(
+        'It looks like you are trying to load data that was saved from an '
+        'old version of DevTools. This data uses a legacy format that is no '
+        'longer supported. To load this file in DevTools, you will need to '
+        'downgrade your Flutter version to < 3.22.',
+      );
+      return;
     }
 
     final connectedApp = OfflineConnectedApp.parse(

--- a/packages/devtools_app/lib/src/shared/config_specific/post_message/_post_message_stub.dart
+++ b/packages/devtools_app/lib/src/shared/config_specific/post_message/_post_message_stub.dart
@@ -7,6 +7,6 @@ import 'post_message.dart';
 Stream<PostMessageEvent> get onPostMessage =>
     throw UnsupportedError('unsupported platform');
 
-// ignore: unused-code, the web implementation is a useful helper for posting messages on the window's parent; this stub is necessary for config specific imports.
+// ignore: unused-code, the web implementation is a useful helper for posting messages on the window's parent; this stub is necessary for conditional imports.
 void postMessage(Object? _, String _) =>
     throw UnsupportedError('unsupported platform');

--- a/packages/devtools_app/lib/src/shared/console/console.dart
+++ b/packages/devtools_app/lib/src/shared/console/console.dart
@@ -206,7 +206,7 @@ class _ConsoleOutputState extends State<_ConsoleOutput>
                       );
                     } else {
                       if (kDebugMode) {
-                        throw Exception(
+                        throw UnsupportedError(
                           'ConsoleLine of unsupported type ${line.runtimeType} encountered',
                         );
                       }

--- a/packages/devtools_app/lib/src/shared/console/console.dart
+++ b/packages/devtools_app/lib/src/shared/console/console.dart
@@ -205,10 +205,11 @@ class _ConsoleOutputState extends State<_ConsoleOutput>
                         isSelectable: false,
                       );
                     } else {
-                      assert(
-                        false,
-                        'ConsoleLine of unsupported type ${line.runtimeType} encountered',
-                      );
+                      if (kDebugMode) {
+                        throw Exception(
+                          'ConsoleLine of unsupported type ${line.runtimeType} encountered',
+                        );
+                      }
                       return const SizedBox();
                     }
                   },

--- a/packages/devtools_app/lib/src/shared/diagnostics/inspector_service.dart
+++ b/packages/devtools_app/lib/src/shared/diagnostics/inspector_service.dart
@@ -311,18 +311,16 @@ class InspectorService extends InspectorServiceBase {
     // determine the source of the inspector selection change directly from the
     // inspector selection changed event.
     final currentTime = DateTime.now().millisecondsSinceEpoch;
-    if (ref != null) {
-      if (_expectedSelectionChanges.containsKey(ref)) {
-        final times = _expectedSelectionChanges.remove(ref)!;
-        while (times.isNotEmpty) {
-          final time = times.removeAt(0);
-          if (time + _maxTimeDelaySelectionNotification >= currentTime) {
-            // We triggered this selection change ourselves. This logic would
-            // work fine without the timestamps for the typical case but we use
-            // the timestamps to be safe in case there is a bug and selection
-            // change events were somehow lost.
-            return true;
-          }
+    if (ref != null && _expectedSelectionChanges.containsKey(ref)) {
+      final times = _expectedSelectionChanges.remove(ref)!;
+      while (times.isNotEmpty) {
+        final time = times.removeAt(0);
+        if (time + _maxTimeDelaySelectionNotification >= currentTime) {
+          // We triggered this selection change ourselves. This logic would
+          // work fine without the timestamps for the typical case but we use
+          // the timestamps to be safe in case there is a bug and selection
+          // change events were somehow lost.
+          return true;
         }
       }
     }

--- a/packages/devtools_app/lib/src/shared/framework/screen.dart
+++ b/packages/devtools_app/lib/src/shared/framework/screen.dart
@@ -502,14 +502,13 @@ abstract class Screen {
     );
   }
 
-  if (screen.requiresAdvancedDeveloperMode) {
-    if (!preferences.advancedDeveloperModeEnabled.value) {
-      _log.finest('screen requires advanced developer mode: returning false');
-      return (
-        show: false,
-        disabledReason: ScreenDisabledReason.requiresAdvancedDeveloperMode,
-      );
-    }
+  if (screen.requiresAdvancedDeveloperMode &&
+      !preferences.advancedDeveloperModeEnabled.value) {
+    _log.finest('screen requires advanced developer mode: returning false');
+    return (
+      show: false,
+      disabledReason: ScreenDisabledReason.requiresAdvancedDeveloperMode,
+    );
   }
 
   final serviceManager = serviceConnection.serviceManager;

--- a/packages/devtools_app/lib/src/shared/memory/class_name.dart
+++ b/packages/devtools_app/lib/src/shared/memory/class_name.dart
@@ -167,7 +167,7 @@ class HeapClassName with Serializable {
     // or detect weak references automatically, without hard coding
     // class names.
     if (kDebugMode) {
-      throw Exception('Unexpected library for $className: $library.');
+      throw StateError('Unexpected library for $className: $library.');
     }
     return false;
   }

--- a/packages/devtools_app/lib/src/shared/memory/class_name.dart
+++ b/packages/devtools_app/lib/src/shared/memory/class_name.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
 
 import 'package:devtools_shared/devtools_shared.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:vm_service/vm_service.dart';
 
@@ -165,7 +166,9 @@ class HeapClassName with Serializable {
     // TODO(polina-c): create a way for users to add their weak classes
     // or detect weak references automatically, without hard coding
     // class names.
-    assert(false, 'Unexpected library for $className: $library.');
+    if (kDebugMode) {
+      throw Exception('Unexpected library for $className: $library.');
+    }
     return false;
   }
 

--- a/packages/devtools_app/lib/src/shared/preferences/_cpu_profiler_preferences.dart
+++ b/packages/devtools_app/lib/src/shared/preferences/_cpu_profiler_preferences.dart
@@ -19,7 +19,7 @@ class CpuProfilerPreferencesController extends DisposableController
     filterTag.value = await storage.getValue(filterStorageId) ?? '';
     addAutoDisposeListener(
       filterTag,
-      () => storage.setValue(filterStorageId, filterTag.value),
+      () => unawaited(storage.setValue(filterStorageId, filterTag.value)),
     );
   }
 }

--- a/packages/devtools_app/lib/src/shared/preferences/_logging_preferences.dart
+++ b/packages/devtools_app/lib/src/shared/preferences/_logging_preferences.dart
@@ -72,7 +72,7 @@ class LoggingPreferencesController extends DisposableController
     filterTag.value = await storage.getValue(filterStorageId) ?? '';
     addAutoDisposeListener(
       filterTag,
-      () => storage.setValue(filterStorageId, filterTag.value),
+      () => unawaited(storage.setValue(filterStorageId, filterTag.value)),
     );
   }
 }

--- a/packages/devtools_app/lib/src/shared/preferences/_network_preferences.dart
+++ b/packages/devtools_app/lib/src/shared/preferences/_network_preferences.dart
@@ -19,7 +19,7 @@ class NetworkPreferencesController extends DisposableController
     filterTag.value = await storage.getValue(filterStorageId) ?? '';
     addAutoDisposeListener(
       filterTag,
-      () => storage.setValue(filterStorageId, filterTag.value),
+      () => unawaited(storage.setValue(filterStorageId, filterTag.value)),
     );
   }
 }

--- a/packages/devtools_app/lib/src/shared/primitives/extent_delegate_list.dart
+++ b/packages/devtools_app/lib/src/shared/primitives/extent_delegate_list.dart
@@ -344,22 +344,23 @@ class RenderSliverExtentDelegateBoxAdaptor extends RenderSliverMultiBoxAdaptor {
       collectGarbage(leadingGarbage, trailingGarbage);
     } else {
       collectGarbage(0, 0);
+    }
 
-      if (!addInitialChild(
-        index: firstIndex,
-        layoutOffset: _extentDelegate!.layoutOffset(firstIndex),
-      )) {
-        // There are either no children, or we are past the end of all our children.
-        // If it is the latter, we will need to find the first available child.
-        final max = _extentDelegate!.layoutOffset(childManager.childCount);
-        assert(max >= 0.0);
-        geometry = SliverGeometry(
-          scrollExtent: _extentDelegate!.layoutOffset(_extentDelegate!.length),
-          maxPaintExtent: max,
-        );
-        childManager.didFinishLayout();
-        return;
-      }
+    if (firstChild == null &&
+        !addInitialChild(
+          index: firstIndex,
+          layoutOffset: _extentDelegate!.layoutOffset(firstIndex),
+        )) {
+      // There are either no children, or we are past the end of all our children.
+      // If it is the latter, we will need to find the first available child.
+      final max = _extentDelegate!.layoutOffset(childManager.childCount);
+      assert(max >= 0.0);
+      geometry = SliverGeometry(
+        scrollExtent: _extentDelegate!.layoutOffset(_extentDelegate!.length),
+        maxPaintExtent: max,
+      );
+      childManager.didFinishLayout();
+      return;
     }
 
     RenderBox? trailingChildWithLayout;

--- a/packages/devtools_app/lib/src/shared/primitives/extent_delegate_list.dart
+++ b/packages/devtools_app/lib/src/shared/primitives/extent_delegate_list.dart
@@ -344,9 +344,7 @@ class RenderSliverExtentDelegateBoxAdaptor extends RenderSliverMultiBoxAdaptor {
       collectGarbage(leadingGarbage, trailingGarbage);
     } else {
       collectGarbage(0, 0);
-    }
 
-    if (firstChild == null) {
       if (!addInitialChild(
         index: firstIndex,
         layoutOffset: _extentDelegate!.layoutOffset(firstIndex),

--- a/packages/devtools_app/lib/src/shared/table/table.dart
+++ b/packages/devtools_app/lib/src/shared/table/table.dart
@@ -397,11 +397,10 @@ class DevToolsTableState<T> extends State<DevToolsTable<T>>
     final verticalScrollController = this.verticalScrollController;
 
     // If we're at the end already, scroll to expose the new content.
-    if (widget.autoScrollContent) {
-      if (verticalScrollController.hasClients &&
-          verticalScrollController.atScrollBottom) {
-        unawaited(verticalScrollController.autoScrollToBottom());
-      }
+    if (widget.autoScrollContent &&
+        verticalScrollController.hasClients &&
+        verticalScrollController.atScrollBottom) {
+      unawaited(verticalScrollController.autoScrollToBottom());
     }
 
     final columnGroups = widget.tableController.columnGroups;

--- a/packages/devtools_app/lib/src/shared/ui/common_widgets.dart
+++ b/packages/devtools_app/lib/src/shared/ui/common_widgets.dart
@@ -947,7 +947,7 @@ class _JsonViewerState extends State<JsonViewer> {
       ); // Creates tree structure
     }
     // Intended to be unawaited.
-    // ignore: discarded_futures
+    // ignore: discarded_futures, avoid-async-call-in-sync-function
     _initializeTree = _buildAndExpand(variable);
   }
 

--- a/packages/devtools_app/lib/src/shared/ui/search.dart
+++ b/packages/devtools_app/lib/src/shared/ui/search.dart
@@ -1250,15 +1250,13 @@ class _AutoCompleteSearchFieldState extends State<AutoCompleteSearchField>
         }
         // Nothing found, pick item selected in dropdown.
         final autoCompleteList = widget.controller.searchAutoComplete.value;
-        if (foundExact == null ||
+        if (autoCompleteList.isNotEmpty && foundExact == null ||
             autoCompleteList[widget.controller.currentHoveredIndex.value]
                     .text !=
                 foundExact) {
-          if (autoCompleteList.isNotEmpty) {
-            foundExact =
-                autoCompleteList[widget.controller.currentHoveredIndex.value]
-                    .text;
-          }
+          foundExact =
+              autoCompleteList[widget.controller.currentHoveredIndex.value]
+                  .text;
         }
 
         if (foundExact != null) {

--- a/packages/devtools_app/lib/src/standalone_ui/ide_shared/not_connected_overlay.dart
+++ b/packages/devtools_app/lib/src/standalone_ui/ide_shared/not_connected_overlay.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
 
+import 'dart:async';
+
 import 'package:devtools_app_shared/service.dart';
 import 'package:devtools_app_shared/ui.dart';
 import 'package:flutter/material.dart';
@@ -51,7 +53,7 @@ class _NotConnectedOverlayState extends State<NotConnectedOverlay> {
           Text(stateLabel, style: theme.textTheme.headlineMedium),
           if (showReconnectButton)
             ElevatedButton(
-              onPressed: () => dtdManager.reconnect(),
+              onPressed: () => unawaited(dtdManager.reconnect()),
               child: const Text('Retry'),
             ),
         ],

--- a/packages/devtools_app/lib/src/standalone_ui/ide_shared/property_editor/property_editor_controller.dart
+++ b/packages/devtools_app/lib/src/standalone_ui/ide_shared/property_editor/property_editor_controller.dart
@@ -109,9 +109,11 @@ class PropertyEditorController extends DisposableController
           return;
         }
         _requestDebouncer.run(
-          () => _updateWithEditableWidgetData(
-            textDocument: textDocument,
-            cursorPosition: cursorPosition,
+          () => unawaited(
+            _updateWithEditableWidgetData(
+              textDocument: textDocument,
+              cursorPosition: cursorPosition,
+            ),
           ),
         );
       }),

--- a/packages/devtools_app/test/screens/debugger/syntax_highlighter_test.dart
+++ b/packages/devtools_app/test/screens/debugger/syntax_highlighter_test.dart
@@ -511,6 +511,7 @@ void main() {
         });
       }
 
+      // ignore: avoid-empty-test-groups, false positive.
       group('single span highlighting:', () {
         for (final spanText in modifierSpans) {
           testSingleSpan('modifier', spanText, modifierSyntaxColor);

--- a/packages/devtools_app/test/screens/debugger/syntax_highlighter_test.dart
+++ b/packages/devtools_app/test/screens/debugger/syntax_highlighter_test.dart
@@ -18,6 +18,7 @@ import 'package:devtools_test/helpers.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:meta/meta.dart';
 
 const modifierSpans = [
   // Start multi-capture spans
@@ -486,6 +487,7 @@ void main() {
         );
       });
 
+      @isTest
       void testSingleSpan(
         String name,
         String spanText,
@@ -511,7 +513,6 @@ void main() {
         });
       }
 
-      // ignore: avoid-empty-test-groups, false positive.
       group('single span highlighting:', () {
         for (final spanText in modifierSpans) {
           testSingleSpan('modifier', spanText, modifierSyntaxColor);

--- a/packages/devtools_app/test/screens/inspector/inspector_screen_test.dart
+++ b/packages/devtools_app/test/screens/inspector/inspector_screen_test.dart
@@ -85,7 +85,7 @@ void main() {
     await fakeExtensionManager.fakeFrame();
   }
 
-  void mockNoExtensionsAvailable() {
+  Future<void> mockNoExtensionsAvailable() async {
     fakeExtensionManager.extensionValueOnDevice = {
       extensions.toggleOnDeviceWidgetInspector.extension: true,
       extensions.toggleSelectWidgetMode.extension: false,
@@ -93,7 +93,7 @@ void main() {
     };
     // Don't actually send any events to the client indicating that service
     // extensions are avaiable.
-    fakeExtensionManager.fakeFrame();
+    await fakeExtensionManager.fakeFrame();
   }
 
   testWidgetsWithWindowSize('builds its tab', windowSize, (
@@ -206,7 +206,7 @@ void main() {
     'Test toggling service extension buttons with no extensions available',
     windowSize,
     (WidgetTester tester) async {
-      mockNoExtensionsAvailable();
+      await mockNoExtensionsAvailable();
       expect(
         fakeExtensionManager.extensionValueOnDevice[extensions
             .debugPaint

--- a/packages/devtools_app/test/screens/memory/chart/chart_test.dart
+++ b/packages/devtools_app/test/screens/memory/chart/chart_test.dart
@@ -564,10 +564,10 @@ void main() {
           } else if (monitorType.isReset) {
             addDataToTrace(controller, monitorResetTraceIndex, rawData);
           } else {
-            assert(false, 'Unknown monitor type');
+            throw Exception('Unknown monitor type');
           }
         } else if (event.isEmpty) {
-          assert(false, 'Unexpected EventSample of isEmpty.');
+          throw Exception('Unexpected EventSample of isEmpty.');
         }
       }
     }

--- a/packages/devtools_app/test/screens/memory/diff/controller/diff_pane_controller_test.dart
+++ b/packages/devtools_app/test/screens/memory/diff/controller/diff_pane_controller_test.dart
@@ -4,10 +4,8 @@
 
 import 'package:devtools_app/src/screens/memory/framework/memory_tabs.dart';
 import 'package:devtools_app/src/screens/memory/panes/diff/controller/diff_pane_controller.dart';
-import 'package:devtools_app/src/screens/memory/panes/diff/controller/diff_pane_controller.dart'
-    as diff_pane_controller
-    show Json;
-import 'package:devtools_app/src/screens/memory/panes/diff/controller/snapshot_item.dart';
+import 'package:devtools_app/src/screens/memory/panes/diff/controller/snapshot_item.dart'
+    hide Json;
 import 'package:devtools_test/helpers.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -53,10 +51,7 @@ void main() {
       snapshots.first.diffWith.value = snapshots.last;
 
       final json = controller.toJson();
-      expect(
-        json.keys.toSet(),
-        equals(diff_pane_controller.Json.values.map((e) => e.name).toSet()),
-      );
+      expect(json.keys.toSet(), equals(Json.values.map((e) => e.name).toSet()));
       final fromJson = DiffPaneController.fromJson(json);
 
       final snapshotsFromJson = fromJson.core.snapshots.value

--- a/packages/devtools_app/test/screens/memory/shared/heap/heap_analyzer_test.dart
+++ b/packages/devtools_app/test/screens/memory/shared/heap/heap_analyzer_test.dart
@@ -15,6 +15,7 @@ void main() {
       final heap = HeapData(t.heap, created: DateTime.now());
       await heap.calculate;
 
+      // ignore: avoid-accessing-collections-by-constant-index, intentional use of special index.
       expect(heap.retainedSizes![heapRootIndex], equals(t.rootRetainedSize));
 
       var actualUnreachableSize = 0;

--- a/packages/devtools_app/test/screens/vm_developer/object_inspector/vm_developer_common_widgets_test.dart
+++ b/packages/devtools_app/test/screens/vm_developer/object_inspector/vm_developer_common_widgets_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
 
+import 'dart:async';
+
 import 'package:devtools_app/devtools_app.dart';
 import 'package:devtools_app/src/screens/vm_developer/object_inspector/inbound_references_tree.dart';
 import 'package:devtools_app/src/screens/vm_developer/vm_developer_common_widgets.dart';
@@ -281,7 +283,8 @@ void main() {
           InboundReferencesTree(
             controller: testObjectInspectorViewController,
             object: mockClassObject,
-            onExpanded: (bool _) => mockClassObject.requestInboundsRefs(),
+            onExpanded: (bool _) =>
+                unawaited(mockClassObject.requestInboundsRefs()),
           ),
         ),
       );

--- a/packages/devtools_app/test/test_infra/scenes/standalone_ui/mock_editor_widget.dart
+++ b/packages/devtools_app/test/test_infra/scenes/standalone_ui/mock_editor_widget.dart
@@ -277,8 +277,9 @@ class _MockEditorWidgetState extends State<MockEditorWidget>
                     children: [
                       const Text('DTD Connection: '),
                       ElevatedButton(
-                        onPressed: () =>
-                            dtdManager.disconnectImpl(allowReconnect: true),
+                        onPressed: () => unawaited(
+                          dtdManager.disconnectImpl(allowReconnect: true),
+                        ),
                         child: const Text('Drop Connection'),
                       ),
                     ],

--- a/packages/devtools_app/test/test_infra/test_data/memory/heap/heap_graph_fakes.dart
+++ b/packages/devtools_app/test/test_infra/test_data/memory/heap/heap_graph_fakes.dart
@@ -93,6 +93,7 @@ class FakeHeapSnapshotGraph extends Fake implements HeapSnapshotGraph {
           ),
         );
         final index = objects.length - 1;
+        // ignore: avoid-accessing-collections-by-constant-index, intentional use of special index.
         objects[heapRootIndex].addReference(index);
       }
     }

--- a/packages/devtools_app_shared/lib/src/service/eval_on_dart_library.dart
+++ b/packages/devtools_app_shared/lib/src/service/eval_on_dart_library.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
 
+// ignore_for_file: avoid-duplicate-named-imports, used for easily prefixing Error without collision.
+
 // This code is directly based on src/io/flutter/inspector/EvalOnDartLibrary.java
 // If you add a method to this class you should also add it to EvalOnDartLibrary.java
 import 'dart:async';

--- a/packages/devtools_app_shared/lib/src/ui/theme/_ide_theme_web.dart
+++ b/packages/devtools_app_shared/lib/src/ui/theme/_ide_theme_web.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
 
-// ignore_for_file: unused-code, this file is exported via config specific exports.
+// ignore_for_file: unused-code, this file is exported via a conditional export.
 
 import 'package:web/web.dart';
 

--- a/packages/devtools_app_shared/lib/src/utils/url/_url_web.dart
+++ b/packages/devtools_app_shared/lib/src/utils/url/_url_web.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
 
-// ignore_for_file: unused-code, this file is exported via config specific exports.
+// ignore_for_file: unused-code, this file is exported via conditional exports.
 
 import 'package:web/web.dart';
 

--- a/packages/devtools_app_shared/test/test_utils.dart
+++ b/packages/devtools_app_shared/test/test_utils.dart
@@ -6,6 +6,7 @@ import 'package:devtools_app_shared/ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:meta/meta.dart';
 
 // NOTE: these helpers are duplicated from `package:devtools_test`. We copied
 // them instead of importing `devtools_test`, because `devtools_test` is not
@@ -28,6 +29,7 @@ Widget wrap(Widget widget) {
 }
 
 /// Runs a test with the size of the app window under test to [windowSize].
+@isTest
 void testWidgetsWithWindowSize(
   String name,
   Size windowSize,

--- a/packages/devtools_app_shared/test/ui/split_pane_test.dart
+++ b/packages/devtools_app_shared/test/ui/split_pane_test.dart
@@ -1217,6 +1217,7 @@ void main() {
           );
         },
       );
+
       testWidgetsWithWindowSize('return Axis.vertical', const Size(500, 800), (
         WidgetTester tester,
       ) async {

--- a/packages/devtools_shared/lib/src/test/chrome.dart
+++ b/packages/devtools_shared/lib/src/test/chrome.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
 
-// ignore_for_file: avoid_print
+// ignore_for_file: avoid_print, avoid-duplicate-named-imports, fix after moving file to package:dds.
 
 // DO NOT DELETE THIS FILE. It is imported by DDS and used in the
 // devtools_server tests.

--- a/packages/devtools_shared/test/helpers/extension_test_manager_test.dart
+++ b/packages/devtools_shared/test/helpers/extension_test_manager_test.dart
@@ -8,8 +8,6 @@ import 'package:test/test.dart';
 import 'extension_test_manager.dart';
 
 void main() {
-  group('$ExtensionTestManager', () {});
-
   group('$TestPackageWithExtension', () {
     test('$driftPackage', () {
       expect(driftPackage.name, 'drift');


### PR DESCRIPTION
Enable first set of additional DCM lints. More to come. Work towards https://github.com/flutter/devtools/issues/9939.

Enables the following rules and fixes (or ignores) violations:
- avoid-async-call-in-sync-function
- avoid-collapsible-if
- avoid-accessing-collections-by-constant-index
- avoid-banned-imports (enforces no Flutter imports in devtools_shared)
- avoid-constant-assert-conditions
- avoid-duplicate-named-imports
- avoid-empty-test-groups