### PR TITLE
Update CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -4,16 +4,16 @@
 inspector/          @kenzieschmoll @srawlins
 
 # Network Files
-network/            @srawlins @bkonyi @kenzieschmoll
+network/            @srawlins @kenzieschmoll
 
 # Performance Files
 performance/        @kenzieschmoll
 
 # CPU Profiler files
-profiler/           @kenzieschmoll @bkonyi
+profiler/           @kenzieschmoll
 
 # Memory files
-memory/             @bkonyi @kenzieschmoll
+memory/             @kenzieschmoll
 
 # Debugger files
 debugger/           @srawlins


### PR DESCRIPTION
Removes @bkonyi from network, profiler, and memory sections in CODEOWNERS while retaining ownership of vm_developer and devtools_shared.