### PR TITLE
Fix unreadable release notes blockquote in dark theme

### DIFF
--- a/packages/devtools_app/lib/src/shared/ui/side_panel.dart
+++ b/packages/devtools_app/lib/src/shared/ui/side_panel.dart
@@ -182,6 +182,17 @@ class SidePanel extends AnimatedWidget {
                 : Expanded(
                     child: Markdown(
                       data: markdownData!,
+                      styleSheet: MarkdownStyleSheet(
+                        // [MarkdownStyleSheet.fromTheme], which supplies the
+                        // rest of the style sheet, hard codes
+                        // `Colors.blue.shade100` as the blockquote fill while
+                        // taking the text color from the theme. In the dark
+                        // theme that draws light gray text on light blue.
+                        blockquoteDecoration: BoxDecoration(
+                          color: theme.colorScheme.secondaryContainer,
+                          borderRadius: defaultBorderRadius,
+                        ),
+                      ),
                       onTapLink: (text, url, title) =>
                           unawaited(launchUrlWithErrorHandling(url!)),
                     ),

--- a/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
+++ b/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
@@ -15,7 +15,9 @@ To learn more about DevTools, check out the
 
 ## General updates
 
-TODO: Remove this section if there are not any updates.
+* Fixed unreadable text in the release notes panel, where blockquotes were
+  drawn on a hard coded light blue background in the dark theme.
+  [#9945](https://github.com/flutter/devtools/issues/9945)
 
 ## Inspector updates
 

--- a/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
+++ b/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
@@ -17,7 +17,7 @@ To learn more about DevTools, check out the
 
 * Fixed unreadable text in the release notes panel, where blockquotes were
   drawn on a hard coded light blue background in the dark theme.
-  [#9945](https://github.com/flutter/devtools/issues/9945)
+  [#9957](https://github.com/flutter/devtools/pull/9957)
 
 ## Inspector updates
 

--- a/packages/devtools_app/test/shared/ui/side_panel_test.dart
+++ b/packages/devtools_app/test/shared/ui/side_panel_test.dart
@@ -1,0 +1,102 @@
+// Copyright 2026 The Flutter Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
+
+import 'package:devtools_app/devtools_app.dart';
+import 'package:devtools_app_shared/ui.dart';
+import 'package:devtools_app_shared/utils.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// The smallest contrast ratio WCAG 2.1 accepts for body text at level AA.
+///
+/// See https://www.w3.org/TR/WCAG21/#contrast-minimum.
+const _minimumContrastRatio = 4.5;
+
+void main() {
+  setUp(() {
+    setGlobal(IdeTheme, IdeTheme());
+  });
+
+  group('$SidePanelViewer', () {
+    // `MarkdownStyleSheet.fromTheme` fills blockquotes with
+    // `Colors.blue.shade100` but takes the text color from the theme, so a
+    // release note that opens with a blockquote drew `onSurface` text on light
+    // blue in the dark theme.
+    // Regression test for https://github.com/flutter/devtools/issues/9945.
+    for (final useDarkTheme in [true, false]) {
+      final themeName = useDarkTheme ? 'dark' : 'light';
+      testWidgets('blockquote text is legible in the $themeName theme', (
+        tester,
+      ) async {
+        const summary = 'Release notes for Dart and Flutter DevTools.';
+        final controller = SidePanelController();
+        await tester.pumpWidget(
+          MaterialApp(
+            theme: themeFor(
+              isDarkTheme: useDarkTheme,
+              ideTheme: IdeTheme(),
+              theme: ThemeData(
+                useMaterial3: true,
+                colorScheme: useDarkTheme ? darkColorScheme : lightColorScheme,
+              ),
+            ),
+            home: SidePanelViewer(controller: controller),
+          ),
+        );
+        controller.markdown.value = '# Release notes\n\n> $summary';
+        controller.toggleVisibility(true);
+        await tester.pumpAndSettle();
+
+        final summaryFinder = find.byWidgetPredicate(
+          (widget) =>
+              widget is RichText && widget.text.toPlainText() == summary,
+        );
+        expect(summaryFinder, findsOneWidget);
+
+        final textColor = _colorOfSpan(
+          tester.widget<RichText>(summaryFinder).text,
+          summary,
+        );
+        final fillColor = tester
+            .widgetList<DecoratedBox>(
+              find.ancestor(
+                of: summaryFinder,
+                matching: find.byType(DecoratedBox),
+              ),
+            )
+            .map((box) => box.decoration)
+            .whereType<BoxDecoration>()
+            .map((decoration) => decoration.color)
+            .nonNulls
+            .first;
+
+        expect(
+          _contrastRatio(textColor!, fillColor),
+          greaterThanOrEqualTo(_minimumContrastRatio),
+        );
+      });
+    }
+  });
+}
+
+/// The color the span holding [text] is painted with, or null if [root] holds
+/// no such span.
+Color? _colorOfSpan(InlineSpan root, String text) {
+  Color? color;
+  root.visitChildren((span) {
+    if (span is TextSpan && span.text == text) {
+      color = span.style?.color;
+      return false;
+    }
+    return true;
+  });
+  return color;
+}
+
+/// The WCAG contrast ratio between [a] and [b], from 1 (identical) to 21
+/// (black on white).
+double _contrastRatio(Color a, Color b) {
+  final luminances = [a.computeLuminance(), b.computeLuminance()]..sort();
+  return (luminances.last + 0.05) / (luminances.first + 0.05);
+}


### PR DESCRIPTION
Work towards https://github.com/flutter/devtools/issues/9945

The blockquote fill comes from `MarkdownStyleSheet.fromTheme`, which hard codes it to `Colors.blue.shade100` and takes the text style from the theme. With the dark palette, that works out to `#C7C6CA` on `#BBDEFB`, a 1.21:1 ratio. The 2.60.0 notes open with a blockquote right under the title, which is the banner in the screenshots.

I moved the decoration onto the panel: the fill becomes `secondaryContainer` and the corner radius follows `defaultBorderRadius` instead of the hard coded 2.0. I kept the text color at `onSurface`, which clears AA on the new fill, 5.48:1 dark and 13.29:1 light, and keeps the diff to just the one stylesheet override. Widget tests measure the contrast in both themes.

The rest of the issue, whether the notes belong in the embedded view, is untouched.

| | Before | After |
| --- | --- | --- |
| Dark | ![The release notes blockquote before the fix, dark theme](https://raw.githubusercontent.com/Yusufihsangorgel/devtools/25748b9e34cb1acf10092007c10174f24e085d63/before-dark.png) | ![The release notes blockquote after the fix, dark theme](https://raw.githubusercontent.com/Yusufihsangorgel/devtools/25748b9e34cb1acf10092007c10174f24e085d63/after-dark.png) |
| Light | ![The release notes blockquote before the fix, light theme](https://raw.githubusercontent.com/Yusufihsangorgel/devtools/25748b9e34cb1acf10092007c10174f24e085d63/before-light.png) | ![The release notes blockquote after the fix, light theme](https://raw.githubusercontent.com/Yusufihsangorgel/devtools/25748b9e34cb1acf10092007c10174f24e085d63/after-light.png) |

## Pre-launch Checklist

### General checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I updated/added relevant documentation (doc comments with `///`).

### Issues checklist

- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I listed at least one issue which has the [`contributions-welcome`] or [`good-first-issue`] label.
- [x] I did not list at least one issue with the [`contributions-welcome`] or [`good-first-issue`] label. I understand this means my PR might take longer to be reviewed.

### Tests checklist

- [x] I added new tests to check the change I am making...
- [ ] OR there is a reason for not adding tests, which I explained in the PR description.

### AI-tooling checklist

- [ ] I did not use any AI tooling in creating this PR.
- [x] OR I did use AI tooling, and...
    * [x] I read the [AI contributions guidelines] and agree to follow them.
    * [x] I reviewed all AI-generated code before opening this PR.
    * [x] I understand and am able to discuss the code in this PR.
    * [x] I have verifed the accuracy of any AI-generated text included in the PR description.
    * [x] I commit to verifying the accuracy of any AI-generated code or text that I upload in response to review comments.

### Feature-change checklist

- [ ] This PR does not change the DevTools UI or behavior and...
    * [ ] I added the `release-notes-not-required` label or left a comment requesting the label be added.
- [x] OR this PR does change the DevTools UI or behavior and...
    * [x] I added an entry to `packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md`.
    * [x] I included before/after screenshots and/or a GIF demo of the new UI to my PR description.
    * [ ] I ran the DevTools app locally to manually verify my changes.

![build.yaml badge]

If you need help, consider asking for help on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/devtools/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[CLA]: https://cla.developers.google.com/
[`contributions-welcome`]: https://github.com/flutter/devtools/issues?q=state%3Aopen%20label%3Acontributions-welcome
[`good-first-issue`]: https://github.com/flutter/devtools/issues?q=state%3Aopen%20label%3Agood-first-issue
[AI contributions guidelines]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[build.yaml badge]: https://github.com/flutter/devtools/actions/workflows/build.yaml/badge.svg
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
