### PR TITLE
fix: adjust ANSI colors for light/dark DevTools theme

### DIFF
--- a/packages/devtools_app/lib/src/screens/logging/_message_column.dart
+++ b/packages/devtools_app/lib/src/screens/logging/_message_column.dart
@@ -74,6 +74,7 @@ class MessageColumn extends ColumnData<LogData>
                         //  The current summary is generally the first 200 chars of details.
                         data.summary!,
                         theme.regularTextStyle,
+                        brightness: theme.brightness,
                       ),
                     if (hasSummary && hasDetails())
                       TextSpan(text: '  •  ', style: theme.subtleTextStyle),
@@ -81,6 +82,7 @@ class MessageColumn extends ColumnData<LogData>
                       ...textSpansFromAnsi(
                         detailsComputed ? data.details! : '<fetching>',
                         theme.subtleTextStyle,
+                        brightness: theme.brightness,
                       ),
                   ],
                 ),

--- a/packages/devtools_app/lib/src/screens/vm_developer/object_inspector/vm_instance_display.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/object_inspector/vm_instance_display.dart
@@ -171,6 +171,7 @@ class DisplayProvider extends StatelessWidget {
               children: textSpansFromAnsi(
                 variable.text ?? '',
                 theme.subtleFixedFontStyle,
+                brightness: theme.brightness,
               ),
             ),
           ),

--- a/packages/devtools_app/lib/src/shared/console/console.dart
+++ b/packages/devtools_app/lib/src/shared/console/console.dart
@@ -196,6 +196,7 @@ class _ConsoleOutputState extends State<_ConsoleOutput>
                           children: textSpansFromAnsi(
                             line.text,
                             theme.regularTextStyle,
+                            brightness: theme.brightness,
                           ),
                         ),
                       );

--- a/packages/devtools_app/lib/src/shared/console/widgets/display_provider.dart
+++ b/packages/devtools_app/lib/src/shared/console/widgets/display_provider.dart
@@ -75,6 +75,7 @@ class _DisplayProviderState extends State<DisplayProvider> {
             children: textSpansFromAnsi(
               widget.variable.text!,
               theme.subtleFixedFontStyle,
+              brightness: theme.brightness,
             ),
           ),
         ),

--- a/packages/devtools_app/lib/src/shared/primitives/utils.dart
+++ b/packages/devtools_app/lib/src/shared/primitives/utils.dart
@@ -545,7 +545,11 @@ class DebugTimingLogger {
   }
 }
 
-List<TextSpan> textSpansFromAnsi(String input, TextStyle defaultStyle) {
+List<TextSpan> textSpansFromAnsi(
+  String input,
+  TextStyle defaultStyle, {
+  required Brightness brightness,
+}) {
   final parser = AnsiParser(input);
   return parser.parse().map((entry) {
     final styled = entry.bold || entry.fgColor != null || entry.bgColor != null;
@@ -553,8 +557,8 @@ List<TextSpan> textSpansFromAnsi(String input, TextStyle defaultStyle) {
       text: entry.text,
       style: styled
           ? TextStyle(
-              color: ansiToColor(entry.fgColor),
-              backgroundColor: ansiToColor(entry.bgColor),
+              color: ansiToColor(entry.fgColor, brightness: brightness),
+              backgroundColor: ansiToColor(entry.bgColor, brightness: brightness),
               fontWeight: entry.bold ? FontWeight.bold : FontWeight.normal,
             )
           : defaultStyle,
@@ -562,13 +566,27 @@ List<TextSpan> textSpansFromAnsi(String input, TextStyle defaultStyle) {
   }).toList();
 }
 
-Color? ansiToColor(List<int>? ansiInput) {
+Color? ansiToColor(List<int>? ansiInput, {required Brightness brightness}) {
   if (ansiInput == null) {
     return null;
   }
 
   assert(ansiInput.length == 3, 'Ansi color list should contain 3 elements');
-  return Color.fromRGBO(ansiInput[0], ansiInput[1], ansiInput[2], 1);
+  final color = Color.fromRGBO(ansiInput[0], ansiInput[1], ansiInput[2], 1);
+  return _ansiColorVisibleOnBackground(color, brightness);
+}
+
+/// Adjusts ANSI colors that would be unreadable against the DevTools background.
+Color _ansiColorVisibleOnBackground(Color color, Brightness brightness) {
+  final hsl = HSLColor.fromColor(color);
+  if (brightness == Brightness.dark) {
+    if (hsl.lightness < 0.2) {
+      return hsl.withLightness(0.65).toColor();
+    }
+  } else if (hsl.lightness > 0.85) {
+    return hsl.withLightness(0.25).toColor();
+  }
+  return color;
 }
 
 /// An extension on [LogicalKeySet] to provide user-facing names for key

--- a/packages/devtools_app/test/shared/primitives/utils_test.dart
+++ b/packages/devtools_app/test/shared/primitives/utils_test.dart
@@ -680,6 +680,35 @@ void main() {
       equals('http://127.0.0.1:9100'),
     );
   });
+
+  group('ansiToColor', () {
+    test('lightens dark colors on dark backgrounds', () {
+      const black = Color.fromRGBO(0, 0, 0, 1);
+      final adjusted = ansiToColor([0, 0, 0], brightness: Brightness.dark)!;
+      expect(adjusted, isNot(equals(black)));
+      expect(adjusted.computeLuminance(), greaterThan(0.2));
+    });
+
+    test('darkens light colors on light backgrounds', () {
+      const white = Color.fromRGBO(255, 255, 255, 1);
+      final adjusted = ansiToColor([255, 255, 255], brightness: Brightness.light)!;
+      expect(adjusted, isNot(equals(white)));
+      expect(adjusted.computeLuminance(), lessThan(0.5));
+    });
+
+    test('preserves readable colors', () {
+      const red = Color.fromRGBO(187, 0, 0, 1);
+      expect(
+        ansiToColor([187, 0, 0], brightness: Brightness.dark),
+        equals(red),
+      );
+      expect(
+        ansiToColor([187, 0, 0], brightness: Brightness.light),
+        equals(red),
+      );
+    });
+  });
+  });
 }
 
 class _SubtractionResult {


### PR DESCRIPTION
## Summary
ANSI escape codes in log/console output often specify colors that are unreadable against the current DevTools background (e.g. black text on a dark theme).

This PR passes the current theme brightness into `textSpansFromAnsi` and adjusts foreground/background ANSI colors when they would have insufficient contrast:
- On dark themes: lighten colors with lightness < 0.2
- On light themes: darken colors with lightness > 0.85

Fixes #6345

## Test plan
- [x] Added unit tests for `ansiToColor` contrast adjustment
- [ ] Manual: verify colored log output is readable in both light and dark DevTools themes