### PR TITLE
Fix RenderFlex overflow in debugging controls at narrow widths

### DIFF
--- a/packages/devtools_app/lib/src/screens/debugger/controls.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/controls.dart
@@ -64,19 +64,37 @@ class _DebuggingControlsState extends State<DebuggingControls>
       height: defaultButtonHeight,
       child: Row(
         children: [
-          _pauseAndResumeButtons(
-            isPaused: serviceConnection.serviceManager.isMainIsolatePaused,
-            resuming: resuming,
+          // The debugging controls have no way to shrink further once their
+          // labels have already been dropped (see
+          // [DebuggingControls.minWidth]), so below roughly 630px the icon-only
+          // content still does not fit and the [Row] overflows. Making the
+          // controls scroll horizontally keeps every control reachable at any
+          // width instead of clipping them behind an overflow error. The
+          // libraries button stays pinned on the right, outside the scroll
+          // view, so it does not scroll out of reach.
+          Expanded(
+            child: SingleChildScrollView(
+              scrollDirection: Axis.horizontal,
+              child: Row(
+                children: [
+                  _pauseAndResumeButtons(
+                    isPaused:
+                        serviceConnection.serviceManager.isMainIsolatePaused,
+                    resuming: resuming,
+                  ),
+                  const SizedBox(width: denseSpacing),
+                  _stepButtons(canStep: canStep),
+                  const SizedBox(width: denseSpacing),
+                  BreakOnExceptionsControl(controller: controller),
+                  if (isVmApp) ...[
+                    const SizedBox(width: denseSpacing),
+                    CodeStatisticsControls(controller: controller),
+                  ],
+                ],
+              ),
+            ),
           ),
           const SizedBox(width: denseSpacing),
-          _stepButtons(canStep: canStep),
-          const SizedBox(width: denseSpacing),
-          BreakOnExceptionsControl(controller: controller),
-          if (isVmApp) ...[
-            const SizedBox(width: denseSpacing),
-            CodeStatisticsControls(controller: controller),
-          ],
-          const Expanded(child: SizedBox(width: denseSpacing)),
           _librariesButton(),
         ],
       ),

--- a/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
+++ b/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
@@ -44,6 +44,10 @@ TODO: Remove this section if there are not any updates.
 * Fix a bug in the TextMate grammar parser that could result in code after
   comments being classified as comments.
   [#9921](https://github.com/flutter/devtools/pull/9921).
+* Fixed an overflow in the debugging controls when the Debugger screen is
+  narrow, such as when DevTools is embedded in an IDE side panel. The controls
+  now scroll horizontally instead of overflowing.
+  [#9942](https://github.com/flutter/devtools/pull/9942)
 
 ## Network profiler updates
 

--- a/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
+++ b/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
@@ -47,7 +47,7 @@ TODO: Remove this section if there are not any updates.
 * Fixed an overflow in the debugging controls when the Debugger screen is
   narrow, such as when DevTools is embedded in an IDE side panel. The controls
   now scroll horizontally instead of overflowing.
-  [#9942](https://github.com/flutter/devtools/pull/9942)
+  [#9949](https://github.com/flutter/devtools/pull/9949)
 
 ## Network profiler updates
 

--- a/packages/devtools_app/test/screens/debugger/debugger_controls_overflow_test.dart
+++ b/packages/devtools_app/test/screens/debugger/debugger_controls_overflow_test.dart
@@ -25,24 +25,30 @@ void main() {
 
   const windowHeight = 800.0;
 
-  final fakeServiceConnection = FakeServiceConnectionManager();
-  final scriptManager = MockScriptManager();
-  mockConnectedApp(fakeServiceConnection.serviceManager.connectedApp!);
-  setGlobal(ServiceConnectionManager, fakeServiceConnection);
-  setGlobal(IdeTheme, IdeTheme());
-  setGlobal(ScriptManager, scriptManager);
-  setGlobal(NotificationService, NotificationService());
-  setGlobal(BreakpointManager, BreakpointManager());
-  setGlobal(
-    DevToolsEnvironmentParameters,
-    ExternalDevToolsEnvironmentParameters(),
-  );
-  setGlobal(PreferencesController, PreferencesController());
-  fakeServiceConnection.consoleService.ensureServiceInitialized();
-  when(
-    fakeServiceConnection.errorBadgeManager.errorCountNotifier('debugger'),
-  ).thenReturn(ValueNotifier<int>(0));
-  final debuggerController = createMockDebuggerControllerWithDefaults();
+  late FakeServiceConnectionManager fakeServiceConnection;
+  late MockScriptManager scriptManager;
+  late MockDebuggerController debuggerController;
+
+  setUp(() {
+    fakeServiceConnection = FakeServiceConnectionManager();
+    scriptManager = MockScriptManager();
+    mockConnectedApp(fakeServiceConnection.serviceManager.connectedApp!);
+    setGlobal(ServiceConnectionManager, fakeServiceConnection);
+    setGlobal(IdeTheme, IdeTheme());
+    setGlobal(ScriptManager, scriptManager);
+    setGlobal(NotificationService, NotificationService());
+    setGlobal(BreakpointManager, BreakpointManager());
+    setGlobal(
+      DevToolsEnvironmentParameters,
+      ExternalDevToolsEnvironmentParameters(),
+    );
+    setGlobal(PreferencesController, PreferencesController());
+    fakeServiceConnection.consoleService.ensureServiceInitialized();
+    when(
+      fakeServiceConnection.errorBadgeManager.errorCountNotifier('debugger'),
+    ).thenReturn(ValueNotifier<int>(0));
+    debuggerController = createMockDebuggerControllerWithDefaults();
+  });
 
   Future<void> pumpControls(WidgetTester tester) async {
     await tester.pumpWidget(

--- a/packages/devtools_app/test/screens/debugger/debugger_controls_overflow_test.dart
+++ b/packages/devtools_app/test/screens/debugger/debugger_controls_overflow_test.dart
@@ -1,0 +1,89 @@
+// Copyright 2026 The Flutter Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
+
+import 'package:devtools_app/devtools_app.dart';
+import 'package:devtools_app/src/screens/debugger/controls.dart';
+import 'package:devtools_app_shared/ui.dart';
+import 'package:devtools_app_shared/utils.dart';
+import 'package:devtools_test/devtools_test.dart';
+import 'package:devtools_test/helpers.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+
+void main() {
+  /// Widths the debugging controls are expected to lay out at without
+  /// overflowing.
+  ///
+  /// The controls stop showing button labels below
+  /// [DebuggingControls.minWidth], but the remaining icon-only content still
+  /// did not fit below roughly 630px, which is a realistic width for DevTools
+  /// embedded in an IDE side panel. See
+  /// https://github.com/flutter/devtools/issues/4917.
+  const windowWidths = [1200.0, 800.0, 600.0, 500.0, 400.0];
+
+  const windowHeight = 800.0;
+
+  final fakeServiceConnection = FakeServiceConnectionManager();
+  final scriptManager = MockScriptManager();
+  mockConnectedApp(fakeServiceConnection.serviceManager.connectedApp!);
+  setGlobal(ServiceConnectionManager, fakeServiceConnection);
+  setGlobal(IdeTheme, IdeTheme());
+  setGlobal(ScriptManager, scriptManager);
+  setGlobal(NotificationService, NotificationService());
+  setGlobal(BreakpointManager, BreakpointManager());
+  setGlobal(
+    DevToolsEnvironmentParameters,
+    ExternalDevToolsEnvironmentParameters(),
+  );
+  setGlobal(PreferencesController, PreferencesController());
+  fakeServiceConnection.consoleService.ensureServiceInitialized();
+  when(
+    fakeServiceConnection.errorBadgeManager.errorCountNotifier('debugger'),
+  ).thenReturn(ValueNotifier<int>(0));
+  final debuggerController = createMockDebuggerControllerWithDefaults();
+
+  Future<void> pumpControls(WidgetTester tester) async {
+    await tester.pumpWidget(
+      wrapWithControllers(
+        const DebuggingControls(),
+        debugger: debuggerController,
+      ),
+    );
+    await tester.pump();
+  }
+
+  group('DebuggingControls', () {
+    for (final width in windowWidths) {
+      testWidgetsWithWindowSize(
+        'does not overflow at ${width.toInt()}px',
+        Size(width, windowHeight),
+        (WidgetTester tester) async {
+          await pumpControls(tester);
+
+          expect(tester.takeException(), isNull);
+        },
+      );
+    }
+
+    testWidgetsWithWindowSize(
+      'keeps the file explorer button pinned to the right edge',
+      const Size(1200.0, windowHeight),
+      (WidgetTester tester) async {
+        await pumpControls(tester);
+
+        final controlsRight = tester
+            .getRect(find.byType(DebuggingControls))
+            .right;
+        final fileExplorerButtonRight = tester
+            .getRect(
+              find.widgetWithIcon(GaDevToolsButton, Icons.folder_outlined),
+            )
+            .right;
+
+        expect(fileExplorerButtonRight, equals(controlsRight));
+      },
+    );
+  });
+}


### PR DESCRIPTION
Fixes #4917

The debugging controls already drop their button labels below `DebuggingControls.minWidth`, but there is no strategy left once the icon-only content itself does not fit, so the controls `Row` overflows. The 2022 report was at a wider width; the small-mode work since then fixed the common case but not the narrow one.

I measured the current threshold by pumping `DebuggingControls` through the repo's test harness at descending window widths on `master`:

| Window width | Before | After |
|---|---|---|
| 1200 px | no overflow | no overflow |
| 800 px | no overflow | no overflow |
| 600 px | overflowed by 29 px | no overflow |
| 500 px | overflowed by 129 px | no overflow |
| 400 px | overflowed by 229 px | no overflow |

So it starts at roughly 630px, which is realistic for DevTools embedded in an IDE side panel.

## The change

The controls now scroll horizontally instead of overflowing, so every control stays reachable at any width rather than being clipped behind an overflow error. The file explorer button stays pinned outside the scroll view so it does not scroll out of reach, which keeps the wide layout visually unchanged.

In #4917 @kenzieschmoll suggested merging the pause/resume buttons, densifying the stepping group, or shrinking the exceptions dropdown font. I went with scrolling because it is the least invasive of the options I proposed on the issue and it holds at any width rather than buying back a fixed number of pixels — but I'm happy to switch to a denser layout, or combine the two, if you'd prefer that direction.

## Before / after at 500px

Before:

![before](https://raw.githubusercontent.com/theprantadutta/devtools/screenshots-4917/.pr-shots/4917_before.png)

After:

![after](https://raw.githubusercontent.com/theprantadutta/devtools/screenshots-4917/.pr-shots/4917_after.png)

These are widget-test captures rather than app screenshots, so text renders as solid bars in the test font — the relevant part is the overflow striping on the right edge in the "before" image, and the file explorer button being visible and pinned in the "after" image.

## Tests

Added `debugger_controls_overflow_test.dart`, which pumps the controls at each of the widths above and asserts no exception, plus one test pinning the file explorer button to the right edge so the wide layout does not silently regress. I confirmed the test fails on the three narrow widths without the fix and passes with it.

`test/screens/debugger/` and `scaffold_debugging_controls_test.dart` otherwise pass. One unrelated pre-existing failure in `debugger_evaluation_test.dart` ("EvalOnDartLibrary returns no operators for int") reproduces on a clean `master` checkout without my change.

## Pre-launch Checklist

### General checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I updated/added relevant documentation (doc comments with `///`).

### Issues checklist

- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I listed at least one issue which has the [`contributions-welcome`] or [`good-first-issue`] label.
- [ ] I did not list at least one issue with the [`contributions-welcome`] or [`good-first-issue`] label. I understand this means my PR might take longer to be reviewed.

### Tests checklist

- [x] I added new tests to check the change I am making...
- [ ] OR there is a reason for not adding tests, which I explained in the PR description.

### AI-tooling checklist

- [ ] I did not use any AI tooling in creating this PR.
- [x] OR I did use AI tooling, and...
    * [x] I read the [AI contributions guidelines] and agree to follow them.
    * [x] I reviewed all AI-generated code before opening this PR.
    * [x] I understand and am able to discuss the code in this PR.
    * [x] I have verifed the accuracy of any AI-generated text included in the PR description.
    * [x] I commit to verifying the accuracy of any AI-generated code or text that I upload in response to review comments.

### Feature-change checklist

- [ ] This PR does not change the DevTools UI or behavior and...
    * [ ] I added the `release-notes-not-required` label or left a comment requesting the label be added.
- [x] OR this PR does change the DevTools UI or behavior and...
    * [x] I added an entry to `packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md`.
    * [x] I included before/after screenshots and/or a GIF demo of the new UI to my PR description.
    * [ ] I ran the DevTools app locally to manually verify my changes.

On that last box: I verified this through widget tests and the rendered captures above rather than by running the DevTools app against a live VM service, so I've left it unchecked rather than tick something I didn't do. If you'd like a manual pass against a running app before this lands, say the word and I'll do that.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/devtools/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[CLA]: https://cla.developers.google.com/
[`contributions-welcome`]: https://github.com/flutter/devtools/issues?q=state%3Aopen%20label%3Acontributions-welcome
[`good-first-issue`]: https://github.com/flutter/devtools/issues?q=state%3Aopen%20label%3Agood-first-issue
[AI contributions guidelines]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
