### PR TITLE
Fix flakiness is mac integration tests

### DIFF
--- a/packages/devtools_app/lib/src/screens/network/network_model.dart
+++ b/packages/devtools_app/lib/src/screens/network/network_model.dart
@@ -4,7 +4,6 @@
 
 import 'package:devtools_shared/devtools_shared.dart';
 import 'package:flutter/material.dart';
-import 'package:meta/meta.dart';
 import 'package:vm_service/vm_service.dart';
 
 import '../../shared/primitives/utils.dart';

--- a/packages/devtools_app_shared/CHANGELOG.md
+++ b/packages/devtools_app_shared/CHANGELOG.md
@@ -7,6 +7,7 @@ found in the LICENSE file or at https://developers.google.com/open-source/licens
 * Fix a `RangeError` thrown by `SplitPane` when the number of children
   changes between rebuilds.
 * Fix garbage collection issues with the result list in `asyncEval` on both native VM and web.
+* Safely handle RPC errors and unexpected exceptions when calling service extensions in `ServiceExtensionManager`.
 * The minimum Dart SDK version is bumped to 3.11.0.
 * The minimum Flutter SDK version is bumped to 3.41.0.
 

--- a/packages/devtools_app_shared/lib/src/service/service_extension_manager.dart
+++ b/packages/devtools_app_shared/lib/src/service/service_extension_manager.dart
@@ -223,11 +223,16 @@ final class ServiceExtensionManager with DisposerMixin {
         await _onFrameEventReceived();
       }
     } on RPCError catch (e) {
-      if (e.code == RPCErrorKind.kServerError.code) {
+      if (e.code == RPCErrorKind.kServerError.code ||
+          e.isServiceDisposedError) {
         // Connection disappeared
         return;
       }
-      rethrow;
+      _log.warning('Error checking for first Flutter frame: $e');
+      return;
+    } catch (e, st) {
+      _log.warning('Error checking for first Flutter frame: $e', e, st);
+      return;
     }
   }
 
