### PR TITLE
Hide extension button when embedded in an IDE

### DIFF
--- a/.agents/skills/debugging-devtools-extensions/SKILL.md
+++ b/.agents/skills/debugging-devtools-extensions/SKILL.md
@@ -39,23 +39,7 @@ Use the system OS open command to launch Chrome/browser directly to the desired 
 - **Linux**: `xdg-open "http://localhost:52941/foo_ext?embedMode=one"`
 - **Windows**: `start "http://localhost:52941/foo_ext?embedMode=one"`
 
-## 3. Testing Extension URLs & Embed Modes
-
-Navigating to specific query parameters tests different extension UI states:
-
-- **Single Extension Screen (`embedOne`)**:
-  `http://localhost:52941/foo_ext?embedMode=one`
-  *(Renders single extension view like extensions are rendered inside VS Code. In this mode, the extensions settings button, a puzzle piece icon, IS visible in the bottom status bar)*
-
-- **Extensions-Only View (`embedMany`)**:
-  `http://localhost:52941/?hide=all-except-extensions&embedMode=many`
-  *(Renders only extension tabs like extensions are rendered inside IntelliJ/Android Studio. In this mode, the extensions settings button, a puzzle piece icon, IS visible in the top tab bar)*
-
-- **Standard Core Screen (`embedOne`)**:
-  `http://localhost:52941/inspector?embedMode=one`
-  *(Renders standard tool panel like they are rendered in VS Code. In this mode, the extensions settings button, a puzzle piece icon, IS HIDDEN)*
-
-## 4. Connecting to an End-User Target App
+## 3. Connecting to an End-User Target App
 
 To test against real pub package extensions:
 
@@ -70,7 +54,7 @@ To test against real pub package extensions:
    - **Linux**: `xdg-open "http://localhost:52941/foo_ext?embedMode=one&uri=<VM_SERVICE_URI>"`
    - **Windows**: `start "http://localhost:52941/foo_ext?embedMode=one&uri=<VM_SERVICE_URI>"`
 
-## 5. Human Interaction & User Prompting Steps
+## 4. Human Interaction & User Prompting Steps
 
 When an AI agent is performing this workflow:
 

--- a/.agents/skills/debugging-devtools-extensions/SKILL.md
+++ b/.agents/skills/debugging-devtools-extensions/SKILL.md
@@ -65,15 +65,15 @@ To test against real pub package extensions:
    flutter run -d chrome
    ```
 2. Ask the user to copy/paste the VM Service URI from the terminal output (e.g. `ws://127.0.0.1:8181/xxx=/ws`).
-3. Open the browser automatically with the `uri` parameter:
-   ```bash
-   open "http://localhost:52941/foo_ext?embedMode=one&uri=<VM_SERVICE_URI>"
-   ```
+3. Open the browser automatically with the `uri` parameter using the appropriate OS command (as described in Step 2b):
+   - **macOS**: `open "http://localhost:52941/foo_ext?embedMode=one&uri=<VM_SERVICE_URI>"`
+   - **Linux**: `xdg-open "http://localhost:52941/foo_ext?embedMode=one&uri=<VM_SERVICE_URI>"`
+   - **Windows**: `start "http://localhost:52941/foo_ext?embedMode=one&uri=<VM_SERVICE_URI>"`
 
 ## 5. Human Interaction & User Prompting Steps
 
 When an AI agent is performing this workflow:
 
 - **Obtaining VM Service URI**: When connecting to a target app, ask the user to provide the VM Service URI printed in the target app's console output (using `ask_question` or a direct prompt).
-- **Automated Browser Opening**: The agent should launch DevTools and execute `open <url>` to launch the browser automatically.
-- **Manual Visual Verification**: Ask the user to inspect the opened browser window and confirm whether the expected extension UI or status bar button appears.
+- **Automated Browser Opening**: The agent should launch DevTools and execute the appropriate OS command (`open`, `xdg-open`, or `start` as described in Step 2b) to launch the browser automatically.
+- **Manual Visual Verification**: Ask the user to inspect the opened browser window and confirm whether the expected extension UI or behavior is visible.

