### PR TITLE
Add sandbox attribute to extension iframe in DevTools.

### DIFF
--- a/packages/devtools_app/lib/src/extensions/embedded/_controller_web.dart
+++ b/packages/devtools_app/lib/src/extensions/embedded/_controller_web.dart
@@ -61,11 +61,11 @@ String _debugExtensionPlaceholderHtml(String name) {
 
 /// The sandbox permissions granted to embedded extension iframes.
 ///
-/// Restricts the extension from accessing same-origin resources such as
-/// the parent window DOM, cookies, or local storage, while allowing
-/// javascript execution, forms, downloads, and popup windows.
+/// Grants the extension same-origin capabilities (needed for service workers,
+/// storage, etc.) while allowing javascript execution, forms, downloads, and
+/// popup windows.
 const _extensionSandboxRules =
-    'allow-scripts allow-forms allow-downloads allow-popups allow-popups-to-escape-sandbox';
+    'allow-scripts allow-same-origin allow-forms allow-downloads allow-popups allow-popups-to-escape-sandbox';
 
 class EmbeddedExtensionControllerImpl extends EmbeddedExtensionController
     with AutoDisposeControllerMixin {

--- a/packages/devtools_app/lib/src/extensions/embedded/_controller_web.dart
+++ b/packages/devtools_app/lib/src/extensions/embedded/_controller_web.dart
@@ -123,7 +123,9 @@ class EmbeddedExtensionControllerImpl extends EmbeddedExtensionController
       // This url is safe because we built it ourselves and it does not include
       // any user input.
       ..src = extensionUrl
-      ..allow = 'usb';
+      ..allow = 'usb'
+      ..sandbox.value =
+          'allow-scripts allow-forms allow-downloads allow-popups allow-popups-to-escape-sandbox';
     _extensionIFrame.style
       ..border = 'none'
       ..height = '100%'

--- a/packages/devtools_app/lib/src/extensions/embedded/_controller_web.dart
+++ b/packages/devtools_app/lib/src/extensions/embedded/_controller_web.dart
@@ -59,6 +59,14 @@ String _debugExtensionPlaceholderHtml(String name) {
 ''';
 }
 
+/// The sandbox permissions granted to embedded extension iframes.
+///
+/// Restricts the extension from accessing same-origin resources such as
+/// the parent window DOM, cookies, or local storage, while allowing
+/// javascript execution, forms, downloads, and popup windows.
+const _extensionSandboxRules =
+    'allow-scripts allow-forms allow-downloads allow-popups allow-popups-to-escape-sandbox';
+
 class EmbeddedExtensionControllerImpl extends EmbeddedExtensionController
     with AutoDisposeControllerMixin {
   EmbeddedExtensionControllerImpl(super.extensionConfig);
@@ -124,8 +132,7 @@ class EmbeddedExtensionControllerImpl extends EmbeddedExtensionController
       // any user input.
       ..src = extensionUrl
       ..allow = 'usb'
-      ..sandbox.value =
-          'allow-scripts allow-forms allow-downloads allow-popups allow-popups-to-escape-sandbox';
+      ..sandbox.value = _extensionSandboxRules;
     _extensionIFrame.style
       ..border = 'none'
       ..height = '100%'

--- a/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
+++ b/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
@@ -79,6 +79,8 @@ TODO: Remove this section if there are not any updates.
 
 * Hide the DevTools extensions menu button in single-screen embedded mode (`EmbedMode.embedOne`) on standard screens.
   [#8507](https://github.com/flutter/devtools/issues/8507)
+* Added iframe sandboxing for embedded DevTools extensions to enforce origin
+  isolation. [#TODO](https://github.com/flutter/devtools/pull/TODO)
 
 ## Advanced developer mode updates
 

--- a/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
+++ b/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
@@ -80,7 +80,7 @@ TODO: Remove this section if there are not any updates.
 * Hide the DevTools extensions menu button in single-screen embedded mode (`EmbedMode.embedOne`) on standard screens.
   [#8507](https://github.com/flutter/devtools/issues/8507)
 * Added iframe sandboxing for embedded DevTools extensions to enforce origin
-  isolation. [#TODO](https://github.com/flutter/devtools/pull/TODO)
+  isolation. [#9967](https://github.com/flutter/devtools/pull/9967)
 
 ## Advanced developer mode updates
 


### PR DESCRIPTION
This change grants these permissions:
- `allow-scripts`: enables extension JS / Wasm execution.
- `allow-forms`: permits standard form interactions.
- `allow-downloads`: allows extensions to export files/logs.
- `allow-popups` & `allow-popups-to-escape-sandbox`: allows opening external links.

This does not grant `allow-same-origin` permission, so extensions can't access the parent window's DOM, cookies, or local storage.