### PR TITLE
Remove unused NetworkRequest.durationDisplay getter and test

### DIFF
--- a/packages/devtools_app/lib/src/screens/network/network_model.dart
+++ b/packages/devtools_app/lib/src/screens/network/network_model.dart
@@ -41,15 +41,6 @@ abstract class NetworkRequest
 
   String get id;
 
-  @visibleForTesting
-  String get durationDisplay {
-    final duration = this.duration;
-    final text = duration != null
-        ? durationText(duration, unit: DurationDisplayUnit.milliseconds)
-        : 'Pending';
-    return 'Duration: $text';
-  }
-
   @override
   bool matchesSearchToken(RegExp regExpSearch) {
     return uri.caseInsensitiveContains(regExpSearch);

--- a/packages/devtools_app/test/screens/network/network_model_test.dart
+++ b/packages/devtools_app/test/screens/network/network_model_test.dart
@@ -415,15 +415,6 @@ void main() {
       expect(httpWsHandshake.port, 56744);
     });
 
-    test('durationDisplay returns correct value', () {
-      expect(httpGet.durationDisplay, 'Duration: 811.7 ms');
-      expect(httpGetWithError.durationDisplay, 'Duration: 2029.5 ms');
-      expect(httpPost.durationDisplay, 'Duration: 1508.0 ms');
-      expect(httpPut.durationDisplay, 'Duration: 1325.8 ms');
-      expect(httpPatch.durationDisplay, 'Duration: 1243.7 ms');
-      expect(httpWsHandshake.durationDisplay, 'Duration: 41.4 ms');
-    });
-
     test('isValid returns correct value', () {
       expect(httpGet.isValid, isTrue);
       expect(httpGetWithError.isValid, isTrue);


### PR DESCRIPTION
I  keep seeing "Dart Code metric" CI failing in PRs that didn't touch [network_model.dart]
<img width="1126" height="196" alt="image" src="https://github.com/user-attachments/assets/40da2a51-c5d9-490c-bacd-d683cacfd681" /> 
This PR is to fix that by removing durationDisplay from NetworkRequest and its corresponding unit test in network_model_test.dart. The getter was not used anywhere in DevTools production code (durations are formatted directly via durationText in DurationColumn and HttpRequestOverviewView), which was causing DCM's check-unused-code to fail with 'getter durationDisplay is used only in tests'.


## Pre-launch Checklist

### General checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [ ] I signed the [CLA].
- [ ] I updated/added relevant documentation (doc comments with `///`).

### Issues checklist

- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I listed at least one issue which has the [`contributions-welcome`] or [`good-first-issue`] label. 
- [ ] I did not list at least one issue with the [`contributions-welcome`] or [`good-first-issue`] label. I understand this means my PR might take longer to be reviewed. 

### Tests checklist

- [ ] I added new tests to check the change I am making...
- [ ] OR there is a reason for not adding tests, which I explained in the PR description.

### AI-tooling checklist

- [ ] I did not use any AI tooling in creating this PR.
- [ ] OR I did use AI tooling, and...
    * [ ] I read the [AI contributions guidelines] and agree to follow them.
    * [ ] I reviewed all AI-generated code before opening this PR.
    * [ ] I understand and am able to discuss the code in this PR.
    * [ ] I have verifed the accuracy of any AI-generated text included in the PR description.
    * [ ] I commit to verifying the accuracy of any AI-generated code or text that I upload in response to review comments.

### Feature-change checklist 

- [ ] This PR does not change the DevTools UI or behavior and...
    * [ ] I added the `release-notes-not-required` label or left a comment requesting the label be added.
- [ ] OR this PR does change the DevTools UI or behavior and...
    * [ ] I added an entry to `packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md`.
    * [ ] I included before/after screenshots and/or a GIF demo of the new UI to my PR description.
    * [ ] I ran the DevTools app locally to manually verify my changes.

![build.yaml badge]

If you need help, consider asking for help on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/devtools/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[CLA]: https://cla.developers.google.com/
[`contributions-welcome`]: https://github.com/flutter/devtools/issues?q=state%3Aopen%20label%3Acontributions-welcome
[`good-first-issue`]: https://github.com/flutter/devtools/issues?q=state%3Aopen%20label%3Agood-first-issue
[AI contributions guidelines]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[build.yaml badge]: https://github.com/flutter/devtools/actions/workflows/build.yaml/badge.svg
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
