### PR TITLE
Fix issue with compare_benchmarks.dart script

### DIFF
--- a/packages/devtools_app/benchmark/scripts/compare_benchmarks.dart
+++ b/packages/devtools_app/benchmark/scripts/compare_benchmarks.dart
@@ -5,7 +5,6 @@
 import 'dart:convert';
 import 'dart:io';
 
-import 'package:devtools_app/src/shared/primitives/utils.dart';
 import 'package:web_benchmarks/analysis.dart';
 
 import 'utils.dart';

--- a/packages/devtools_app/benchmark/scripts/utils.dart
+++ b/packages/devtools_app/benchmark/scripts/utils.dart
@@ -2,9 +2,14 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
 
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:web_benchmarks/analysis.dart';
+
+/// Returns a pretty-printed representation of a JSON payload.
+String prettyPrintJson(Object? json) =>
+    const JsonEncoder.withIndent('  ').convert(json);
 
 File? checkFileExists(String path) {
   final testFile = File.fromUri(Uri.parse(path));


### PR DESCRIPTION
A recent change to use a `prettyPrintJson` helper from `devtools_app` caused errors when running the benchmark comparison scripts since `devtools_app` introduces an unnecessary flutter dependency for this script.

This PR removes the import from `devtools_app` to inline the helper in the benchmark utils. 