@@ -274,6 +279,8 @@ final class ServiceExtensionManager with DisposerMixin {
       } on SentinelException catch (_) {
         // Service extension stopped existing while calling, so do nothing.
         // This typically happens during hot restarts.
+      } catch (e, st) {
+        _log.warning('Error adding service extension $name: $e', e, st);
       }
     } else {
       // Set any extensions that are already enabled on the device. This will
@@ -439,11 +446,16 @@ final class ServiceExtensionManager with DisposerMixin {
           );
         }
       } on RPCError catch (e) {
-        if (e.code == RPCErrorKind.kServerError.code) {
+        if (e.isServiceDisposedError ||
+            e.code == RPCErrorKind.kServerError.code) {
           // The connection disappeared.
           return false;
         }
-        rethrow;
+        _log.warning('Failed to call service extension $name: $e');
+        return false;
+      } catch (e, st) {
+        _log.warning('Failed to call service extension $name: $e', e, st);
+        return false;
       }
 
       return true;

--- a/packages/devtools_app_shared/lib/src/service/service_extension_manager.dart
+++ b/packages/devtools_app_shared/lib/src/service/service_extension_manager.dart
@@ -222,6 +222,10 @@ final class ServiceExtensionManager with DisposerMixin {
       if (didSendFirstFrameEvent) {
         await _onFrameEventReceived();
       }
+    } on SentinelException catch (_) {
+      // Service extension or isolate stopped existing while calling, so do
+      // nothing. This typically happens during hot restarts.
+      return;
     } on RPCError catch (e) {
       if (e.code == RPCErrorKind.kServerError.code ||
           e.isServiceDisposedError) {
@@ -345,6 +349,10 @@ final class ServiceExtensionManager with DisposerMixin {
             );
             await _maybeRestoreExtension(name, value);
         }
+      } on SentinelException catch (_) {
+        // Service extension or isolate stopped existing while restoring, so do
+        // nothing. This typically happens during hot restarts.
+        return false;
       } on RPCError catch (e) {
         if (e.isServiceDisposedError) {
           return false;
@@ -445,6 +453,10 @@ final class ServiceExtensionManager with DisposerMixin {
             args: {name.substring(name.lastIndexOf('.') + 1): value},
           );
         }
+      } on SentinelException catch (_) {
+        // Service extension or isolate stopped existing while calling, so do
+        // nothing. This typically happens during hot restarts.
+        return false;
       } on RPCError catch (e) {
         if (e.isServiceDisposedError ||
             e.code == RPCErrorKind.kServerError.code) {

--- a/packages/devtools_app_shared/test/service/service_extensions_test.dart
+++ b/packages/devtools_app_shared/test/service/service_extensions_test.dart
@@ -2,8 +2,10 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
 
+import 'package:devtools_app_shared/service.dart';
 import 'package:devtools_app_shared/service_extensions.dart';
-import 'package:test/test.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:vm_service/vm_service.dart';
 
 void main() {
   group('ServiceExtensions', () {
@@ -28,5 +30,95 @@ void main() {
         isTrue,
       );
     });
+
+    test(
+      'ServiceExtensionManager handles RPCError / DWDS Promise collected gracefully',
+      () async {
+        var extensionCalls = 0;
+        final fakeService = _FakeVmService(
+          onCallServiceExtension: (method, isolateId, args) {
+            extensionCalls++;
+            throw RPCError(
+              'callServiceExtension',
+              -32603,
+              'Unexpected DWDS error for callServiceExtension: WipError\n-32000 Promise was collected',
+            );
+          },
+        );
+
+        final isolateManager = IsolateManager();
+        isolateManager.vmServiceOpened(fakeService);
+
+        final manager = ServiceExtensionManager(isolateManager);
+        manager.vmServiceOpened(fakeService, _FakeConnectedApp());
+
+        // Pre-enable an extension (like ErrorBadgeManager does for structuredErrors).
+        await manager.setServiceExtensionState(
+          structuredErrors.extension,
+          enabled: true,
+          value: true,
+          callExtension: false,
+        );
+
+        // Initialize isolates on IsolateManager.
+        final isolateRef = IsolateRef(
+          id: 'isolate-1',
+          number: '1',
+          name: 'main',
+        );
+        await isolateManager.init([isolateRef]);
+
+        // Wait for all async listeners and microtasks to complete.
+        await pumpEventQueue();
+
+        // Verify that the manager attempted to restore the pre-enabled extension
+        // state on the newly registered isolate (and gracefully handled the error).
+        expect(extensionCalls, equals(1));
+      },
+    );
   });
+}
+
+/// A fake [VmService] implementation for testing service extension calls.
+class _FakeVmService extends Fake implements VmService {
+  _FakeVmService({required this.onCallServiceExtension});
+
+  final Future<Response> Function(
+    String method,
+    String? isolateId,
+    Map<String, dynamic>? args,
+  )
+  onCallServiceExtension;
+
+  @override
+  Stream<Event> get onIsolateEvent => const Stream<Event>.empty();
+
+  @override
+  Stream<Event> get onExtensionEvent => const Stream<Event>.empty();
+
+  @override
+  Stream<Event> get onDebugEvent => const Stream<Event>.empty();
+
+  @override
+  Future<Isolate> getIsolate(String isolateId) async => Isolate(
+    id: isolateId,
+    number: '1',
+    name: 'main',
+    extensionRPCs: [structuredErrors.extension],
+  );
+
+  @override
+  Future<Response> callServiceExtension(
+    String method, {
+    String? isolateId,
+    Map<String, dynamic>? args,
+  }) {
+    return onCallServiceExtension(method, isolateId, args);
+  }
+}
+
+/// A fake [ConnectedApp] implementation that simulates a connected Flutter app.
+class _FakeConnectedApp extends Fake implements ConnectedApp {
+  @override
+  Future<bool> get isFlutterApp async => true;
 }


### PR DESCRIPTION
I set an agent to analyze the logs of four different failed (flaky) runs of "macos-latest devtools_app integration-test integration_dart2js - flutter-web." The log was typically:

```
══╡ EXCEPTION CAUGHT BY FLUTTER TEST FRAMEWORK ╞═════════════════
The following ParallelWaitError<List<void>, List<AsyncError?>>
was thrown running a test:
ParallelWaitError: ext.flutter.inspector.structuredErrors:
(-32603) Unexpected DWDS error for callServiceExtension: WipError
-32000 Promise was collected
When the exception was thrown, this was the stack:
dart-sdk/lib/_internal/js_dev_runtime/patch/core_patch.dart 749:28                get current
package:vm_service/src/vm_service.dart 278:34                                     new
package:vm_service/src/vm_service.dart 1960:25
```

The agent determined:

1. When DevTools connects to the Flutter Web test application, `ErrorBadgeManager.vmServiceOpened`
 calls: `serviceConnection.serviceManager.serviceExtensionManager.setServiceExtensionState`, this stores `ext.flutter.inspector.structuredErrors` in `ServiceExtensionManager._enabledServiceExtensions`.
2. When isolate or frame events arrive (in `_registerMainIsolate` or `_onFrameEventReceived`), `ServiceExtensionManager` iterates over all extensions using `.wait`. Because ext.flutter.inspector.structuredErrors was pre-enabled, `_addServiceExtension` invokes `_callServiceExtensionIfReady`.
   * In a Flutter Web app running in Chrome via DWDS, `callServiceExtension` triggers a Chrome DevTools Protocol Runtime.evaluate command with `awaitPromise: true`.
   * In V8 / Chrome (especially under CI load or when GC occurs while DevTools switches tabs), if the JavaScript Promise created in the web page is garbage-collected by V8 before resolving, Chrome's CDP agent returns error `-32000 Promise was collected`.
   * DWDS catches the Chrome WIP error and returns a JSON-RPC error with code -32603 (Internal Error) and message `Unexpected DWDS error for callServiceExtension: WipError -32000 Promise was collected`.
3. We have inadequate error-handling in `ServiceExtensionManager._callServiceExtensionIfReady`. Unlike 
`_restoreExtensionFromDeviceIfReady`, which safely catches errors and checks `RpcErrorExtension.isServiceDisposedError`, `_callServiceExtensionIfReady` rethrows any RPCError whose code is not `RPCErrorKind.kServerError.code (-32000)`.

This PR essentially removes two rethrows, and improves logging.