### PR TITLE
Fix some little things for CI

### DIFF
--- a/packages/devtools_app_shared/pubspec.yaml
+++ b/packages/devtools_app_shared/pubspec.yaml
@@ -31,7 +31,6 @@ dev_dependencies:
   flutter_lints: ^6.0.0
   flutter_test:
     sdk: flutter
-  test: ^1.21.0
 
 flutter:
   uses-material-design: true

--- a/packages/devtools_test/lib/src/mocks/fake_service_extension_manager.dart
+++ b/packages/devtools_test/lib/src/mocks/fake_service_extension_manager.dart
@@ -79,7 +79,7 @@ base class FakeServiceExtensionManager extends Fake
   /// Hook for tests to call to fake changing the state of a service
   /// extension.
   void fakeServiceExtensionStateChanged(
-    final String name,
+    String name,
     String valueFromJson,
   ) async {
     final extension = serviceExtensionsAllowlist[name];

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -510,6 +510,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.1.0"
+  listen:
+    dependency: transitive
+    description:
+      name: listen
+      sha256: "47501a08016a43fcad79252439d723f50f14f88fa7bfd8a177e0a417e5c9e1f2"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.1"
   logging:
     dependency: transitive
     description:


### PR DESCRIPTION
DCM discovered that devtools_app_shared no longer depends on the test package, so remove that.

Also internal analyzers are complaining about this final parameter. I think we don't get any warnings locally because the code is not versioned to Dart 3.13, where primary constructors make `final` non-declaring parameters illegal.