--- a/.agents/skills/debugging-devtools-extensions/SKILL.md
+++ b/.agents/skills/debugging-devtools-extensions/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: debugging-devtools-extensions
+description: Guidelines and step-by-step workflow for debugging DevTools extensions locally, including stub mode, fixed-port launching, browser auto-opening, URL query parameters, target app connection, and human-in-the-loop interaction. Use when debugging or testing DevTools extension behavior.
+---
+
+# Debugging DevTools Extensions
+
+Follow this workflow to test and debug DevTools extensions locally.
+
+## 1. Local Stub Extensions Mode (No Server Needed)
+
+When running DevTools in standalone web mode (`flutter run -d chrome`), DevTools does not run the `devtools_server` backend by default. To test extensions without a running server backend:
+
+1. Open [`packages/devtools_app/lib/src/shared/development_helpers.dart`](file:///Users/ryjohn/code/github/flutter/devtools/packages/devtools_app/lib/src/shared/development_helpers.dart#L57).
+2. Set `const _debugDevToolsExtensions = true;`.
+
+> [!WARNING]
+> Never commit `_debugDevToolsExtensions = true;` to git. A repository unit test (`development_helpers_test.dart`) enforces that this flag remains `false`.
+
+Activating stub mode registers the following mock extensions:
+- `foo_ext` (`package:foo`)
+- `bar_ext` (`package:bar`)
+- `provider_ext` (`package:provider`)
+
+## 2. Automated Launch & Browser Navigation
+
+The agent can automate running DevTools AND launching the browser directly to the target URL:
+
+### Step 2a: Launch DevTools on a Fixed Port
+In `packages/devtools_app`, launch DevTools specifying a fixed `--web-port`:
+```bash
+flutter run -d chrome --web-port=52941
+```
+
+### Step 2b: Open Browser to Target URL Automatically
+Use the system OS open command to launch Chrome/browser directly to the desired test URL:
+
+- **macOS**: `open "http://localhost:52941/foo_ext?embedMode=one"`
+- **Linux**: `xdg-open "http://localhost:52941/foo_ext?embedMode=one"`
+- **Windows**: `start "http://localhost:52941/foo_ext?embedMode=one"`
+
+## 3. Testing Extension URLs & Embed Modes
+
+Navigating to specific query parameters tests different extension UI states:
+
+- **Single Extension Screen (`embedOne`)**:
+  `http://localhost:52941/foo_ext?embedMode=one`
+  *(Renders single extension view; puzzle piece icon IS visible in status bar)*
+
+- **Extensions-Only View**:
+  `http://localhost:52941/?hide=all-except-extensions&embedMode=many`
+  *(Renders only extension tabs; puzzle piece icon IS visible)*
+
+- **Standard Core Screen (`embedOne`)**:
+  `http://localhost:52941/inspector?embedMode=one`
+  *(Renders standard tool panel; puzzle piece icon IS HIDDEN)*
+
+## 4. Connecting to an End-User Target App
+
+To test against real pub package extensions:
+
+1. Run the sample app in `packages/devtools_extensions/example/app_that_uses_foo`:
+   ```bash
+   cd packages/devtools_extensions/example/app_that_uses_foo
+   flutter run -d chrome
+   ```
+2. Ask the user to copy/paste the VM Service URI from the terminal output (e.g. `ws://127.0.0.1:8181/xxx=/ws`).
+3. Open the browser automatically with the `uri` parameter:
+   ```bash
+   open "http://localhost:52941/foo_ext?embedMode=one&uri=<VM_SERVICE_URI>"
+   ```
+
+## 5. Human Interaction & User Prompting Steps
+
+When an AI agent is performing this workflow:
+
+- **Obtaining VM Service URI**: When connecting to a target app, ask the user to provide the VM Service URI printed in the target app's console output (using `ask_question` or a direct prompt).
+- **Automated Browser Opening**: The agent should launch DevTools and execute `open <url>` to launch the browser automatically.
+- **Manual Visual Verification**: Ask the user to inspect the opened browser window and confirm whether the expected extension UI or status bar button appears.

--- a/.agents/skills/debugging-devtools-extensions/SKILL.md
+++ b/.agents/skills/debugging-devtools-extensions/SKILL.md
@@ -45,15 +45,15 @@ Navigating to specific query parameters tests different extension UI states:
 
 - **Single Extension Screen (`embedOne`)**:
   `http://localhost:52941/foo_ext?embedMode=one`
-  *(Renders single extension view; puzzle piece icon IS visible in status bar)*
+  *(Renders single extension view like extensions are rendered inside VS Code. In this mode, the extensions settings button, a puzzle piece icon, IS visible in the bottom status bar)*
 
-- **Extensions-Only View**:
+- **Extensions-Only View (`embedMany`)**:
   `http://localhost:52941/?hide=all-except-extensions&embedMode=many`
-  *(Renders only extension tabs; puzzle piece icon IS visible)*
+  *(Renders only extension tabs like extensions are rendered inside IntelliJ/Android Studio. In this mode, the extensions settings button, a puzzle piece icon, IS visible in the top tab bar)*
 
 - **Standard Core Screen (`embedOne`)**:
   `http://localhost:52941/inspector?embedMode=one`
-  *(Renders standard tool panel; puzzle piece icon IS HIDDEN)*
+  *(Renders standard tool panel like they are rendered in VS Code. In this mode, the extensions settings button, a puzzle piece icon, IS HIDDEN)*
 
 ## 4. Connecting to an End-User Target App
 

--- a/packages/devtools_app/lib/src/extensions/embedded/_controller_web.dart
+++ b/packages/devtools_app/lib/src/extensions/embedded/_controller_web.dart
@@ -42,7 +42,30 @@ class EmbeddedExtensionControllerImpl extends EmbeddedExtensionController
 
   String get extensionUrl {
     if (debugDevToolsExtensions && !isDevToolsServerAvailable) {
-      return 'https://flutter.dev/';
+      return 'data:text/html;charset=utf-8,${Uri.encodeComponent('''
+<!DOCTYPE html>
+<html>
+<head>
+  <style>
+    body {
+      font-family: sans-serif;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      height: 100vh;
+      margin: 0;
+      background-color: #202124;
+      color: #e8eaed;
+    }
+  </style>
+</head>
+<body>
+  <h3>DevTools Extension Placeholder (${extensionConfig.name})</h3>
+  <p>Local debugging placeholder view.</p>
+</body>
+</html>
+''')}';
     }
 
     final basePath = devtoolsAssetsBasePath(

--- a/packages/devtools_app/lib/src/extensions/embedded/_controller_web.dart
+++ b/packages/devtools_app/lib/src/extensions/embedded/_controller_web.dart
@@ -30,19 +30,10 @@ import 'controller.dart';
 /// [ui_web.PlatformViewRegistry], which [_viewIdIncrementer] is used to create.
 var _viewIdIncrementer = 0;
 
-class EmbeddedExtensionControllerImpl extends EmbeddedExtensionController
-    with AutoDisposeControllerMixin {
-  EmbeddedExtensionControllerImpl(super.extensionConfig);
-
-  /// The view id for the extension iFrame.
-  ///
-  /// See [_viewIdIncrementer] for an explanation of why we use an incrementer
-  /// in the id.
-  late final viewId = 'ext-${extensionConfig.name}-${_viewIdIncrementer++}';
-
-  String get extensionUrl {
-    if (debugDevToolsExtensions && !isDevToolsServerAvailable) {
-      return 'data:text/html;charset=utf-8,${Uri.encodeComponent('''
+/// HTML template for the placeholder view used when debugging extensions without
+/// a running DevTools server.
+String _debugExtensionPlaceholderHtml(String name) {
+  return '''
 <!DOCTYPE html>
 <html>
 <head>
@@ -61,11 +52,27 @@ class EmbeddedExtensionControllerImpl extends EmbeddedExtensionController
   </style>
 </head>
 <body>
-  <h3>DevTools Extension Placeholder (${extensionConfig.name})</h3>
+  <h3>DevTools Extension Placeholder ($name)</h3>
   <p>Local debugging placeholder view.</p>
 </body>
 </html>
-''')}';
+''';
+}
+
+class EmbeddedExtensionControllerImpl extends EmbeddedExtensionController
+    with AutoDisposeControllerMixin {
+  EmbeddedExtensionControllerImpl(super.extensionConfig);
+
+  /// The view id for the extension iFrame.
+  ///
+  /// See [_viewIdIncrementer] for an explanation of why we use an incrementer
+  /// in the id.
+  late final viewId = 'ext-${extensionConfig.name}-${_viewIdIncrementer++}';
+
+  String get extensionUrl {
+    if (debugDevToolsExtensions && !isDevToolsServerAvailable) {
+      final html = _debugExtensionPlaceholderHtml(extensionConfig.name);
+      return 'data:text/html;charset=utf-8,${Uri.encodeComponent(html)}';
     }
 
     final basePath = devtoolsAssetsBasePath(

--- a/packages/devtools_app/lib/src/framework/scaffold/scaffold.dart
+++ b/packages/devtools_app/lib/src/framework/scaffold/scaffold.dart
@@ -59,10 +59,7 @@ class DevToolsScaffold extends StatefulWidget {
        );
 
   /// Returns the list of ScaffoldAction widgets.
-  static List<Widget> defaultActions({
-    Color? color,
-    Screen? currentScreen,
-  }) {
+  static List<Widget> defaultActions({Color? color, Screen? currentScreen}) {
     final queryParams = DevToolsQueryParams.load();
 
     // If DevTools is running in an IDE (EmbedMode.embedOne), then hide

--- a/packages/devtools_app/lib/src/framework/scaffold/scaffold.dart
+++ b/packages/devtools_app/lib/src/framework/scaffold/scaffold.dart
@@ -64,12 +64,14 @@ class DevToolsScaffold extends StatefulWidget {
 
     // If DevTools is running in an IDE (EmbedMode.embedOne), then hide
     // [ExtensionSettingsAction], unless this screen is showing an extension.
+    final showForEmbedMode =
+        ideTheme.embedMode != EmbedMode.embedOne ||
+        currentScreen is ExtensionScreen ||
+        queryParams.hideAllExceptExtensions;
     final showExtensionSettings =
         FeatureFlags.devToolsExtensions.isEnabled &&
         !queryParams.hideExtensions &&
-        (ideTheme.embedMode != EmbedMode.embedOne ||
-            currentScreen is ExtensionScreen ||
-            queryParams.hideAllExceptExtensions);
+        showForEmbedMode;
 
     return [
       OpenSettingsAction(color: color),

--- a/packages/devtools_app/lib/src/framework/scaffold/scaffold.dart
+++ b/packages/devtools_app/lib/src/framework/scaffold/scaffold.dart
@@ -57,10 +57,16 @@ class DevToolsScaffold extends StatefulWidget {
          embedMode: embedMode,
        );
 
+  /// Returns the list of ScaffoldAction widgets.
+  ///
+  /// The button to display the extensions dialog ([ExtensionSettingsAction]) is
+  /// omitted if DevTools extensions are disabled, hidden via query parameters,
+  /// or if the DevTools is running in an IDE (EmbedMode.embedOne).
   static List<Widget> defaultActions({Color? color}) => [
     OpenSettingsAction(color: color),
     if (FeatureFlags.devToolsExtensions.isEnabled &&
-        !DevToolsQueryParams.load().hideExtensions)
+        !DevToolsQueryParams.load().hideExtensions &&
+        ideTheme.embedMode != EmbedMode.embedOne)
       ExtensionSettingsAction(color: color),
     ReportFeedbackButton(color: color),
     OpenAboutAction(color: color),

--- a/packages/devtools_app/lib/src/framework/scaffold/scaffold.dart
+++ b/packages/devtools_app/lib/src/framework/scaffold/scaffold.dart
@@ -9,6 +9,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
 import '../../app.dart';
+import '../../extensions/extension_screen.dart';
 import '../../extensions/extension_settings.dart';
 import '../../screens/debugger/debugger_screen.dart';
 import '../../shared/analytics/prompt.dart';
@@ -58,19 +59,28 @@ class DevToolsScaffold extends StatefulWidget {
        );
 
   /// Returns the list of ScaffoldAction widgets.
-  ///
-  /// The button to display the extensions dialog ([ExtensionSettingsAction]) is
-  /// omitted if DevTools extensions are disabled, hidden via query parameters,
-  /// or if the DevTools is running in an IDE (EmbedMode.embedOne).
-  static List<Widget> defaultActions({Color? color}) => [
-    OpenSettingsAction(color: color),
-    if (FeatureFlags.devToolsExtensions.isEnabled &&
-        !DevToolsQueryParams.load().hideExtensions &&
-        ideTheme.embedMode != EmbedMode.embedOne)
-      ExtensionSettingsAction(color: color),
-    ReportFeedbackButton(color: color),
-    OpenAboutAction(color: color),
-  ];
+  static List<Widget> defaultActions({
+    Color? color,
+    Screen? currentScreen,
+  }) {
+    final queryParams = DevToolsQueryParams.load();
+
+    // If DevTools is running in an IDE (EmbedMode.embedOne), then hide
+    // [ExtensionSettingsAction], unless this screen is showing an extension.
+    final showExtensionSettings =
+        FeatureFlags.devToolsExtensions.isEnabled &&
+        !queryParams.hideExtensions &&
+        (ideTheme.embedMode != EmbedMode.embedOne ||
+            currentScreen is ExtensionScreen ||
+            queryParams.hideAllExceptExtensions);
+
+    return [
+      OpenSettingsAction(color: color),
+      if (showExtensionSettings) ExtensionSettingsAction(color: color),
+      ReportFeedbackButton(color: color),
+      OpenAboutAction(color: color),
+    ];
+  }
 
   /// The padding around the content in the DevTools UI.
   EdgeInsets get appPadding => EdgeInsets.fromLTRB(

--- a/packages/devtools_app/lib/src/framework/scaffold/scaffold.dart
+++ b/packages/devtools_app/lib/src/framework/scaffold/scaffold.dart
@@ -59,20 +59,24 @@ class DevToolsScaffold extends StatefulWidget {
        );
 
   /// Returns the list of ScaffoldAction widgets.
-  static List<Widget> defaultActions({Color? color, Screen? currentScreen}) {
-    final queryParams = DevToolsQueryParams.load();
-
-    // If DevTools is running in an IDE (EmbedMode.embedOne), then hide
-    // [ExtensionSettingsAction], unless this screen is showing an extension.
-    final showForEmbedMode =
-        ideTheme.embedMode != EmbedMode.embedOne ||
-        currentScreen is ExtensionScreen ||
-        queryParams.hideAllExceptExtensions;
+  static List<Widget> defaultActions({
+    Color? color,
+    Screen? currentScreen,
+    DevToolsQueryParams? queryParams,
+  }) {
+    queryParams ??= DevToolsQueryParams.load();
+    // Whether DevTools is embedded in an IDE displaying extension(s).
+    final isEmbeddedExtensionScreen =
+        isEmbedded() &&
+        (currentScreen is ExtensionScreen ||
+            queryParams.hideAllExceptExtensions);
+    // Show extension settings if extensions are enabled and not hidden, AND:
+    // - DevTools is running standalone in the browser (!isEmbedded), OR
+    // - DevTools is embedded in an IDE, but specifically showing an extension.
     final showExtensionSettings =
         FeatureFlags.devToolsExtensions.isEnabled &&
         !queryParams.hideExtensions &&
-        showForEmbedMode;
-
+        (!isEmbedded() || isEmbeddedExtensionScreen);
     return [
       OpenSettingsAction(color: color),
       if (showExtensionSettings) ExtensionSettingsAction(color: color),

--- a/packages/devtools_app/lib/src/framework/scaffold/status_line.dart
+++ b/packages/devtools_app/lib/src/framework/scaffold/status_line.dart
@@ -124,7 +124,10 @@ class StatusLine extends StatelessWidget {
         BulletSpacer(color: foregroundColor),
         Row(
           crossAxisAlignment: CrossAxisAlignment.end,
-          children: DevToolsScaffold.defaultActions(color: foregroundColor),
+          children: DevToolsScaffold.defaultActions(
+            color: foregroundColor,
+            currentScreen: currentScreen,
+          ),
         ),
       ],
     ];

--- a/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
+++ b/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
@@ -69,7 +69,8 @@ TODO: Remove this section if there are not any updates.
 
 ## DevTools extension updates
 
-TODO: Remove this section if there are not any updates.
+* Hide the DevTools extensions menu button in single-screen embedded mode (`EmbedMode.embedOne`) on standard screens.
+  [#8507](https://github.com/flutter/devtools/issues/8507)
 
 ## Advanced developer mode updates
 

--- a/packages/devtools_app/test/framework/scaffold/scaffold_test.dart
+++ b/packages/devtools_app/test/framework/scaffold/scaffold_test.dart
@@ -294,11 +294,11 @@ void main() {
 
   test(
     'defaultActions includes ExtensionSettingsAction based on EmbedMode and screen type',
-        () {
+    () {
       setGlobal(IdeTheme, IdeTheme());
       expect(
         DevToolsScaffold.defaultActions().any(
-              (w) => w is ExtensionSettingsAction,
+          (w) => w is ExtensionSettingsAction,
         ),
         isTrue,
       );
@@ -306,7 +306,7 @@ void main() {
       setGlobal(IdeTheme, IdeTheme(embedMode: EmbedMode.embedMany));
       expect(
         DevToolsScaffold.defaultActions().any(
-              (w) => w is ExtensionSettingsAction,
+          (w) => w is ExtensionSettingsAction,
         ),
         isFalse,
       );

--- a/packages/devtools_app/test/framework/scaffold/scaffold_test.dart
+++ b/packages/devtools_app/test/framework/scaffold/scaffold_test.dart
@@ -294,33 +294,38 @@ void main() {
 
   test(
     'defaultActions includes ExtensionSettingsAction based on EmbedMode and screen type',
-    () {
+        () {
       setGlobal(IdeTheme, IdeTheme());
       expect(
         DevToolsScaffold.defaultActions().any(
-          (w) => w is ExtensionSettingsAction,
+              (w) => w is ExtensionSettingsAction,
         ),
         isTrue,
       );
-
+      // In embedMany without extension query params or screen, it is hidden:
       setGlobal(IdeTheme, IdeTheme(embedMode: EmbedMode.embedMany));
       expect(
         DevToolsScaffold.defaultActions().any(
-          (w) => w is ExtensionSettingsAction,
+              (w) => w is ExtensionSettingsAction,
         ),
+        isFalse,
+      );
+      // In embedMany with hideAllExceptExtensions, it is visible:
+      expect(
+        DevToolsScaffold.defaultActions(
+          queryParams: DevToolsQueryParams({'hide': 'all-except-extensions'}),
+        ).any((w) => w is ExtensionSettingsAction),
         isTrue,
       );
-
+      // In embedOne mode with standard screen, it is hidden:
       setGlobal(IdeTheme, IdeTheme(embedMode: EmbedMode.embedOne));
-      // Standard screen in embedOne mode hides ExtensionSettingsAction
       expect(
         DevToolsScaffold.defaultActions(
           currentScreen: _screen1,
         ).any((w) => w is ExtensionSettingsAction),
         isFalse,
       );
-
-      // ExtensionScreen in embedOne mode shows ExtensionSettingsAction
+      // In embedOne mode with ExtensionScreen, it is visible:
       final extensionScreen = ExtensionScreen(
         StubDevToolsExtensions.fooExtension,
       );

--- a/packages/devtools_app/test/framework/scaffold/scaffold_test.dart
+++ b/packages/devtools_app/test/framework/scaffold/scaffold_test.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
 
 import 'package:devtools_app/devtools_app.dart';
+import 'package:devtools_app/src/extensions/extension_settings.dart';
 import 'package:devtools_app/src/framework/scaffold/scaffold.dart';
 import 'package:devtools_app/src/shared/framework/framework_controller.dart';
 import 'package:devtools_app/src/shared/managers/survey.dart';
@@ -288,6 +289,49 @@ void main() {
     );
     expect(scaffold.actions, isEmpty);
   });
+
+  test('defaultActions includes ExtensionSettingsAction based on EmbedMode', () {
+    setGlobal(IdeTheme, IdeTheme());
+    expect(
+      DevToolsScaffold.defaultActions().any(
+        (w) => w is ExtensionSettingsAction,
+      ),
+      isTrue,
+    );
+
+    setGlobal(IdeTheme, IdeTheme(embedMode: EmbedMode.embedMany));
+    expect(
+      DevToolsScaffold.defaultActions().any(
+        (w) => w is ExtensionSettingsAction,
+      ),
+      isTrue,
+    );
+
+    setGlobal(IdeTheme, IdeTheme(embedMode: EmbedMode.embedOne));
+    expect(
+      DevToolsScaffold.defaultActions().any(
+        (w) => w is ExtensionSettingsAction,
+      ),
+      isFalse,
+    );
+  });
+
+  testWidgets(
+    'hides ExtensionSettingsAction in StatusLine for EmbedMode.embedOne',
+    (WidgetTester tester) async {
+      setGlobal(IdeTheme, IdeTheme(embedMode: EmbedMode.embedOne));
+      await tester.pumpWidget(
+        wrapScaffold(
+          DevToolsScaffold(
+            screens: const [_screen1],
+            page: _screen1.screenId,
+            embedMode: EmbedMode.embedOne,
+          ),
+        ),
+      );
+      expect(find.byType(ExtensionSettingsAction), findsNothing);
+    },
+  );
 }
 
 class _TestScreen extends Screen {

--- a/packages/devtools_app/test/framework/scaffold/scaffold_test.dart
+++ b/packages/devtools_app/test/framework/scaffold/scaffold_test.dart
@@ -292,43 +292,46 @@ void main() {
     expect(scaffold.actions, isEmpty);
   });
 
-  test('defaultActions includes ExtensionSettingsAction based on EmbedMode and screen type', () {
-    setGlobal(IdeTheme, IdeTheme());
-    expect(
-      DevToolsScaffold.defaultActions().any(
-        (w) => w is ExtensionSettingsAction,
-      ),
-      isTrue,
-    );
+  test(
+    'defaultActions includes ExtensionSettingsAction based on EmbedMode and screen type',
+    () {
+      setGlobal(IdeTheme, IdeTheme());
+      expect(
+        DevToolsScaffold.defaultActions().any(
+          (w) => w is ExtensionSettingsAction,
+        ),
+        isTrue,
+      );
 
-    setGlobal(IdeTheme, IdeTheme(embedMode: EmbedMode.embedMany));
-    expect(
-      DevToolsScaffold.defaultActions().any(
-        (w) => w is ExtensionSettingsAction,
-      ),
-      isTrue,
-    );
+      setGlobal(IdeTheme, IdeTheme(embedMode: EmbedMode.embedMany));
+      expect(
+        DevToolsScaffold.defaultActions().any(
+          (w) => w is ExtensionSettingsAction,
+        ),
+        isTrue,
+      );
 
-    setGlobal(IdeTheme, IdeTheme(embedMode: EmbedMode.embedOne));
-    // Standard screen in embedOne mode hides ExtensionSettingsAction
-    expect(
-      DevToolsScaffold.defaultActions(currentScreen: _screen1).any(
-        (w) => w is ExtensionSettingsAction,
-      ),
-      isFalse,
-    );
+      setGlobal(IdeTheme, IdeTheme(embedMode: EmbedMode.embedOne));
+      // Standard screen in embedOne mode hides ExtensionSettingsAction
+      expect(
+        DevToolsScaffold.defaultActions(
+          currentScreen: _screen1,
+        ).any((w) => w is ExtensionSettingsAction),
+        isFalse,
+      );
 
-    // ExtensionScreen in embedOne mode shows ExtensionSettingsAction
-    final extensionScreen = ExtensionScreen(
-      StubDevToolsExtensions.fooExtension,
-    );
-    expect(
-      DevToolsScaffold.defaultActions(currentScreen: extensionScreen).any(
-        (w) => w is ExtensionSettingsAction,
-      ),
-      isTrue,
-    );
-  });
+      // ExtensionScreen in embedOne mode shows ExtensionSettingsAction
+      final extensionScreen = ExtensionScreen(
+        StubDevToolsExtensions.fooExtension,
+      );
+      expect(
+        DevToolsScaffold.defaultActions(
+          currentScreen: extensionScreen,
+        ).any((w) => w is ExtensionSettingsAction),
+        isTrue,
+      );
+    },
+  );
 
   testWidgets(
     'hides ExtensionSettingsAction in StatusLine for EmbedMode.embedOne',

--- a/packages/devtools_app/test/framework/scaffold/scaffold_test.dart
+++ b/packages/devtools_app/test/framework/scaffold/scaffold_test.dart
@@ -3,8 +3,10 @@
 // found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
 
 import 'package:devtools_app/devtools_app.dart';
+import 'package:devtools_app/src/extensions/extension_screen.dart';
 import 'package:devtools_app/src/extensions/extension_settings.dart';
 import 'package:devtools_app/src/framework/scaffold/scaffold.dart';
+import 'package:devtools_app/src/shared/development_helpers.dart';
 import 'package:devtools_app/src/shared/framework/framework_controller.dart';
 import 'package:devtools_app/src/shared/managers/survey.dart';
 import 'package:devtools_app/src/shared/primitives/query_parameters.dart';
@@ -290,7 +292,7 @@ void main() {
     expect(scaffold.actions, isEmpty);
   });
 
-  test('defaultActions includes ExtensionSettingsAction based on EmbedMode', () {
+  test('defaultActions includes ExtensionSettingsAction based on EmbedMode and screen type', () {
     setGlobal(IdeTheme, IdeTheme());
     expect(
       DevToolsScaffold.defaultActions().any(
@@ -308,11 +310,23 @@ void main() {
     );
 
     setGlobal(IdeTheme, IdeTheme(embedMode: EmbedMode.embedOne));
+    // Standard screen in embedOne mode hides ExtensionSettingsAction
     expect(
-      DevToolsScaffold.defaultActions().any(
+      DevToolsScaffold.defaultActions(currentScreen: _screen1).any(
         (w) => w is ExtensionSettingsAction,
       ),
       isFalse,
+    );
+
+    // ExtensionScreen in embedOne mode shows ExtensionSettingsAction
+    final extensionScreen = ExtensionScreen(
+      StubDevToolsExtensions.fooExtension,
+    );
+    expect(
+      DevToolsScaffold.defaultActions(currentScreen: extensionScreen).any(
+        (w) => w is ExtensionSettingsAction,
+      ),
+      isTrue,
     );
   });
 


### PR DESCRIPTION
Hide the extension settings action when DevTools is running in an IDE, unless the current screen is an extension.

This also helps with debugging extensions locally by adding an agent skill, and by fixing an issue where `flutter.dev`'s `X-Frame-Options` header caused a "connection refused" when debugging extensions locally.

Fixes https://github.com/flutter/devtools/issues/8507