### PR TITLE
Clarify Diff Snapshots Freed column is per class #8837

### DIFF
--- a/packages/devtools_app/lib/src/screens/memory/panes/diff/widgets/classes_table_diff.dart
+++ b/packages/devtools_app/lib/src/screens/memory/panes/diff/widgets/classes_table_diff.dart
@@ -163,6 +163,7 @@ class _SizeColumn extends ColumnData<DiffClassData> {
   _SizeColumn(this.dataPart, this.sizeType)
     : super(
         columnTitle(dataPart),
+        titleTooltip: columnTooltip(dataPart),
         fixedWidthPx: 80.0,
         alignment: ColumnAlignment.right,
       );
@@ -180,6 +181,24 @@ class _SizeColumn extends ColumnData<DiffClassData> {
         return 'Delta';
       case _DataPart.persisted:
         return 'Persisted';
+    }
+  }
+
+  static String columnTooltip(_DataPart dataPart) {
+    switch (dataPart) {
+      case _DataPart.created:
+        return 'Size of this class allocated between the two snapshots.\n'
+            'This is the value for this row, not a cumulative total.';
+      case _DataPart.deleted:
+        return 'Size of this class released between the two snapshots.\n'
+            'This is the value for this row, not a cumulative total.';
+      case _DataPart.delta:
+        return 'Net size change of this class between the two snapshots '
+            '(allocated minus freed).\n'
+            'This is the value for this row, not a cumulative total.';
+      case _DataPart.persisted:
+        return 'Size of this class present in both snapshots.\n'
+            'This is the value for this row, not a cumulative total.';
     }
   }
 

--- a/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
+++ b/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
@@ -36,6 +36,9 @@ TODO: Remove this section if there are not any updates.
 ## Memory updates
 
 * Added the ability to pin classes to the top of the Profile Memory table. [#8898](https://github.com/flutter/devtools/issues/8898)
+* Clarified that Diff Snapshots size columns (Allocated, Freed, Delta, Persisted)
+  show memory for that class row, not a running total of the table.
+  [#8837](https://github.com/flutter/devtools/issues/8837)
 
 ## Debugger updates
 


### PR DESCRIPTION
The Diff Snapshots size columns already report each class on its own row. Freed had no header tooltip, so 29.9MB looked like it might be a running total.

I added tooltips on Allocated, Freed, Delta, and Persisted that say the value is for that class row.

Fixes #8837

## Pre-launch Checklist

### General checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I updated/added relevant documentation (doc comments with `///`).

### Issues checklist

- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I listed at least one issue which has the [`contributions-welcome`] or [`good-first-issue`] label.
- [x] I did not list at least one issue with the [`contributions-welcome`] or [`good-first-issue`] label. I understand this means my PR might take longer to be reviewed.

### Tests checklist

- [ ] I added new tests to check the change I am making...
- [x] OR there is a reason for not adding tests, which I explained in the PR description.

The change is header tooltip copy. Existing table code already shows `titleTooltip` on hover.

### AI-tooling checklist

- [ ] I did not use any AI tooling in creating this PR.
- [ ] OR I did use AI tooling, and...
    * [ ] I read the [AI contributions guidelines] and agree to follow them.
    * [ ] I reviewed all AI-generated code before opening this PR.
    * [ ] I understand and am able to discuss the code in this PR.
    * [ ] I have verifed the accuracy of any AI-generated text included in the PR description.
    * [ ] I commit to verifying the accuracy of any AI-generated code or text that I upload in response to review comments.

### Feature-change checklist

- [ ] This PR does not change the DevTools UI or behavior and...
    * [ ] I added the `release-notes-not-required` label or left a comment requesting the label be added.
- [x] OR this PR does change the DevTools UI or behavior and...
    * [x] I added an entry to `packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md`.
    * [ ] I included before/after screenshots and/or a GIF demo of the new UI to my PR description.
    * [ ] I ran the DevTools app locally to manually verify my changes.

No layout change, only column header tooltips, so I did not attach screenshots.
