### PR TITLE
Fix Flutter frames chart freeze after switching screens

### DIFF
--- a/packages/devtools_app/lib/src/screens/performance/panes/flutter_frames/flutter_frames_chart.dart
+++ b/packages/devtools_app/lib/src/screens/performance/panes/flutter_frames/flutter_frames_chart.dart
@@ -249,6 +249,14 @@ class _FramesChartState extends State<FramesChart> with AutoDisposeMixin {
     _framesScrollController = ScrollController(
       initialScrollOffset: initialScrollOffset,
     );
+
+    // Snap after layout so [atScrollBottom] matches for live follow.
+    if (_selectedFrameIndex == null) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!mounted || !_framesScrollController.hasClients) return;
+        unawaited(_framesScrollController.autoScrollToBottom(jump: true));
+      });
+    }
   }
 
   @override
@@ -261,13 +269,18 @@ class _FramesChartState extends State<FramesChart> with AutoDisposeMixin {
   }
 
   double _calculateInitialHorizontalScrollOffset() {
-    final selectedIndex = _selectedFrameIndex;
-    if (selectedIndex == null) return 0.0;
-
     final chartWidthWithoutAxisLabels =
         widget.constraints.maxWidth - _yAxisUnitsSpace;
     final totalFramesInView =
         chartWidthWithoutAxisLabels ~/ _defaultFrameWidthWithPadding;
+
+    final selectedIndex = _selectedFrameIndex;
+    if (selectedIndex == null) {
+      // Dock to the live edge when remounting with no selection (#9525).
+      final framesOutOfView = widget.frames.length - totalFramesInView;
+      return math.max(0.0, framesOutOfView * _defaultFrameWidthWithPadding);
+    }
+
     final fullFrameRangeInView = Range(0, totalFramesInView);
 
     if (fullFrameRangeInView.contains(selectedIndex)) return 0.0;

--- a/packages/devtools_app/lib/src/screens/performance/panes/flutter_frames/flutter_frames_chart.dart
+++ b/packages/devtools_app/lib/src/screens/performance/panes/flutter_frames/flutter_frames_chart.dart
@@ -270,7 +270,7 @@ class _FramesChartState extends State<FramesChart> with AutoDisposeMixin {
 
   double _calculateInitialHorizontalScrollOffset() {
     final chartWidthWithoutAxisLabels =
-        widget.constraints.maxWidth - _yAxisUnitsSpace;
+        math.max(0.0, widget.constraints.maxWidth - _yAxisUnitsSpace);
     final totalFramesInView =
         chartWidthWithoutAxisLabels ~/ _defaultFrameWidthWithPadding;
 

--- a/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
+++ b/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
@@ -23,7 +23,9 @@ TODO: Remove this section if there are not any updates.
 
 ## Performance updates
 
-TODO: Remove this section if there are not any updates.
+* Fixed a bug where the Flutter frames chart could appear frozen after
+  switching away from the Performance screen and coming back.
+  [#9960](https://github.com/flutter/devtools/pull/9960)
 
 ## CPU profiler updates
 

--- a/packages/devtools_app/test/screens/performance/flutter_frames/flutter_frames_chart_test.dart
+++ b/packages/devtools_app/test/screens/performance/flutter_frames/flutter_frames_chart_test.dart
@@ -155,7 +155,29 @@ void main() {
         expect(scrollController.offset, equals(expectedOffset));
       }
 
-      testWidgets('is zero for no selected frame', (WidgetTester tester) async {
+      void verifyScrollAtLiveEdge(WidgetTester tester) {
+        final scrollbar = tester.widget<Scrollbar>(find.byType(Scrollbar));
+        final scrollController = scrollbar.controller!;
+        expect(
+          scrollController.offset,
+          equals(scrollController.position.maxScrollExtent),
+        );
+      }
+
+      FlutterFrame createFrame(int number) {
+        return FlutterFrame.fromJson({
+          'number': number,
+          'startTime': 10000 + number * 50000,
+          'elapsed': 20000,
+          'build': 10000,
+          'raster': 12000,
+          'vsyncOverhead': 10,
+        });
+      }
+
+      testWidgets('is at live edge for no selected frame', (
+        WidgetTester tester,
+      ) async {
         expect(framesController.selectedFrame.value, isNull);
 
         await pumpChart(tester);
@@ -165,7 +187,39 @@ void main() {
           findsNWidgets(totalFramesInView),
         );
 
-        verifyScrollOffset(tester, 0.0);
+        verifyScrollAtLiveEdge(tester);
+      });
+
+      testWidgets('stays at live edge when frames are added', (
+        WidgetTester tester,
+      ) async {
+        expect(framesController.selectedFrame.value, isNull);
+
+        await pumpChart(tester);
+        verifyScrollAtLiveEdge(tester);
+
+        framesController.addFrame(createFrame(totalNumFrames));
+        await tester.pumpAndSettle();
+        verifyScrollAtLiveEdge(tester);
+      });
+
+      testWidgets('docks to live edge after remount with no selection', (
+        WidgetTester tester,
+      ) async {
+        expect(framesController.selectedFrame.value, isNull);
+
+        await pumpChart(tester);
+        verifyScrollAtLiveEdge(tester);
+
+        // Leave Performance (dispose chart), then remount after new frames.
+        await tester.pumpWidget(wrap(const SizedBox.shrink()));
+        await tester.pumpAndSettle();
+
+        framesController.addFrame(createFrame(totalNumFrames));
+        framesController.addFrame(createFrame(totalNumFrames + 1));
+
+        await pumpChart(tester);
+        verifyScrollAtLiveEdge(tester);
       });
 
       testWidgets('is offset for selected frame', (WidgetTester tester) async {


### PR DESCRIPTION
issue #9525
This PR fixes issue #9525 where the Flutter frames timeline occasionally looked frozen after switching to another screen and coming back. Frames were still being recorded in the background, but the chart remounted at the oldest frames and only auto-scrolled if it was already at the bottom — so the live ones were off to the right and it felt stuck until a full DevTools reload.

How I fixed it:
Basically, when the chart remounts with no frame selected, it now docks to the live edge instead of starting at offset 0, and snaps after the first layout so live follow keeps working.

before -> 

https://github.com/user-attachments/assets/ab991489-d6b5-4f83-a751-dd92398e192b

after -> 

https://github.com/user-attachments/assets/88549697-b5c1-46a5-bccd-c444b9a97688


## Pre-launch Checklist

### General checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [ ] I signed the [CLA].
- [ ] I updated/added relevant documentation (doc comments with `///`).

### Issues checklist

- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I listed at least one issue which has the [`contributions-welcome`] or [`good-first-issue`] label. 
- [ ] I did not list at least one issue with the [`contributions-welcome`] or [`good-first-issue`] label. I understand this means my PR might take longer to be reviewed. 

### Tests checklist

- [ ] I added new tests to check the change I am making...
- [ ] OR there is a reason for not adding tests, which I explained in the PR description.

### AI-tooling checklist

- [ ] I did not use any AI tooling in creating this PR.
- [ ] OR I did use AI tooling, and...
    * [ ] I read the [AI contributions guidelines] and agree to follow them.
    * [ ] I reviewed all AI-generated code before opening this PR.
    * [ ] I understand and am able to discuss the code in this PR.
    * [ ] I have verifed the accuracy of any AI-generated text included in the PR description.
    * [ ] I commit to verifying the accuracy of any AI-generated code or text that I upload in response to review comments.

### Feature-change checklist 

- [ ] This PR does not change the DevTools UI or behavior and...
    * [ ] I added the `release-notes-not-required` label or left a comment requesting the label be added.
- [ ] OR this PR does change the DevTools UI or behavior and...
    * [ ] I added an entry to `packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md`.
    * [ ] I included before/after screenshots and/or a GIF demo of the new UI to my PR description.
    * [ ] I ran the DevTools app locally to manually verify my changes.

![build.yaml badge]

If you need help, consider asking for help on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/devtools/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[CLA]: https://cla.developers.google.com/
[`contributions-welcome`]: https://github.com/flutter/devtools/issues?q=state%3Aopen%20label%3Acontributions-welcome
[`good-first-issue`]: https://github.com/flutter/devtools/issues?q=state%3Aopen%20label%3Agood-first-issue
[AI contributions guidelines]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[build.yaml badge]: https://github.com/flutter/devtools/actions/workflows/build.yaml/badge.svg
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
