### PR TITLE
Change behavior of DEVTOOLS_TOOL_FLUTTER_FROM_PATH

### DIFF
--- a/tool/bin/dt
+++ b/tool/bin/dt
@@ -3,7 +3,7 @@
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 USE_PATH=false
-if [ ! -z "$DEVTOOLS_TOOL_FLUTTER_FROM_PATH" ]; then
+if [ "$DEVTOOLS_TOOL_FLUTTER_FROM_PATH" = "true" ]; then
   USE_PATH=true
 fi
 for arg in "$@"; do

--- a/tool/bin/dt.bat
+++ b/tool/bin/dt.bat
@@ -4,7 +4,7 @@ REM found in the LICENSE file or at https://developers.google.com/open-source/li
 @echo off
 
 set USE_PATH=
-IF DEFINED DEVTOOLS_TOOL_FLUTTER_FROM_PATH set USE_PATH=1
+IF /I "%DEVTOOLS_TOOL_FLUTTER_FROM_PATH%"=="true" set USE_PATH=1
 for %%a in (%*) do (
 	if "%%a"=="-p" set USE_PATH=1
 	if "%%a"=="--flutter-from-path" set USE_PATH=1

--- a/tool/ci/setup.sh
+++ b/tool/ci/setup.sh
@@ -22,15 +22,15 @@ function flutter {
 export -f flutter
 
 # Determine the Flutter SDK to use:
-# * If `DEVTOOLS_TOOL_FLUTTER_FROM_PATH` is set, then discover from `PATH`.
+# * If `DEVTOOLS_TOOL_FLUTTER_FROM_PATH` is "true", then discover from `PATH`.
 # * If `./tool/flutter-sdk` (a directory) exists, then use that.
-if [ -n "$DEVTOOLS_TOOL_FLUTTER_FROM_PATH" ]; then
+if [ "$DEVTOOLS_TOOL_FLUTTER_FROM_PATH" = "true" ]; then
     if command -v flutter &> /dev/null; then
         FLUTTER_EXE="$(command -v flutter)"
     elif command -v flutter.bat &> /dev/null; then
         FLUTTER_EXE="$(command -v flutter.bat)"
     else
-        echo "DEVTOOLS_TOOL_FLUTTER_FROM_PATH is set, but flutter was not found on PATH"
+        echo "DEVTOOLS_TOOL_FLUTTER_FROM_PATH is set to true, but flutter was not found on PATH"
         exit 1
     fi
     FLUTTER_BIN="$(cd "$(dirname "$FLUTTER_EXE")" && pwd -P)"
@@ -40,7 +40,7 @@ if [ -n "$DEVTOOLS_TOOL_FLUTTER_FROM_PATH" ]; then
 elif [ -d "./tool/flutter-sdk" ]; then
     FLUTTER_DIR="$(pwd)/tool/flutter-sdk"
 else
-    echo "Expected ./tool/flutter-sdk to exist, or DEVTOOLS_TOOL_FLUTTER_FROM_PATH to be set"
+    echo "Expected ./tool/flutter-sdk to exist, or DEVTOOLS_TOOL_FLUTTER_FROM_PATH to be set to true"
     exit 1
 fi
 

--- a/tool/lib/devtools_command_runner.dart
+++ b/tool/lib/devtools_command_runner.dart
@@ -82,8 +82,10 @@ class DevToolsCommandRunner extends CommandRunner {
 
   @override
   Future<void> runCommand(ArgResults topLevelResults) {
+    final flutterFromPathEnvValue =
+        Platform.environment[_flutterFromPathEnvVar] ?? '';
     final flutterFromPathEnv =
-        Platform.environment[_flutterFromPathEnvVar]?.isNotEmpty == true;
+        bool.tryParse(flutterFromPathEnvValue, caseSensitive: false) == true;
     if (topLevelResults.flag(_flutterFromPathFlag) &&
         topLevelResults.wasParsed(_flutterSdkPathFlag)) {
       throw ArgParserException(


### PR DESCRIPTION
Previously, the `DEVTOOLS_TOOL_FLUTTER_FROM_PATH` variable was treated as a "is it present or not" thing. But that could be surprising, because then a value like `DEVTOOLS_TOOL_FLUTTER_FROM_PATH=false` would be considered... true!

This changes it to a value that must be `true` or `false`.