### PR TITLE
Fix "gclient sync" call in "dt serve" for Windows

### DIFF
--- a/tool/lib/model.dart
+++ b/tool/lib/model.dart
@@ -5,6 +5,7 @@
 import 'dart:io';
 
 import 'package:collection/collection.dart';
+import 'package:devtools_tool/utils.dart';
 import 'package:path/path.dart' as path;
 
 class DevToolsRepo {
@@ -278,14 +279,16 @@ class FlutterSdk {
 
   final String sdkPath;
 
-  static String get flutterExecutableName =>
-      Platform.isWindows ? 'flutter.bat' : 'flutter';
+  /// The name of the 'flutter' shell script for the current platform.
+  static String get flutterExecutableName => shellScriptName('flutter');
 
+  /// The name of the 'dart' wrapper shell script in Flutter for the current
+  /// platform.
+  ///
   /// On windows, 'dart' is fine for running the .exe from the Dart SDK directly
   /// but the wrapper in the Flutter bin folder is a .bat and needs an explicit
   /// extension.
-  static String get dartWrapperExecutableName =>
-      Platform.isWindows ? 'dart.bat' : 'dart';
+  static String get dartWrapperExecutableName => shellScriptName('dart');
 
   String get flutterExePath => path.join(sdkPath, 'bin', flutterExecutableName);
 

--- a/tool/lib/utils.dart
+++ b/tool/lib/utils.dart
@@ -34,7 +34,7 @@ abstract class DartSdkHelper {
 /// Returns the name of the shell script [name] for the current platform.
 ///
 /// On Windows, shell scripts have `.bat` extensions and must be invoked
-/// using them them.
+/// using them.
 String shellScriptName(String name) {
   return Platform.isWindows ? '$name.bat' : name;
 }

--- a/tool/lib/utils.dart
+++ b/tool/lib/utils.dart
@@ -31,6 +31,14 @@ abstract class DartSdkHelper {
   }
 }
 
+/// Returns the name of the shell script [name] for the current platform.
+///
+/// On Windows, shell scripts have `.bat` extensions and must be invoked
+/// using them them.
+String shellScriptName(String name) {
+  return Platform.isWindows ? '$name.bat' : name;
+}
+
 String localDartSdkLocation() {
   final localDartSdkLocation = Platform.environment['LOCAL_DART_SDK'];
   if (localDartSdkLocation == null) {
@@ -86,7 +94,11 @@ class CliCommand {
     List<String> args, {
     bool throwOnException = true,
   }) {
-    return CliCommand('gclient', args, throwOnException: throwOnException);
+    return CliCommand(
+      shellScriptName('gclient'),
+      args,
+      throwOnException: throwOnException,
+    );
   }
 
   factory CliCommand.tool(List<String> args, {bool throwOnException = true}) {


### PR DESCRIPTION
On Windows, shell scripts must be invoked with their ".bat" suffix. Without this fix, "gclient sync" would fail when called by "dt serve".

